### PR TITLE
feat(offramp): add offramp page and calculator for selling crypto

### DIFF
--- a/app/api/exchange-rate/route.ts
+++ b/app/api/exchange-rate/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server"
+
+const COINGECKO_URL =
+  "https://api.coingecko.com/api/v3/simple/price?ids=usd-coin,stellar&vs_currencies=ngn,kes,ghs,zar,ugx"
+
+export async function GET() {
+  try {
+    const response = await fetch(COINGECKO_URL, {
+      next: { revalidate: 20 },
+      headers: {
+        "User-Agent": "Aframp/1.0",
+        Accept: "application/json",
+      },
+    })
+
+    if (!response.ok) {
+      return NextResponse.json({ error: "Failed to fetch rates" }, { status: response.status })
+    }
+
+    const data = await response.json()
+    return NextResponse.json(data)
+  } catch (error) {
+    return NextResponse.json({ error: "Unable to fetch exchange rates" }, { status: 500 })
+  }
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,14 +2,14 @@ import { Suspense } from "react"
 import { DashboardPageClient } from "@/components/dashboard/dashboard-page-client"
 
 interface DashboardPageProps {
-  searchParams: {
+  searchParams: Promise<{
     wallet?: string
     address?: string
-  }
+  }>
 }
 
-export default function DashboardPage({ searchParams }: DashboardPageProps) {
-  const { wallet, address } = searchParams
+export default async function DashboardPage({ searchParams }: DashboardPageProps) {
+  const { wallet, address } = await searchParams
 
   return (
     <Suspense
@@ -26,4 +26,3 @@ export default function DashboardPage({ searchParams }: DashboardPageProps) {
     </Suspense>
   )
 }
-

--- a/app/offramp/bank-details/page.tsx
+++ b/app/offramp/bank-details/page.tsx
@@ -1,0 +1,20 @@
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+
+export default function OfframpBankDetailsPage() {
+  return (
+    <div className="min-h-screen bg-background flex items-center justify-center px-4">
+      <div className="max-w-lg w-full rounded-3xl border border-border bg-card p-6 text-center">
+        <h1 className="text-2xl font-semibold text-foreground">Bank Details</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          This step is coming next. We saved your order and will guide you through bank verification.
+        </p>
+        <div className="mt-6 flex items-center justify-center gap-3">
+          <Button asChild variant="outline">
+            <Link href="/offramp">Back to Offramp</Link>
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/offramp/page.tsx
+++ b/app/offramp/page.tsx
@@ -1,0 +1,5 @@
+import { OfframpPageClient } from "@/components/offramp/offramp-page-client"
+
+export default function OfframpPage() {
+  return <OfframpPageClient />
+}

--- a/components/offramp/asset-selector.tsx
+++ b/components/offramp/asset-selector.tsx
@@ -1,0 +1,76 @@
+"use client"
+
+import { useMemo, useState } from "react"
+import { ChevronDown } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { formatNumber } from "@/lib/onramp/formatters"
+import type { OfframpAssetOption } from "@/types/offramp"
+
+interface AssetSelectorProps {
+  options: OfframpAssetOption[]
+  value: string
+  onChange: (value: string) => void
+}
+
+export function AssetSelector({ options, value, onChange }: AssetSelectorProps) {
+  const [open, setOpen] = useState(false)
+  const selected = useMemo(() => options.find((option) => option.id === value) || options[0], [options, value])
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex h-[52px] w-full items-center justify-between rounded-xl border border-border bg-background px-4 py-3 text-left text-sm font-medium text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
+        aria-expanded={open}
+        aria-haspopup="listbox"
+      >
+        <div className="flex items-center gap-2">
+          <span className="text-base" aria-hidden>
+            {selected.icon}
+          </span>
+          <div>
+            <div className="text-sm font-semibold">{selected.label}</div>
+            <div className="text-xs text-muted-foreground">
+              {formatNumber(selected.balance, 4)} available • {selected.chain}
+            </div>
+          </div>
+        </div>
+        <ChevronDown className="h-4 w-4 text-muted-foreground" />
+      </button>
+
+      {open ? (
+        <div
+          className="absolute z-20 mt-2 w-full rounded-2xl border border-border bg-card shadow-lg"
+          role="listbox"
+        >
+          {options.map((option) => (
+            <button
+              key={option.id}
+              type="button"
+              onClick={() => {
+                onChange(option.id)
+                setOpen(false)
+              }}
+              className={cn(
+                "flex w-full items-center justify-between px-4 py-3 text-left text-sm hover:bg-muted",
+                option.id === selected.id ? "bg-muted" : ""
+              )}
+            >
+              <div className="flex items-center gap-2">
+                <span className="text-base" aria-hidden>
+                  {option.icon}
+                </span>
+                <div>
+                  <div className="font-medium text-foreground">{option.label}</div>
+                  <div className="text-xs text-muted-foreground">{option.chain}</div>
+                </div>
+              </div>
+              <span className="text-xs text-muted-foreground">{formatNumber(option.balance, 4)}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/components/offramp/offramp-calculator.tsx
+++ b/components/offramp/offramp-calculator.tsx
@@ -1,0 +1,230 @@
+'use client'
+
+import { AlertTriangle, Clock, Info, Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { AmountInput } from '@/components/onramp/amount-input'
+import { CurrencySelector } from '@/components/onramp/currency-selector'
+import { AssetSelector } from '@/components/offramp/asset-selector'
+import { formatCurrency, formatNumber } from '@/lib/onramp/formatters'
+import { formatRateCountdown, formatUsd } from '@/lib/offramp/formatters'
+import type { FiatCurrency } from '@/types/onramp'
+import type { OfframpAssetOption } from '@/types/offramp'
+
+interface OfframpCalculatorProps {
+  options: OfframpAssetOption[]
+  assetId: string
+  amountInput: string
+  fiatCurrency: FiatCurrency
+  rate: number
+  rateCountdown: number
+  rateUpdatedAt: number
+  isRateLoading: boolean
+  fiatAmount: number
+  usdEquivalent: number
+  fees: {
+    offrampFee: number
+    networkFee: number
+    bankFee: number
+    totalFees: number
+    receiveAmount: number
+  }
+  errors: {
+    amount?: string
+    liquidity?: string
+    limit?: string
+  }
+  limits: { min: number; max: number }
+  isCalculating: boolean
+  isValid: boolean
+  lockCountdown: number | null
+  onAssetChange: (value: string) => void
+  onAmountChange: (value: string) => void
+  onMax: () => void
+  onFiatChange: (value: FiatCurrency) => void
+  onRefreshRate: () => void
+  onSubmit: () => void
+}
+
+export function OfframpCalculator({
+  options,
+  assetId,
+  amountInput,
+  fiatCurrency,
+  rate,
+  rateCountdown,
+  rateUpdatedAt,
+  isRateLoading,
+  fiatAmount,
+  usdEquivalent,
+  fees,
+  errors,
+  limits,
+  isCalculating,
+  isValid,
+  lockCountdown,
+  onAssetChange,
+  onAmountChange,
+  onMax,
+  onFiatChange,
+  onRefreshRate,
+  onSubmit,
+}: OfframpCalculatorProps) {
+  const selected = options.find((option) => option.id === assetId) || options[0]
+  const receiveLabel = formatCurrency(fees.receiveAmount, fiatCurrency)
+  const feeLabel = formatCurrency(fees.offrampFee, fiatCurrency)
+
+  return (
+    <div className="rounded-3xl border border-border bg-card p-6 shadow-lg">
+      <form
+        className="space-y-6"
+        onSubmit={(event) => {
+          event.preventDefault()
+          onSubmit()
+        }}
+      >
+        <div className="space-y-3">
+          <h3 className="text-sm font-semibold text-foreground">Asset</h3>
+          <AssetSelector options={options} value={assetId} onChange={onAssetChange} />
+          <div className="rounded-xl border border-border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+            Multi-chain support enabled. Select the chain that matches your wallet.
+          </div>
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-[1fr_140px] md:items-end">
+          <div>
+            <AmountInput
+              label="You're Selling"
+              value={amountInput}
+              onChange={onAmountChange}
+              placeholder="0.00"
+              error={errors.amount}
+            />
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            className="h-[52px] w-full rounded-xl text-foreground hover:text-foreground/90"
+            onClick={onMax}
+          >
+            Max
+          </Button>
+        </div>
+
+        <div className="rounded-2xl border border-border bg-muted/30 px-4 py-3 text-sm text-muted-foreground">
+          ≈ {formatUsd(usdEquivalent)} USD equivalent
+        </div>
+
+        <div className="grid gap-4 md:grid-cols-[1fr_180px] md:items-end">
+          <div className="space-y-2">
+            <label className="text-sm font-medium text-foreground">You&apos;ll Receive</label>
+            <div className="h-[52px] w-full rounded-xl border border-border bg-muted/10 px-4 py-3 text-2xl font-semibold text-right text-muted-foreground shadow-sm">
+              {receiveLabel}
+            </div>
+            {/* <div className="min-h-[16px]" aria-hidden /> */}
+          </div>
+          <CurrencySelector
+            variant="fiat"
+            value={fiatCurrency}
+            onChange={(value) => {
+              // Ensure value is a fiat currency before calling onFiatChange
+              if (typeof value === 'string' || (value && (value as any).symbol)) {
+                onFiatChange(value as FiatCurrency)
+              }
+            }}
+            className="md:mt-6"
+          />
+        </div>
+
+        <div className="rounded-2xl border border-border bg-muted/30 px-4 py-3 text-xs text-muted-foreground">
+          <div className="flex items-center justify-between">
+            <span>Rate</span>
+            <span className="font-medium text-foreground">
+              1 {selected.asset} = {formatNumber(rate, 2)} {fiatCurrency}
+            </span>
+          </div>
+          <div className="mt-2 flex items-center justify-between">
+            <span>Refresh in</span>
+            <span className="flex items-center gap-2">
+              <Clock className="h-3.5 w-3.5" /> {rateCountdown}s
+            </span>
+          </div>
+          <div className="mt-2 text-xs text-muted-foreground">
+            Last updated: {new Date(rateUpdatedAt).toLocaleTimeString()}
+          </div>
+          <button
+            type="button"
+            onClick={onRefreshRate}
+            className="mt-2 inline-flex items-center gap-2 text-xs text-primary"
+          >
+            {isRateLoading ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
+            Refresh rate
+          </button>
+        </div>
+
+        {lockCountdown !== null ? (
+          <div className="flex items-center gap-2 rounded-xl border border-border bg-success/10 px-3 py-2 text-xs text-success">
+            <Clock className="h-3.5 w-3.5" /> Rate locked for: {formatRateCountdown(lockCountdown)}
+          </div>
+        ) : null}
+
+        <div className="rounded-2xl border border-border bg-muted/20 px-4 py-4 text-sm text-muted-foreground">
+          <div className="flex items-center justify-between">
+            <span>Offramp fee (1%)</span>
+            <span className="font-medium text-foreground">{feeLabel}</span>
+          </div>
+          <div className="mt-2 flex items-center justify-between">
+            <span>Network fee</span>
+            <span className="font-medium text-foreground">
+              {formatCurrency(fees.networkFee, fiatCurrency)}
+            </span>
+          </div>
+          <div className="mt-2 flex items-center justify-between">
+            <span>Bank transfer fee</span>
+            <span className="font-medium text-foreground">FREE</span>
+          </div>
+          <div className="mt-3 flex items-center justify-between border-t border-border pt-3 text-foreground">
+            <span className="font-medium">Total fees</span>
+            <span className="font-semibold">{formatCurrency(fees.totalFees, fiatCurrency)}</span>
+          </div>
+        </div>
+
+        <div className="rounded-2xl border border-border bg-muted/30 px-4 py-3 text-xs text-muted-foreground">
+          <div className="flex items-center justify-between">
+            <span>Limits</span>
+            <span>
+              Min: {formatCurrency(limits.min, fiatCurrency)} • Max:{' '}
+              {formatCurrency(limits.max, fiatCurrency)} / day
+            </span>
+          </div>
+          {fiatAmount > 1000000 ? (
+            <div className="mt-2 flex items-center gap-2 text-warning">
+              <AlertTriangle className="h-4 w-4" /> Large withdrawals may take longer for compliance
+              review.
+            </div>
+          ) : null}
+        </div>
+
+        {errors.liquidity || errors.limit ? (
+          <div className="flex items-center gap-2 rounded-xl border border-warning/30 bg-warning/10 px-3 py-2 text-xs text-warning">
+            <Info className="h-4 w-4" /> {errors.liquidity || errors.limit}
+          </div>
+        ) : null}
+
+        {isCalculating ? (
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 className="h-3 w-3 animate-spin" /> Updating estimate...
+          </div>
+        ) : null}
+
+        <Button
+          size="lg"
+          className="w-full rounded-full text-base"
+          type="submit"
+          disabled={!isValid || isRateLoading}
+        >
+          Continue to Bank Details →
+        </Button>
+      </form>
+    </div>
+  )
+}

--- a/components/offramp/offramp-page-client.tsx
+++ b/components/offramp/offramp-page-client.tsx
@@ -1,0 +1,249 @@
+'use client'
+
+import { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+import { LogOut } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { OfframpCalculator } from '@/components/offramp/offramp-calculator'
+import { useWalletConnection } from '@/hooks/use-wallet-connection'
+import { useOfframpRate } from '@/hooks/use-offramp-rate'
+import { useOfframpForm } from '@/hooks/use-offramp-form'
+import { useOfframpBalances } from '@/hooks/use-offramp-balances'
+import { formatCurrency, truncateAddress } from '@/lib/onramp/formatters'
+import { formatUsd, formatRateCountdown } from '@/lib/offramp/formatters'
+import type { OfframpOrder } from '@/types/offramp'
+
+const ORDER_KEY = 'offramp:latest-order'
+const LOCK_KEY = 'offramp:rate-lock'
+
+const assetUsdRates: Record<string, number> = {
+  cNGN: 0.00063,
+  USDC: 1,
+  USDT: 1,
+  XLM: 0.12,
+}
+
+export function OfframpPageClient() {
+  const router = useRouter()
+  const { address, connected, loading, disconnect } = useWalletConnection()
+  const [lockExpiresAt, setLockExpiresAt] = useState<number | null>(null)
+  const [rateOverride, setRateOverride] = useState(0)
+
+  const { options: assetOptions } = useOfframpBalances(address)
+  const form = useOfframpForm(assetOptions, rateOverride)
+  const selectedAsset = form.selectedAsset
+  const { rate, countdown, lastUpdated, isLoading, refresh } = useOfframpRate(
+    selectedAsset.asset,
+    selectedAsset.chain
+  )
+
+  useEffect(() => {
+    if (rate) setRateOverride(rate)
+  }, [rate])
+
+  useEffect(() => {
+    const stored = localStorage.getItem(LOCK_KEY)
+    if (stored) {
+      const parsed = JSON.parse(stored) as { expiresAt: number }
+      if (parsed.expiresAt > Date.now()) {
+        setLockExpiresAt(parsed.expiresAt)
+      }
+    }
+  }, [])
+
+  useEffect(() => {
+    router.prefetch('/offramp/bank-details')
+  }, [router])
+
+  const lockCountdown = useMemo(() => {
+    if (!lockExpiresAt) return null
+    const seconds = Math.max(Math.floor((lockExpiresAt - Date.now()) / 1000), 0)
+    return seconds
+  }, [lockExpiresAt])
+
+  useEffect(() => {
+    if (!lockExpiresAt) return
+    const timer = setInterval(() => {
+      setLockExpiresAt((prev) => (prev && prev > Date.now() ? prev : null))
+    }, 1000)
+    return () => clearInterval(timer)
+  }, [lockExpiresAt])
+
+  const usdEquivalent = useMemo(() => {
+    const usdRate = assetUsdRates[selectedAsset.asset]
+    return form.amountValue > 0 ? form.amountValue * usdRate : 0
+  }, [form.amountValue, selectedAsset.asset])
+
+  const handleSubmit = () => {
+    if (!form.isValid) return
+
+    const lockExpires = Date.now() + 15 * 60 * 1000
+    setLockExpiresAt(lockExpires)
+    localStorage.setItem(LOCK_KEY, JSON.stringify({ expiresAt: lockExpires }))
+
+    const order: OfframpOrder = {
+      id: `offramp-${Date.now()}`,
+      createdAt: Date.now(),
+      lockExpiresAt: lockExpires,
+      assetId: selectedAsset.id,
+      asset: selectedAsset.asset,
+      chain: selectedAsset.chain,
+      amount: parseFloat(form.state.amountInput.replace(/,/g, '')) || 0,
+      fiatCurrency: form.state.fiatCurrency,
+      rate,
+      fiatAmount: form.fiatAmount,
+      fees: form.fees,
+      status: 'pending_bank_details',
+    }
+
+    localStorage.setItem(ORDER_KEY, JSON.stringify(order))
+    localStorage.setItem(`offramp:order:${order.id}`, JSON.stringify(order))
+    router.push(`/offramp/bank-details?order=${order.id}`)
+  }
+
+  const headerAddress = truncateAddress(address, 4)
+
+  if (loading) {
+    return (
+      <div className="min-h-screen bg-background">
+        <div className="container mx-auto px-4 py-12">
+          <div className="animate-pulse space-y-6">
+            <div className="h-8 w-48 rounded-full bg-muted" />
+            <div className="h-64 rounded-3xl bg-muted" />
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-background">
+      <header className="sticky top-0 z-40 border-b border-border bg-card/80 backdrop-blur-md">
+        <div className="container mx-auto flex items-center justify-between px-4 py-4">
+          <Link href="/" className="flex items-center gap-2">
+            <div className="w-9 h-9 rounded-xl bg-primary flex items-center justify-center">
+              <span className="text-primary-foreground font-bold text-base">A</span>
+            </div>
+            <span className="font-semibold text-foreground text-lg">Aframp</span>
+          </Link>
+
+          <nav className="hidden md:flex items-center gap-2 text-sm text-muted-foreground">
+            <Link href="/onramp" className="rounded-full px-3 py-2 hover:text-foreground">
+              Onramp
+            </Link>
+            <Link href="/offramp" className="rounded-full px-3 py-2 bg-muted text-foreground">
+              Offramp
+            </Link>
+            <button type="button" className="rounded-full px-3 py-2 hover:text-foreground">
+              Pay Bills
+            </button>
+          </nav>
+
+          <div className="flex items-center gap-3">
+            {connected ? (
+              <div
+                className="flex items-center gap-2 rounded-full border border-border bg-muted/40 px-3 py-1 text-xs text-foreground"
+                title={address}
+              >
+                <span className="h-2 w-2 rounded-full bg-success pulse-glow" />
+                {headerAddress}
+              </div>
+            ) : null}
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={disconnect}
+              className="hidden md:inline-flex"
+            >
+              <LogOut className="mr-2 h-4 w-4" />
+              Disconnect
+            </Button>
+          </div>
+        </div>
+      </header>
+
+      <main className="container mx-auto px-4 py-10">
+        <section className="text-center">
+          <p className="text-sm font-semibold text-primary">💸 Sell Crypto for Local Currency</p>
+          <h1 className="mt-3 text-3xl font-semibold text-foreground md:text-4xl">
+            Cash out your stablecoins and crypto with transparent fees
+          </h1>
+          <p className="mt-3 text-sm text-muted-foreground">
+            Real-time rates, liquidity checks, and fast bank transfers.
+          </p>
+        </section>
+
+        <div className="mt-10 grid gap-8 lg:grid-cols-[minmax(0,620px)_1fr]">
+          <OfframpCalculator
+            options={assetOptions}
+            assetId={form.state.assetId}
+            amountInput={form.state.amountInput}
+            fiatCurrency={form.state.fiatCurrency}
+            rate={rate}
+            rateCountdown={countdown}
+            rateUpdatedAt={lastUpdated}
+            isRateLoading={isLoading}
+            fiatAmount={form.fiatAmount}
+            usdEquivalent={usdEquivalent}
+            fees={form.fees}
+            errors={form.errors}
+            limits={form.limits}
+            isCalculating={form.isCalculating}
+            isValid={form.isValid}
+            lockCountdown={lockCountdown}
+            onAssetChange={form.setAssetId}
+            onAmountChange={form.setAmountInput}
+            onMax={form.setMaxAmount}
+            onFiatChange={form.setFiatCurrency}
+            onRefreshRate={refresh}
+            onSubmit={handleSubmit}
+          />
+
+          <div className="space-y-6">
+            <div className="rounded-3xl border border-border bg-muted/20 p-6">
+              <h3 className="text-lg font-semibold text-foreground">Liquidity Status</h3>
+              <p className="mt-2 text-sm text-muted-foreground">
+                Available liquidity for {form.state.fiatCurrency}:{' '}
+                {formatCurrency(1500000, form.state.fiatCurrency)}
+              </p>
+              <div className="mt-4 rounded-xl border border-border bg-card px-4 py-3 text-sm text-muted-foreground">
+                Large withdrawals above {formatCurrency(1000000, form.state.fiatCurrency)} may take
+                longer to settle.
+              </div>
+            </div>
+            <div className="rounded-3xl border border-border bg-card p-6">
+              <h4 className="text-sm font-semibold text-foreground">Estimated Payout</h4>
+              <div className="mt-3 space-y-2 text-sm text-muted-foreground">
+                <div className="flex items-center justify-between">
+                  <span>Crypto sold</span>
+                  <span className="text-foreground">
+                    {form.state.amountInput || '0'} {selectedAsset.asset}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>USD equivalent</span>
+                  <span className="text-foreground">{formatUsd(usdEquivalent)}</span>
+                </div>
+                <div className="flex items-center justify-between">
+                  <span>Rate lock</span>
+                  <span className="text-foreground">
+                    {lockCountdown !== null
+                      ? formatRateCountdown(lockCountdown)
+                      : '15:00 on submit'}
+                  </span>
+                </div>
+                <div className="flex items-center justify-between border-t border-border pt-3 text-foreground">
+                  <span>You receive</span>
+                  <span className="font-semibold">
+                    {formatCurrency(form.fees.receiveAmount, form.state.fiatCurrency)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/components/onramp/currency-selector.tsx
+++ b/components/onramp/currency-selector.tsx
@@ -1,48 +1,59 @@
-"use client"
+'use client'
 
-import type { FiatCurrency, CryptoAsset } from "@/types/onramp"
-import { cn } from "@/lib/utils"
+import type { FiatCurrency, CryptoAsset } from '@/types/onramp'
+import { cn } from '@/lib/utils'
 
 const fiatOptions: { value: FiatCurrency; label: string; flag: string }[] = [
-  { value: "NGN", label: "Nigerian Naira", flag: "🇳🇬" },
-  { value: "KES", label: "Kenyan Shilling", flag: "🇰🇪" },
-  { value: "GHS", label: "Ghanaian Cedi", flag: "🇬🇭" },
-  { value: "ZAR", label: "South African Rand", flag: "🇿🇦" },
-  { value: "UGX", label: "Ugandan Shilling", flag: "🇺🇬" },
+  { value: 'NGN', label: 'Nigerian Naira', flag: '🇳🇬' },
+  { value: 'KES', label: 'Kenyan Shilling', flag: '🇰🇪' },
+  { value: 'GHS', label: 'Ghanaian Cedi', flag: '🇬🇭' },
+  { value: 'ZAR', label: 'South African Rand', flag: '🇿🇦' },
+  { value: 'UGX', label: 'Ugandan Shilling', flag: '🇺🇬' },
 ]
 
 const cryptoOptions: { value: CryptoAsset; label: string; icon: string }[] = [
-  { value: "cNGN", label: "cNGN", icon: "💵" },
-  { value: "cKES", label: "cKES", icon: "💵" },
-  { value: "cGHS", label: "cGHS", icon: "💵" },
-  { value: "USDC", label: "USDC", icon: "🪙" },
-  { value: "XLM", label: "XLM", icon: "✨" },
+  { value: 'cNGN', label: 'cNGN', icon: '💵' },
+  { value: 'cKES', label: 'cKES', icon: '💵' },
+  { value: 'cGHS', label: 'cGHS', icon: '💵' },
+  { value: 'USDC', label: 'USDC', icon: '🪙' },
+  { value: 'XLM', label: 'XLM', icon: '✨' },
 ]
 
 interface CurrencySelectorProps {
-  variant: "fiat" | "crypto"
+  variant: 'fiat' | 'crypto'
   value: FiatCurrency | CryptoAsset
   onChange: (value: FiatCurrency | CryptoAsset) => void
   className?: string
 }
 
 export function CurrencySelector({ variant, value, onChange, className }: CurrencySelectorProps) {
-  const options = variant === "fiat" ? fiatOptions : cryptoOptions
+  const options = variant === 'fiat' ? fiatOptions : cryptoOptions
 
   return (
-    <div className={cn("relative", className)}>
+    <div className={cn('relative', className)}>
       <select
         value={value}
         onChange={(event) => onChange(event.target.value as FiatCurrency | CryptoAsset)}
-        className="h-[52px] w-full rounded-xl border border-border bg-background px-4 py-3 text-sm font-medium text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
-        aria-label={variant === "fiat" ? "Select fiat currency" : "Select crypto asset"}
+        className="h-[52px] w-full appearance-none rounded-xl border border-border bg-background px-4 py-3 pr-10 text-sm font-medium text-foreground shadow-sm focus:outline-none focus:ring-2 focus:ring-primary/30"
+        aria-label={variant === 'fiat' ? 'Select fiat currency' : 'Select crypto asset'}
       >
         {options.map((option) => (
           <option key={option.value} value={option.value}>
-            {"flag" in option ? `${option.flag} ${option.value}` : `${option.icon} ${option.label}`}
+            {'flag' in option ? `${option.flag} ${option.value}` : `${option.icon} ${option.label}`}
           </option>
         ))}
       </select>
+      <span className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-muted-foreground">
+        <svg viewBox="0 0 20 20" className="h-5 w-5" fill="none" aria-hidden="true">
+          <path
+            d="M6 8l4 4 4-4"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </span>
     </div>
   )
 }

--- a/components/onramp/onramp-calculator.tsx
+++ b/components/onramp/onramp-calculator.tsx
@@ -1,14 +1,14 @@
-"use client"
+'use client'
 
-import { Info, Loader2 } from "lucide-react"
-import { AmountInput } from "@/components/onramp/amount-input"
-import { CurrencySelector } from "@/components/onramp/currency-selector"
-import { ExchangeRateDisplay } from "@/components/onramp/exchange-rate-display"
-import { PaymentMethodCard } from "@/components/onramp/payment-method-card"
-import { WalletDisplay } from "@/components/onramp/wallet-display"
-import { Button } from "@/components/ui/button"
-import { formatCurrency, formatNumber } from "@/lib/onramp/formatters"
-import type { CryptoAsset, FiatCurrency, PaymentMethod } from "@/types/onramp"
+import { Info, Loader2 } from 'lucide-react'
+import { AmountInput } from '@/components/onramp/amount-input'
+import { CurrencySelector } from '@/components/onramp/currency-selector'
+import { ExchangeRateDisplay } from '@/components/onramp/exchange-rate-display'
+import { PaymentMethodCard } from '@/components/onramp/payment-method-card'
+import { WalletDisplay } from '@/components/onramp/wallet-display'
+import { Button } from '@/components/ui/button'
+import { formatCurrency, formatNumber } from '@/lib/onramp/formatters'
+import type { CryptoAsset, FiatCurrency, PaymentMethod } from '@/types/onramp'
 
 interface OnrampCalculatorProps {
   amountInput: string
@@ -22,8 +22,8 @@ interface OnrampCalculatorProps {
   exchangeLoading?: boolean
   onRefreshRate: () => void
   onAmountChange: (value: string) => void
-  onFiatChange: (value: FiatCurrency | CryptoAsset) => void
-  onCryptoChange: (value: FiatCurrency | CryptoAsset) => void
+  onFiatChange: (value: FiatCurrency) => void
+  onCryptoChange: (value: CryptoAsset) => void
   onPaymentChange: (value: PaymentMethod) => void
   onSubmit: () => void
   onCopyWallet: () => void
@@ -45,11 +45,17 @@ interface OnrampCalculatorProps {
   }
 }
 
-const paymentOptions: { value: PaymentMethod; icon: string; title: string; description: string }[] = [
-  { value: "bank_transfer", icon: "🏦", title: "Bank Transfer", description: "Free, 5-30 mins" },
-  { value: "card", icon: "💳", title: "Card Payment", description: "1.5% fee, Instant" },
-  { value: "mobile_money", icon: "📱", title: "Mobile Money", description: "0.5% fee, 2-10 mins" },
-]
+const paymentOptions: { value: PaymentMethod; icon: string; title: string; description: string }[] =
+  [
+    { value: 'bank_transfer', icon: '🏦', title: 'Bank Transfer', description: 'Free, 5-30 mins' },
+    { value: 'card', icon: '💳', title: 'Card Payment', description: '1.5% fee, Instant' },
+    {
+      value: 'mobile_money',
+      icon: '📱',
+      title: 'Mobile Money',
+      description: '0.5% fee, 2-10 mins',
+    },
+  ]
 
 export function OnrampCalculator({
   amountInput,
@@ -81,11 +87,11 @@ export function OnrampCalculator({
   fees,
 }: OnrampCalculatorProps) {
   const processingFeeLabel =
-    paymentMethod === "bank_transfer"
-      ? "FREE"
-      : paymentMethod === "card"
-      ? `${formatCurrency(fees.processingFee, fiatCurrency)} (1.5%)`
-      : `${formatCurrency(fees.processingFee, fiatCurrency)} (0.5%)`
+    paymentMethod === 'bank_transfer'
+      ? 'FREE'
+      : paymentMethod === 'card'
+        ? `${formatCurrency(fees.processingFee, fiatCurrency)} (1.5%)`
+        : `${formatCurrency(fees.processingFee, fiatCurrency)} (0.5%)`
 
   return (
     <div className="rounded-3xl border border-border bg-card p-6 shadow-lg">
@@ -108,7 +114,7 @@ export function OnrampCalculator({
           <CurrencySelector
             variant="fiat"
             value={fiatCurrency}
-            onChange={onFiatChange}
+            onChange={(value) => onFiatChange(value as FiatCurrency)}
             className="md:mt-6"
           />
         </div>
@@ -134,7 +140,7 @@ export function OnrampCalculator({
           <CurrencySelector
             variant="crypto"
             value={cryptoAsset}
-            onChange={onCryptoChange}
+            onChange={(value) => onCryptoChange(value as CryptoAsset)}
             className="md:mt-6"
           />
         </div>
@@ -180,7 +186,9 @@ export function OnrampCalculator({
           </div>
           <div className="mt-2 flex items-center justify-between">
             <span>Network fee</span>
-            <span className="font-medium text-foreground">{formatCurrency(fees.networkFee, fiatCurrency)}</span>
+            <span className="font-medium text-foreground">
+              {formatCurrency(fees.networkFee, fiatCurrency)}
+            </span>
           </div>
           <div className="mt-3 flex items-center justify-between border-t border-border pt-3 text-foreground">
             <span className="font-medium">Total cost</span>
@@ -190,8 +198,8 @@ export function OnrampCalculator({
 
         <div className="flex flex-col gap-2 text-xs text-muted-foreground">
           <span>
-            Min: {formatCurrency(limits.min, fiatCurrency)} | Max: {formatCurrency(limits.max, fiatCurrency)} per
-            transaction
+            Min: {formatCurrency(limits.min, fiatCurrency)} | Max:{' '}
+            {formatCurrency(limits.max, fiatCurrency)} per transaction
           </span>
         </div>
 

--- a/components/onramp/onramp-page-client.tsx
+++ b/components/onramp/onramp-page-client.tsx
@@ -19,6 +19,7 @@ import { useOnrampForm } from "@/hooks/use-onramp-form"
 import { useWalletConnection } from "@/hooks/use-wallet-connection"
 import { OnrampTestUtils } from "@/components/onramp/onramp-test-utils"
 import type { CryptoAsset, FiatCurrency } from "@/types/onramp"
+import { formatCurrency, truncateAddress } from "@/lib/onramp/formatters"
 import { isValidStellarAddress } from "@/lib/onramp/validation"
 import type { OnrampOrder } from "@/types/onramp"
 
@@ -27,11 +28,12 @@ const ORDER_KEY = "onramp:latest-order"
 export function OnrampPageClient() {
   const router = useRouter()
   const { address, addresses, connected, loading, updateAddress, disconnect } = useWalletConnection()
+  const walletConnected = Boolean(address) || connected
   const [walletModalOpen, setWalletModalOpen] = useState(false)
   const [disconnectModalOpen, setDisconnectModalOpen] = useState(false)
   const [rateOverride, setRateOverride] = useState(0)
 
-  const form = useOnrampForm(rateOverride, connected)
+  const form = useOnrampForm(rateOverride, walletConnected)
   const { data, countdown, warning, error, isLoading, displayRate, refresh } = useExchangeRate(
     form.state.fiatCurrency,
     form.state.cryptoAsset
@@ -50,10 +52,10 @@ export function OnrampPageClient() {
   }, [router])
 
   useEffect(() => {
-    if (!loading && !connected) {
+    if (!loading && !walletConnected) {
       setWalletModalOpen(true)
     }
-  }, [loading, connected])
+  }, [loading, walletConnected])
 
   const handleCopy = async () => {
     try {
@@ -131,16 +133,16 @@ export function OnrampPageClient() {
             <Link href="/onramp" className="rounded-full px-3 py-2 bg-muted text-foreground">
               Onramp
             </Link>
-            <button type="button" className="rounded-full px-3 py-2 hover:text-foreground">
+            <Link href="/offramp" className="rounded-full px-3 py-2 hover:text-foreground">
               Offramp
-            </button>
+            </Link>
             <button type="button" className="rounded-full px-3 py-2 hover:text-foreground">
               Pay Bills
             </button>
           </nav>
 
           <div className="flex items-center gap-3">
-            {connected ? (
+            {walletConnected ? (
               <div
                 className="flex items-center gap-2 rounded-full border border-border bg-muted/40 px-3 py-1 text-xs text-foreground"
                 title={address}

--- a/hooks/use-exchange-rate.ts
+++ b/hooks/use-exchange-rate.ts
@@ -4,8 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import type { CryptoAsset, ExchangeRateResult, ExchangeRateState, FiatCurrency } from "@/types/onramp"
 import { formatRate } from "@/lib/onramp/formatters"
 
-const API_URL =
-  "https://api.coingecko.com/api/v3/simple/price?ids=usd-coin,stellar&vs_currencies=ngn,kes,ghs,zar,ugx"
+const API_URL = "/api/exchange-rate"
 
 const STORAGE_KEY = "onramp:rates"
 const COUNTDOWN_START = 30

--- a/hooks/use-offramp-balances.ts
+++ b/hooks/use-offramp-balances.ts
@@ -1,0 +1,155 @@
+"use client"
+
+import { useEffect, useMemo, useState } from "react"
+import type { OfframpAssetOption, OfframpChain, OfframpAsset } from "@/types/offramp"
+
+const STELLAR_USDC_ISSUER = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN"
+const STELLAR_CNGN_ISSUER = process.env.NEXT_PUBLIC_CNGN_ISSUER || ""
+
+const erc20Contracts: Record<OfframpChain, Partial<Record<OfframpAsset, { address: string; decimals: number }>>> = {
+  Ethereum: {
+    USDC: { address: "0xA0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", decimals: 6 },
+    USDT: { address: "0xdAC17F958D2ee523a2206206994597C13D831ec7", decimals: 6 },
+  },
+  Polygon: {
+    USDC: { address: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174", decimals: 6 },
+    USDT: { address: "0xC2132D05D31c914a87C6611C10748AaCbA948e8F", decimals: 6 },
+  },
+  Base: {
+    USDC: { address: "0x833589fCD6eDb6E08f4c7C32D4f71b54bda02913", decimals: 6 },
+  },
+  Stellar: {},
+}
+
+const rpcUrls: Record<OfframpChain, string> = {
+  Ethereum: "https://cloudflare-eth.com",
+  Polygon: "https://polygon-rpc.com",
+  Base: "https://mainnet.base.org",
+  Stellar: "https://horizon.stellar.org",
+}
+
+const baseOptions: OfframpAssetOption[] = [
+  { id: "cngn-stellar", asset: "cNGN", chain: "Stellar", label: "cNGN", balance: 0, icon: "💵" },
+  { id: "usdc-stellar", asset: "USDC", chain: "Stellar", label: "USDC", balance: 0, icon: "🪙" },
+  { id: "usdc-ethereum", asset: "USDC", chain: "Ethereum", label: "USDC", balance: 0, icon: "🪙" },
+  { id: "usdc-polygon", asset: "USDC", chain: "Polygon", label: "USDC", balance: 0, icon: "🪙" },
+  { id: "usdc-base", asset: "USDC", chain: "Base", label: "USDC", balance: 0, icon: "🪙" },
+  { id: "usdt-ethereum", asset: "USDT", chain: "Ethereum", label: "USDT", balance: 0, icon: "🪙" },
+  { id: "usdt-polygon", asset: "USDT", chain: "Polygon", label: "USDT", balance: 0, icon: "🪙" },
+  { id: "xlm-stellar", asset: "XLM", chain: "Stellar", label: "XLM", balance: 0, icon: "✨" },
+]
+
+function isEvmAddress(address?: string) {
+  return Boolean(address && address.startsWith("0x") && address.length === 42)
+}
+
+function isStellarAddress(address?: string) {
+  return Boolean(address && address.startsWith("G") && address.length === 56)
+}
+
+async function fetchErc20Balance(rpcUrl: string, contract: string, address: string, decimals: number) {
+  const data = `0x70a08231${address.replace("0x", "").padStart(64, "0")}`
+  const response = await fetch(rpcUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "eth_call", params: [{ to: contract, data }, "latest"] }),
+  })
+
+  if (!response.ok) throw new Error("RPC request failed")
+  const payload = await response.json()
+  if (!payload.result) return 0
+  const raw = BigInt(payload.result)
+  return Number(raw) / 10 ** decimals
+}
+
+async function fetchStellarBalances(address: string) {
+  const response = await fetch(`${rpcUrls.Stellar}/accounts/${address}`)
+  if (!response.ok) throw new Error("Horizon request failed")
+  const data = await response.json()
+  return data.balances as Array<{ asset_type: string; asset_code?: string; asset_issuer?: string; balance: string }>
+}
+
+export function useOfframpBalances(address?: string) {
+  const [options, setOptions] = useState<OfframpAssetOption[]>(baseOptions)
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    let cancelled = false
+
+    const loadBalances = async () => {
+      if (!address) {
+        setOptions(baseOptions)
+        return
+      }
+
+      setLoading(true)
+      let nextOptions = [...baseOptions]
+
+      try {
+        if (isStellarAddress(address)) {
+          const balances = await fetchStellarBalances(address)
+          const getStellarAssetBalance = (code: string, issuer?: string) => {
+            const match = balances.find((item) => item.asset_code === code && item.asset_issuer === issuer)
+            return match ? Number(match.balance) : 0
+          }
+
+          const native = balances.find((item) => item.asset_type === "native")
+          const xlmBalance = native ? Number(native.balance) : 0
+
+          nextOptions = nextOptions.map((option) => {
+            if (option.chain !== "Stellar") return option
+            if (option.asset === "XLM") return { ...option, balance: xlmBalance }
+            if (option.asset === "USDC") return { ...option, balance: getStellarAssetBalance("USDC", STELLAR_USDC_ISSUER) }
+            if (option.asset === "cNGN") return { ...option, balance: STELLAR_CNGN_ISSUER ? getStellarAssetBalance("cNGN", STELLAR_CNGN_ISSUER) : 0 }
+            return option
+          })
+        }
+
+        if (isEvmAddress(address)) {
+          const evmChains: OfframpChain[] = ["Ethereum", "Polygon", "Base"]
+          const balancePromises = evmChains.flatMap((chain) => {
+            const entries = erc20Contracts[chain]
+            return Object.entries(entries).map(async ([asset, config]) => {
+              if (!config) return null
+              try {
+                const balance = await fetchErc20Balance(rpcUrls[chain], config.address, address, config.decimals)
+                return { chain, asset: asset as OfframpAsset, balance }
+              } catch (error) {
+                console.error(`Failed to fetch ${asset} on ${chain}`, error)
+                return { chain, asset: asset as OfframpAsset, balance: 0 }
+              }
+            })
+          })
+
+          const results = (await Promise.all(balancePromises)).filter(Boolean) as Array<{
+            chain: OfframpChain
+            asset: OfframpAsset
+            balance: number
+          }>
+
+          nextOptions = nextOptions.map((option) => {
+            const match = results.find((result) => result.chain === option.chain && result.asset === option.asset)
+            return match ? { ...option, balance: match.balance } : option
+          })
+        }
+      } catch (error) {
+        console.error("Failed to load offramp balances", error)
+      }
+
+      if (!cancelled) {
+        setOptions(nextOptions)
+        setLoading(false)
+      }
+    }
+
+    loadBalances()
+
+    return () => {
+      cancelled = true
+    }
+  }, [address])
+
+  const hasAnyBalance = useMemo(() => options.some((option) => option.balance > 0), [options])
+
+  return { options, loading, hasAnyBalance }
+}

--- a/hooks/use-offramp-form.ts
+++ b/hooks/use-offramp-form.ts
@@ -1,0 +1,136 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import type { FiatCurrency } from "@/types/onramp"
+import type { OfframpAssetOption, OfframpFormState } from "@/types/offramp"
+import { calculateFiatAmount, calculateFees, getMinMax } from "@/lib/offramp/calculations"
+import { formatAmountInput, parseAmountInput } from "@/lib/onramp/formatters"
+
+const STORAGE_KEY = "offramp:form"
+const EXPIRY_MS = 15 * 60 * 1000
+
+const defaultState: OfframpFormState = {
+  assetId: "cngn-stellar",
+  amountInput: "",
+  fiatCurrency: "NGN",
+}
+
+export function useOfframpForm(options: OfframpAssetOption[], rate: number) {
+  const [state, setState] = useState<OfframpFormState>(defaultState)
+  const [hydrated, setHydrated] = useState(false)
+  const [errors, setErrors] = useState<{ amount?: string; liquidity?: string; limit?: string }>({})
+  const [debouncedAmount, setDebouncedAmount] = useState(0)
+  const [isCalculating, setIsCalculating] = useState(false)
+
+  useEffect(() => {
+    const stored = localStorage.getItem(STORAGE_KEY)
+    if (!stored) {
+      setHydrated(true)
+      return
+    }
+    const parsed = JSON.parse(stored) as { data: OfframpFormState; timestamp: number }
+    if (Date.now() - parsed.timestamp > EXPIRY_MS) {
+      localStorage.removeItem(STORAGE_KEY)
+      setHydrated(true)
+      return
+    }
+    setState(parsed.data)
+    setHydrated(true)
+  }, [])
+
+  useEffect(() => {
+    if (!hydrated) return
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ data: state, timestamp: Date.now() }))
+  }, [state, hydrated])
+
+  useEffect(() => {
+    setIsCalculating(true)
+    const timer = setTimeout(() => {
+      setDebouncedAmount(parseAmountInput(state.amountInput))
+      setIsCalculating(false)
+    }, 250)
+    return () => clearTimeout(timer)
+  }, [state.amountInput])
+
+  const selectedAsset = useMemo(
+    () => options.find((option) => option.id === state.assetId) || options[0],
+    [options, state.assetId]
+  )
+
+  const fiatAmount = useMemo(() => calculateFiatAmount(debouncedAmount, rate), [debouncedAmount, rate])
+  const fees = useMemo(
+    () => calculateFees(fiatAmount, selectedAsset?.chain ?? "Stellar"),
+    [fiatAmount, selectedAsset]
+  )
+
+  const limits = useMemo(() => getMinMax(state.fiatCurrency), [state.fiatCurrency])
+
+  useEffect(() => {
+    const nextErrors: { amount?: string; liquidity?: string; limit?: string } = {}
+    if (!state.amountInput || debouncedAmount <= 0) {
+      nextErrors.amount = "Enter an amount to continue."
+    }
+
+    if (fiatAmount && fiatAmount < limits.min) {
+      nextErrors.amount = `Minimum withdrawal is ${limits.min.toLocaleString("en-US")}.`
+    }
+
+    if (fiatAmount && fiatAmount > limits.max) {
+      nextErrors.amount = `Maximum withdrawal is ${limits.max.toLocaleString("en-US")}.`
+    }
+
+    const liquidityLimit = 1500000
+    if (fiatAmount > liquidityLimit) {
+      nextErrors.liquidity = "Limited liquidity available right now. Try a smaller amount."
+    }
+
+    const dailyLimit = 5000000
+    const dailyUsed = 1250000
+    if (fiatAmount + dailyUsed > dailyLimit) {
+      nextErrors.limit = "Daily withdrawal limit reached."
+    }
+
+    setErrors(nextErrors)
+  }, [debouncedAmount, fiatAmount, limits.max, limits.min, state.amountInput])
+
+  const setAmountInput = useCallback((value: string) => {
+    const sanitized = value.replace(/[^0-9.]/g, "")
+    const parts = sanitized.split(".")
+    let normalized = [parts[0], parts[1]?.slice(0, 6)].filter(Boolean).join(".")
+    if (sanitized.startsWith(".") && parts[1]) {
+      normalized = `0.${parts[1].slice(0, 6)}`
+    }
+    setState((prev) => ({ ...prev, amountInput: formatAmountInput(normalized) }))
+  }, [])
+
+  const setFiatCurrency = useCallback((currency: FiatCurrency) => {
+    setState((prev) => ({ ...prev, fiatCurrency: currency }))
+  }, [])
+
+  const setAssetId = useCallback((assetId: string) => {
+    setState((prev) => ({ ...prev, assetId }))
+  }, [])
+
+  const setMaxAmount = useCallback(() => {
+    if (!selectedAsset) return
+    setState((prev) => ({ ...prev, amountInput: formatAmountInput(selectedAsset.balance.toString()) }))
+  }, [selectedAsset])
+
+  const isValid = !errors.amount && !errors.liquidity && !errors.limit && fiatAmount > 0
+
+  return {
+    state,
+    selectedAsset,
+    amountValue: debouncedAmount,
+    fiatAmount,
+    fees,
+    limits,
+    errors,
+    isCalculating,
+    isValid,
+    setAmountInput,
+    setFiatCurrency,
+    setAssetId,
+    setMaxAmount,
+  }
+}

--- a/hooks/use-offramp-rate.ts
+++ b/hooks/use-offramp-rate.ts
@@ -1,0 +1,64 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import type { OfframpAsset, OfframpChain } from "@/types/offramp"
+
+const RATE_REFRESH_SECONDS = 30
+
+const rateMap: Record<OfframpAsset, number> = {
+  cNGN: 1584,
+  USDC: 1500,
+  USDT: 1490,
+  XLM: 420,
+}
+
+export function useOfframpRate(asset: OfframpAsset, chain: OfframpChain) {
+  const [countdown, setCountdown] = useState(RATE_REFRESH_SECONDS)
+  const [lastUpdated, setLastUpdated] = useState(Date.now())
+  const [isLoading, setIsLoading] = useState(true)
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const rate = useMemo(() => {
+    const chainMultiplier = chain === "Ethereum" ? 1.01 : chain === "Polygon" ? 0.995 : chain === "Base" ? 1.002 : 1
+    return rateMap[asset] * chainMultiplier
+  }, [asset, chain])
+
+  const refresh = useCallback(() => {
+    setIsLoading(true)
+    setTimeout(() => {
+      setLastUpdated(Date.now())
+      setIsLoading(false)
+      setCountdown(RATE_REFRESH_SECONDS)
+    }, 350)
+  }, [])
+
+  useEffect(() => {
+    refresh()
+  }, [asset, chain, refresh])
+
+  useEffect(() => {
+    if (timerRef.current) clearInterval(timerRef.current)
+
+    timerRef.current = setInterval(() => {
+      setCountdown((prev) => {
+        if (prev <= 1) {
+          refresh()
+          return RATE_REFRESH_SECONDS
+        }
+        return prev - 1
+      })
+    }, 1000)
+
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current)
+    }
+  }, [refresh])
+
+  return {
+    rate,
+    countdown,
+    lastUpdated,
+    isLoading,
+    refresh,
+  }
+}

--- a/lib/offramp/calculations.ts
+++ b/lib/offramp/calculations.ts
@@ -1,0 +1,41 @@
+import type { FiatCurrency } from "@/types/onramp"
+import type { OfframpFeeBreakdown } from "@/types/offramp"
+
+const networkFeeMap: Record<string, number> = {
+  Stellar: 15,
+  Ethereum: 1500,
+  Polygon: 120,
+  Base: 200,
+}
+
+export function calculateFiatAmount(amount: number, rate: number) {
+  if (!amount || amount <= 0) return 0
+  return amount * rate
+}
+
+export function calculateFees(
+  fiatAmount: number,
+  chain: string,
+  offrampFeeRate = 0.01
+): OfframpFeeBreakdown {
+  const offrampFee = fiatAmount * offrampFeeRate
+  const networkFee = networkFeeMap[chain] ?? 15
+  const bankFee = 0
+  const totalFees = offrampFee + networkFee + bankFee
+  const receiveAmount = Math.max(fiatAmount - totalFees, 0)
+
+  return {
+    offrampFee,
+    networkFee,
+    bankFee,
+    totalFees,
+    receiveAmount,
+  }
+}
+
+export function getMinMax(currency: FiatCurrency) {
+  return {
+    min: currency === "NGN" ? 5000 : 5000,
+    max: currency === "NGN" ? 5000000 : 5000000,
+  }
+}

--- a/lib/offramp/formatters.ts
+++ b/lib/offramp/formatters.ts
@@ -1,0 +1,13 @@
+export function formatUsd(amount: number) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    maximumFractionDigits: 2,
+  }).format(amount)
+}
+
+export function formatRateCountdown(seconds: number) {
+  const minutes = Math.floor(seconds / 60)
+  const remaining = seconds % 60
+  return `${minutes}:${remaining.toString().padStart(2, "0")}`
+}

--- a/types/offramp.ts
+++ b/types/offramp.ts
@@ -1,0 +1,49 @@
+import type { FiatCurrency } from "@/types/onramp"
+
+export type OfframpChain = "Stellar" | "Ethereum" | "Polygon" | "Base"
+export type OfframpAsset = "cNGN" | "USDC" | "USDT" | "XLM"
+
+export interface OfframpAssetOption {
+  id: string
+  asset: OfframpAsset
+  chain: OfframpChain
+  label: string
+  balance: number
+  icon: string
+}
+
+export interface OfframpRateState {
+  rate: number
+  lastUpdated: number
+  countdown: number
+  isLoading: boolean
+}
+
+export interface OfframpFormState {
+  assetId: string
+  amountInput: string
+  fiatCurrency: FiatCurrency
+}
+
+export interface OfframpFeeBreakdown {
+  offrampFee: number
+  networkFee: number
+  bankFee: number
+  totalFees: number
+  receiveAmount: number
+}
+
+export interface OfframpOrder {
+  id: string
+  createdAt: number
+  lockExpiresAt: number
+  assetId: string
+  asset: OfframpAsset
+  chain: OfframpChain
+  amount: number
+  fiatCurrency: FiatCurrency
+  rate: number
+  fiatAmount: number
+  fees: OfframpFeeBreakdown
+  status: "pending_bank_details"
+}


### PR DESCRIPTION
This PR closes #14.

Add comprehensive offramp functionality allowing users to sell crypto assets for local fiat currencies. Includes new API endpoint for exchange rates, asset selector component, calculator with fee breakdowns, balance fetching hooks, and updated onramp components for consistency. Supports multiple chains (Stellar, Ethereum, Polygon, Base) and assets (cNGN, USDC, USDT, XLM).