### PR TITLE
feat: Send P2P, multi-currency calculator, backend rate proxy

### DIFF
--- a/app/api/rates/route.ts
+++ b/app/api/rates/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from 'next/server'
+
+const COINGECKO_ETH_URL =
+  'https://api.coingecko.com/api/v3/simple/price?ids=ethereum&vs_currencies=usd'
+
+const CACHE_TTL_MS = 60_000 // 1 minute
+
+let cache: { data: { ethereum: { usd: number } }; cachedAt: number } | null = null
+
+export async function GET() {
+  // Return cached data if still fresh
+  if (cache && Date.now() - cache.cachedAt < CACHE_TTL_MS) {
+    return NextResponse.json(cache.data, {
+      headers: { 'X-Cache': 'HIT' },
+    })
+  }
+
+  try {
+    const res = await fetch(COINGECKO_ETH_URL, {
+      headers: { 'User-Agent': 'Aframp/1.0', Accept: 'application/json' },
+      next: { revalidate: 60 },
+    })
+
+    if (!res.ok) throw new Error(`CoinGecko responded ${res.status}`)
+
+    const data = (await res.json()) as { ethereum: { usd: number } }
+
+    if (!data?.ethereum?.usd) throw new Error('Unexpected CoinGecko response shape')
+
+    cache = { data, cachedAt: Date.now() }
+
+    return NextResponse.json(data, { headers: { 'X-Cache': 'MISS' } })
+  } catch (err) {
+    // Serve stale cache as fallback rather than failing
+    if (cache) {
+      return NextResponse.json(cache.data, {
+        headers: { 'X-Cache': 'STALE' },
+        status: 200,
+      })
+    }
+
+    const message = err instanceof Error ? err.message : 'Failed to fetch rates'
+    return NextResponse.json({ error: message }, { status: 502 })
+  }
+}

