### PR TITLE
feat: error boundaries

### DIFF
--- a/app/bills/pay/[billerId]/error.tsx
+++ b/app/bills/pay/[billerId]/error.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import ErrorLayout from '@/components/error/ErrorLayout'
+
+export default function BillsPayError({ reset }: { reset: () => void }) {
+  return (
+    <ErrorLayout
+      title="Payment Error"
+      message="Something went wrong while loading the bill payment."
+      actions={[
+        { label: 'Retry', onClick: reset },
+        { label: 'Back to Bills', href: '/bills' },
+      ]}
+    />
+  )
+}

--- a/app/bills/receipt/[transactionId]/error.tsx
+++ b/app/bills/receipt/[transactionId]/error.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import ErrorLayout from '@/components/error/ErrorLayout'
+
+export default function BillsReceiptError({ reset }: { reset: () => void }) {
+  return (
+    <ErrorLayout
+      title="Receipt Error"
+      message="Something went wrong while loading your receipt."
+      actions={[
+        { label: 'Retry', onClick: reset },
+        { label: 'Back to Bills', href: '/bills' },
+      ]}
+    />
+  )
+}

--- a/app/offramp/processing/[orderId]/error.tsx
+++ b/app/offramp/processing/[orderId]/error.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import ErrorLayout from '@/components/error/ErrorLayout'
+
+export default function OfframpProcessingError({ reset }: { reset: () => void }) {
+  return (
+    <ErrorLayout
+      title="Processing Error"
+      message="Something went wrong while processing your offramp order."
+      actions={[
+        { label: 'Retry', onClick: reset },
+        { label: 'Back to Offramp', href: '/offramp' },
+      ]}
+    />
+  )
+}

--- a/app/onramp/payment/[orderId]/error.tsx
+++ b/app/onramp/payment/[orderId]/error.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import ErrorLayout from '@/components/error/ErrorLayout'
+
+export default function OnrampPaymentError({ reset }: { reset: () => void }) {
+  return (
+    <ErrorLayout
+      title="Payment Error"
+      message="Something went wrong while loading your payment."
+      actions={[
+        { label: 'Retry', onClick: reset },
+        { label: 'Back to Onramp', href: '/onramp' },
+      ]}
+    />
+  )
+}

--- a/app/onramp/processing/[orderId]/error.tsx
+++ b/app/onramp/processing/[orderId]/error.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import ErrorLayout from '@/components/error/ErrorLayout'
+
+export default function OnrampProcessingError({ reset }: { reset: () => void }) {
+  return (
+    <ErrorLayout
+      title="Processing Error"
+      message="Something went wrong while processing your onramp order."
+      actions={[
+        { label: 'Retry', onClick: reset },
+        { label: 'Back to Onramp', href: '/onramp' },
+      ]}
+    />
+  )
+}


### PR DESCRIPTION
  Created error.tsx in all 5 dynamic route segments:
  
  ┌─────────────────────────────────────────────┬───────────┐
  │ File                                        │ Back link │
  ├─────────────────────────────────────────────┼───────────┤
  │ app/offramp/processing/[orderId]/error.tsx  │ /offramp  │
  ├─────────────────────────────────────────────┼───────────┤
  │ app/onramp/processing/[orderId]/error.tsx   │ /onramp   │
  ├─────────────────────────────────────────────┼───────────┤
  │ app/onramp/payment/[orderId]/error.tsx      │ /onramp   │
  ├─────────────────────────────────────────────┼───────────┤
  │ app/bills/pay/[billerId]/error.tsx          │ /bills    │
  ├─────────────────────────────────────────────┼───────────┤
  │ app/bills/receipt/[transactionId]/error.tsx │ /bills    │
  └─────────────────────────────────────────────┴───────────┘
  
  Each file is 'use client' (required by Next.js for error boundaries), receives the reset prop to retry, and reuses the existing ErrorLayout component —
  consistent with the global app/error.tsx. Errors thrown inside these routes will now be caught at the nearest boundary instead of bubbling up to crash the
  whole app.

closes #124 