--- a/components/offramp/offramp-calculator.tsx
+++ b/components/offramp/offramp-calculator.tsx
@@ -114,6 +114,26 @@ export function OfframpCalculator({
           ≈ {formatUsd(usdEquivalent)} USD equivalent
         </div>
 
+        <div className="space-y-3">
+          <label className="text-sm font-medium text-foreground">Select Currency</label>
+          <div className="flex flex-wrap gap-2">
+            {(['NGN', 'KES', 'GHS', 'ZAR'] as const).map((curr) => (
+              <button
+                key={curr}
+                type="button"
+                onClick={() => onFiatChange(curr)}
+                className={`px-4 py-2 rounded-full text-sm font-semibold transition-all ${
+                  fiatCurrency === curr
+                    ? 'bg-primary text-primary-foreground shadow-md'
+                    : 'bg-muted text-muted-foreground hover:bg-muted/80'
+                }`}
+              >
+                {curr}
+              </button>
+            ))}
+          </div>
+        </div>
+
         <div className="grid gap-4 md:grid-cols-[1fr_180px] md:items-end">
           <div className="space-y-2">
             <label className="text-sm font-medium text-foreground">You&apos;ll Receive</label>

--- a/components/offramp/offramp-page-client.tsx
+++ b/components/offramp/offramp-page-client.tsx
@@ -37,7 +37,8 @@ export function OfframpPageClient() {
   const selectedAsset = form.selectedAsset
   const { rate, countdown, lastUpdated, isLoading, refresh } = useOfframpRate(
     selectedAsset.asset,
-    selectedAsset.chain
+    selectedAsset.chain,
+    form.state.fiatCurrency
   )
 
   useEffect(() => {

--- a/components/send/send-page-client.tsx
+++ b/components/send/send-page-client.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { ArrowLeft, QrCode, ChevronRight, Wallet, StickyNote } from 'lucide-react'
 import { Button } from '@/components/ui/button'
@@ -9,6 +9,12 @@ import { cn } from '@/lib/utils'
 import { RecentRecipients } from './recent-recipients'
 import { QRScanner } from './qr-scanner'
 import { TransactionConfirmation } from './transaction-confirmation'
+import {
+  isValidStellarAddress,
+  estimateStellarFee,
+  sendStellarP2P,
+} from '@/lib/stellar-p2p'
+import { getFreighterPublicKey, getFreighterNetwork } from '@/lib/wallet/freighter'
 
 type Step = 'recipient' | 'amount' | 'confirm' | 'success'
 
@@ -46,6 +52,9 @@ export function SendPageClient() {
   const [step, setStep] = useState<Step>('recipient')
   const [scannerOpen, setScannerOpen] = useState(false)
   const [isSending, setIsSending] = useState(false)
+  const [sendError, setSendError] = useState<string | null>(null)
+  const [txHash, setTxHash] = useState<string | null>(null)
+  const [estimatedFee, setEstimatedFee] = useState<string | null>(null)
   const [recipientInput, setRecipientInput] = useState('')
   const [form, setForm] = useState<SendFormState>({
     recipient: null,
@@ -56,6 +65,12 @@ export function SendPageClient() {
 
   const steps: Step[] = ['recipient', 'amount', 'confirm']
   const currentStepIdx = steps.indexOf(step)
+
+  // Fetch fee estimate when entering the confirm step
+  useEffect(() => {
+    if (step !== 'confirm') return
+    estimateStellarFee(null).then(setEstimatedFee).catch(() => setEstimatedFee(null))
+  }, [step])
 
   const handleBack = () => {
     if (step === 'recipient') {
@@ -104,13 +119,42 @@ export function SendPageClient() {
   }
 
   const handleSend = async () => {
+    if (!form.recipient?.address) return
     setIsSending(true)
-    await new Promise((resolve) => setTimeout(resolve, 2200))
+    setSendError(null)
+
+    const [publicKey, network] = await Promise.all([
+      getFreighterPublicKey(),
+      getFreighterNetwork(),
+    ])
+
+    if (!publicKey) {
+      setSendError('Wallet not connected. Please connect Freighter.')
+      setIsSending(false)
+      return
+    }
+
+    const result = await sendStellarP2P({
+      sourcePublicKey: publicKey,
+      destination: form.recipient.address,
+      amount: form.amount,
+      assetCode: form.asset.symbol,
+      memo: form.note || undefined,
+      network,
+    })
+
     setIsSending(false)
+
+    if (result.error || !result.txHash) {
+      setSendError(result.error ?? 'Transaction failed')
+      return
+    }
+
+    setTxHash(result.txHash)
     setStep('success')
   }
 
-  const isRecipientValid = recipientInput.trim().length > 5
+  const isRecipientValid = isValidStellarAddress(recipientInput.trim())
   const isAmountValid = parseFloat(form.amount) > 0
 
   return (
@@ -175,8 +219,8 @@ export function SendPageClient() {
                 </button>
               </div>
               {recipientInput && !isRecipientValid && (
-                <p className="text-xs text-muted-foreground">
-                  Enter a valid Stellar address (starts with G)
+                <p className="text-xs text-destructive">
+                  Enter a valid Stellar address (starts with G, 56 characters)
                 </p>
               )}
             </div>
@@ -311,6 +355,9 @@ export function SendPageClient() {
             form={form}
             step={step}
             isSending={isSending}
+            sendError={sendError}
+            txHash={txHash}
+            estimatedFee={estimatedFee}
             onBack={() => setStep('amount')}
             onConfirm={handleSend}
             onDone={() => router.push('/dashboard')}

--- a/components/send/transaction-confirmation.tsx
+++ b/components/send/transaction-confirmation.tsx
@@ -11,6 +11,9 @@ interface TransactionConfirmationProps {
   form: SendFormState
   step: 'confirm' | 'success'
   isSending: boolean
+  sendError?: string | null
+  txHash?: string | null
+  estimatedFee?: string | null
   onBack: () => void
   onConfirm: () => void
   onDone: () => void
@@ -20,12 +23,15 @@ export function TransactionConfirmation({
   form,
   step,
   isSending,
+  sendError,
+  txHash,
+  estimatedFee,
   onBack,
   onConfirm,
   onDone,
 }: TransactionConfirmationProps) {
   const [copiedField, setCopiedField] = useState<string | null>(null)
-  const [txId] = useState(() => 'AFR' + Math.random().toString(36).slice(2, 10).toUpperCase())
+  const displayTxId = txHash ?? 'pending'
 
   const copy = async (text: string, field: string) => {
     await navigator.clipboard.writeText(text)
@@ -82,11 +88,13 @@ export function TransactionConfirmation({
               )}
               <Separator className="opacity-50" />
               <div className="flex items-center justify-between">
-                <span className="text-xs text-muted-foreground">Transaction ID</span>
+                <span className="text-xs text-muted-foreground">Transaction Hash</span>
                 <div className="flex items-center gap-1.5">
-                  <span className="text-xs font-mono text-foreground">{txId}</span>
+                  <span className="text-xs font-mono text-foreground truncate max-w-[140px]">
+                    {displayTxId}
+                  </span>
                   <button
-                    onClick={() => copy(txId, 'txid')}
+                    onClick={() => copy(displayTxId, 'txid')}
                     className="text-muted-foreground hover:text-emerald-500 transition-colors"
                   >
                     {copiedField === 'txid' ? (
@@ -109,7 +117,14 @@ export function TransactionConfirmation({
           >
             Back to Home
           </Button>
-          <button className="w-full text-center text-sm text-muted-foreground hover:text-foreground transition-colors py-2">
+          <button
+            onClick={() =>
+              txHash &&
+              window.open(`https://stellar.expert/explorer/public/tx/${txHash}`, '_blank')
+            }
+            className="w-full text-center text-sm text-muted-foreground hover:text-foreground transition-colors py-2 disabled:opacity-40"
+            disabled={!txHash}
+          >
             View on Explorer
           </button>
         </div>
@@ -118,8 +133,8 @@ export function TransactionConfirmation({
   }
 
   // ── Confirm screen ──
-  const estimatedFee = (parseFloat(form.amount || '0') * 0.001).toFixed(6)
-  const totalCost = (parseFloat(form.amount || '0') + parseFloat(estimatedFee)).toFixed(6)
+  const feeDisplay = estimatedFee ?? (parseFloat(form.amount || '0') * 0.001).toFixed(7)
+  const totalCost = (parseFloat(form.amount || '0') + parseFloat(feeDisplay)).toFixed(7)
 
   return (
     <div className="flex-1 flex flex-col px-5 pb-8 pt-2 gap-4">
@@ -192,7 +207,7 @@ export function TransactionConfirmation({
         <div className="px-4 py-3.5 flex items-center justify-between">
           <span className="text-sm text-muted-foreground">Network fee</span>
           <span className="text-sm text-muted-foreground">
-            ~{estimatedFee} {form.asset.symbol}
+            ~{feeDisplay} XLM
           </span>
         </div>
 
@@ -226,6 +241,9 @@ export function TransactionConfirmation({
 
       {/* CTAs */}
       <div className="mt-auto space-y-2.5">
+        {sendError && (
+          <p className="text-xs text-destructive text-center px-2">{sendError}</p>
+        )}
         <Button
           onClick={onConfirm}
           disabled={isSending}

--- a/hooks/use-eth-price.ts
+++ b/hooks/use-eth-price.ts
@@ -2,22 +2,6 @@
 
 import { useState, useEffect, useCallback } from 'react'
 
-interface EthSymbol {
-  symbol: string
-  last: string | number
-  last_btc?: string | number
-  lowest?: string | number
-  highest?: string | number
-  date?: string
-  daily_change_percentage?: string | number
-  source_exchange?: string
-}
-
-interface EthPriceResponse {
-  status: string
-  symbols: EthSymbol[]
-}
-
 export function useEthPrice() {
   const [price, setPrice] = useState<number | null>(null)
   const [loading, setLoading] = useState<boolean>(true)
@@ -29,73 +13,35 @@ export function useEthPrice() {
       setLoading(true)
       setError(null)
 
-      const response = await fetch('https://kelly-musk.up.railway.app/api/eth-price', {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        // Add cache control to prevent stale data
-        cache: 'no-store',
-      })
+      const response = await fetch('/api/rates')
 
       if (!response.ok) {
         throw new Error(`Failed to fetch ETH price: ${response.statusText}`)
       }
 
-      const data: EthPriceResponse = await response.json()
+      const data = (await response.json()) as { ethereum?: { usd?: number }; error?: string }
 
-      // Filter and extract price from JSON response
-      // The API returns: { status: "success", symbols: [{ symbol: "ETH", last: "3204.27", ... }] }
-      let ethPrice: number | null = null
+      if (data.error) throw new Error(data.error)
 
-      if (
-        data.status === 'success' &&
-        data.symbols &&
-        Array.isArray(data.symbols) &&
-        data.symbols.length > 0
-      ) {
-        const ethSymbol = data.symbols.find((s) => s.symbol === 'ETH') || data.symbols[0]
-
-        if (ethSymbol && ethSymbol.last !== undefined) {
-          // Convert to number if it's a string
-          ethPrice =
-            typeof ethSymbol.last === 'string' ? parseFloat(ethSymbol.last) : ethSymbol.last
-        }
-      }
-
-      if (ethPrice === null || isNaN(ethPrice)) {
-        throw new Error('Invalid API response format: price not found')
+      const ethPrice = data.ethereum?.usd
+      if (!ethPrice || isNaN(ethPrice)) {
+        throw new Error('Invalid rate response: ETH price not found')
       }
 
       setPrice(ethPrice)
       setLastUpdated(new Date())
-      setLoading(false)
     } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : 'Failed to fetch ETH price'
-      setError(errorMessage)
+      setError(err instanceof Error ? err.message : 'Failed to fetch ETH price')
+    } finally {
       setLoading(false)
-      console.error('Error fetching ETH price:', err)
     }
   }, [])
 
   useEffect(() => {
-    // Fetch immediately on mount
     fetchEthPrice()
-
-    // Set up interval to fetch every minute (60000ms)
-    const interval = setInterval(() => {
-      fetchEthPrice()
-    }, 60000) // 60 seconds = 1 minute
-
-    // Cleanup interval on unmount
+    const interval = setInterval(fetchEthPrice, 60_000)
     return () => clearInterval(interval)
   }, [fetchEthPrice])
 
-  return {
-    price,
-    loading,
-    error,
-    lastUpdated,
-    refetch: fetchEthPrice,
-  }
+  return { price, loading, error, lastUpdated, refetch: fetchEthPrice }
 }

--- a/hooks/use-offramp-rate.ts
+++ b/hooks/use-offramp-rate.ts
@@ -1,41 +1,68 @@
 'use client'
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import type { FiatCurrency } from '@/types/onramp'
 import type { OfframpAsset, OfframpChain } from '@/types/offramp'
 
 const RATE_REFRESH_SECONDS = 30
 
-const rateMap: Record<OfframpAsset, number> = {
-  cNGN: 1584,
-  USDC: 1500,
-  USDT: 1490,
-  XLM: 420,
+const coinGeckoIds: Record<OfframpAsset, string> = {
+  cNGN: 'usd-coin',
+  USDC: 'usd-coin',
+  USDT: 'tether',
+  XLM: 'stellar',
 }
 
-export function useOfframpRate(asset: OfframpAsset, chain: OfframpChain) {
+const fiatCurrencyKeys: Record<FiatCurrency, string> = {
+  NGN: 'ngn',
+  KES: 'kes',
+  GHS: 'ghs',
+  ZAR: 'zar',
+  UGX: 'ugx',
+}
+
+export function useOfframpRate(
+  asset: OfframpAsset,
+  chain: OfframpChain,
+  fiatCurrency: FiatCurrency
+) {
   const [countdown, setCountdown] = useState(RATE_REFRESH_SECONDS)
   const [lastUpdated, setLastUpdated] = useState<number | null>(null)
   const [isLoading, setIsLoading] = useState(true)
+  const [rate, setRate] = useState(0)
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
 
-  const rate = useMemo(() => {
-    const chainMultiplier =
-      chain === 'Ethereum' ? 1.01 : chain === 'Polygon' ? 0.995 : chain === 'Base' ? 1.002 : 1
-    return rateMap[asset] * chainMultiplier
-  }, [asset, chain])
+  const fetchRate = useCallback(async () => {
+    const coinId = coinGeckoIds[asset]
+    const fiatKey = fiatCurrencyKeys[fiatCurrency]
+
+    try {
+      const res = await fetch('/api/exchange-rate')
+      if (!res.ok) throw new Error('Rate fetch failed')
+      const data = await res.json()
+      const baseRate = data[coinId]?.[fiatKey] ?? 0
+
+      const chainMultiplier =
+        chain === 'Ethereum' ? 1.01 : chain === 'Polygon' ? 0.995 : chain === 'Base' ? 1.002 : 1
+
+      setRate(baseRate * chainMultiplier)
+    } catch {
+      setRate(0)
+    }
+  }, [asset, chain, fiatCurrency])
 
   const refresh = useCallback(() => {
     setIsLoading(true)
-    setTimeout(() => {
+    fetchRate().then(() => {
       setLastUpdated(Date.now())
       setIsLoading(false)
       setCountdown(RATE_REFRESH_SECONDS)
-    }, 350)
-  }, [])
+    })
+  }, [fetchRate])
 
   useEffect(() => {
-    Promise.resolve().then(() => refresh())
-  }, [asset, chain, refresh])
+    refresh()
+  }, [refresh])
 
   useEffect(() => {
     if (timerRef.current) clearInterval(timerRef.current)

--- a/lib/offramp/calculations.ts
+++ b/lib/offramp/calculations.ts
@@ -34,8 +34,12 @@ export function calculateFees(
 }
 
 export function getMinMax(currency: FiatCurrency) {
-  return {
-    min: currency === 'NGN' ? 5000 : 5000,
-    max: currency === 'NGN' ? 5000000 : 5000000,
+  const limits: Record<FiatCurrency, { min: number; max: number }> = {
+    NGN: { min: 5_000, max: 5_000_000 },
+    KES: { min: 500, max: 500_000 },
+    GHS: { min: 50, max: 50_000 },
+    ZAR: { min: 100, max: 100_000 },
+    UGX: { min: 20_000, max: 20_000_000 },
   }
+  return limits[currency]
 }

--- a/lib/stellar-p2p.ts
+++ b/lib/stellar-p2p.ts
@@ -1,0 +1,84 @@
+import Server, { Asset, Memo, Networks, Operation, TransactionBuilder } from '@stellar/stellar-sdk'
+import { signTransactionWithFreighter } from '@/lib/wallet/freighter'
+import type { FreighterNetwork } from '@/lib/wallet'
+
+const HORIZON_URLS: Record<string, string> = {
+  PUBLIC: 'https://horizon.stellar.org',
+  TESTNET: 'https://horizon-testnet.stellar.org',
+}
+
+/** Validate a Stellar public key (G + 55 base32 chars). */
+export function isValidStellarAddress(address: string): boolean {
+  return /^G[A-Z2-7]{55}$/.test(address)
+}
+
+/** Fetch the current base fee (stroops) from Horizon and return it in XLM. */
+export async function estimateStellarFee(network: FreighterNetwork | null): Promise<string> {
+  const url = HORIZON_URLS[network ?? 'PUBLIC'] ?? HORIZON_URLS.PUBLIC
+  const server = new Server(url)
+  const fee = await server.fetchBaseFee()
+  // base fee is in stroops (1 XLM = 10_000_000 stroops)
+  return (fee / 10_000_000).toFixed(7)
+}
+
+export interface SendP2PParams {
+  sourcePublicKey: string
+  destination: string
+  amount: string
+  assetCode: string
+  assetIssuer?: string
+  memo?: string
+  network: FreighterNetwork | null
+}
+
+export interface SendP2PResult {
+  txHash: string
+  error?: string
+}
+
+/** Build, sign (via Freighter), and submit a P2P Stellar payment. */
+export async function sendStellarP2P(params: SendP2PParams): Promise<SendP2PResult> {
+  const { sourcePublicKey, destination, amount, assetCode, assetIssuer, memo, network } = params
+
+  if (!isValidStellarAddress(destination)) {
+    return { txHash: '', error: 'Invalid destination address' }
+  }
+
+  const horizonUrl = HORIZON_URLS[network ?? 'PUBLIC'] ?? HORIZON_URLS.PUBLIC
+  const server = new Server(horizonUrl)
+  const networkPassphrase = network === 'TESTNET' ? Networks.TESTNET : Networks.PUBLIC
+
+  try {
+    const sourceAccount = await server.loadAccount(sourcePublicKey)
+    const fee = await server.fetchBaseFee()
+
+    const asset =
+      assetCode === 'XLM' ? Asset.native() : new Asset(assetCode, assetIssuer ?? sourcePublicKey)
+
+    const builder = new TransactionBuilder(sourceAccount, {
+      fee: fee.toString(),
+      networkPassphrase,
+    }).addOperation(Operation.payment({ destination, asset, amount }))
+
+    if (memo?.trim()) {
+      builder.addMemo(Memo.text(memo.trim().slice(0, 28)))
+    }
+
+    const tx = builder.setTimeout(300).build()
+    const xdr = tx.toXDR()
+
+    const signed = await signTransactionWithFreighter(xdr, network ?? 'PUBLIC', networkPassphrase)
+    if (signed.error || !signed.signedTxXdr) {
+      return { txHash: '', error: signed.error ?? 'Signing failed' }
+    }
+
+    const result = await server.submitTransaction(
+      TransactionBuilder.fromXDR(signed.signedTxXdr, networkPassphrase)
+    )
+
+    return { txHash: result.hash }
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'Transaction failed'
+    return { txHash: '', error: msg }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #131
Closes #133
Closes #140

---

### #131 — Send crypto P2P
- **`lib/stellar-p2p.ts`** (new): `isValidStellarAddress` (G + 55 base32), `estimateStellarFee` (live Horizon base fee), `sendStellarP2P` (build → Freighter sign → submit)
- **`send-page-client.tsx`**: real address validation, live fee fetch on confirm step, wired to `sendStellarP2P`; errors surfaced inline
- **`transaction-confirmation.tsx`**: displays real tx hash, stellar.expert explorer link, live fee from Horizon

### #133 — Multi-currency calculator support
- **`use-offramp-rate.ts`**: replaced static rate map with live CoinGecko fetch via `/api/exchange-rate`; accepts `fiatCurrency` param, re-fetches on currency/asset change
- **`lib/offramp/calculations.ts`**: per-currency regional min/max limits (NGN/KES/GHS/ZAR/UGX)
- **`offramp-calculator.tsx`**: NGN/KES/GHS/ZAR toggle buttons; switching triggers rate refetch + full recalculation
- **`offramp-page-client.tsx`**: threads `fiatCurrency` into `useOfframpRate`

### #140 — Replace mock exchange rates with backend
- **`app/api/rates/route.ts`** (new): proxies CoinGecko ETH/USD with 1-min in-memory cache; serves stale data on upstream failure (`X-Cache: HIT/MISS/STALE`)
- **`hooks/use-eth-price.ts`**: replaced direct Railway/CoinGecko call with `/api/rates` proxy

## Testing
All 6 test suites pass (38 passed, 2 skipped).