### PR TITLE
feat: add IP-based rate limiting on API routes (closes #164)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Upstash Redis — required for API rate limiting (100 req/min per IP)
+# Get these from https://console.upstash.com after creating a Redis database
+UPSTASH_REDIS_REST_URL=https://<your-upstash-redis-url>.upstash.io
+UPSTASH_REDIS_REST_TOKEN=<your-upstash-redis-token>

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,43 @@
+import { Ratelimit } from '@upstash/ratelimit'
+import { Redis } from '@upstash/redis'
+import { NextRequest, NextResponse } from 'next/server'
+
+const ratelimit = new Ratelimit({
+  redis: new Redis({
+    url: process.env.UPSTASH_REDIS_REST_URL!,
+    token: process.env.UPSTASH_REDIS_REST_TOKEN!,
+  }),
+  limiter: Ratelimit.slidingWindow(100, '1 m'),
+  analytics: false,
+})
+
+export async function middleware(request: NextRequest) {
+  const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? '127.0.0.1'
+
+  const { success, limit, remaining, reset } = await ratelimit.limit(ip)
+
+  if (!success) {
+    return NextResponse.json(
+      { error: 'Too many requests. Please try again later.' },
+      {
+        status: 429,
+        headers: {
+          'X-RateLimit-Limit': String(limit),
+          'X-RateLimit-Remaining': String(remaining),
+          'X-RateLimit-Reset': String(reset),
+          'Retry-After': String(Math.ceil((reset - Date.now()) / 1000)),
+        },
+      }
+    )
+  }
+
+  const response = NextResponse.next()
+  response.headers.set('X-RateLimit-Limit', String(limit))
+  response.headers.set('X-RateLimit-Remaining', String(remaining))
+  response.headers.set('X-RateLimit-Reset', String(reset))
+  return response
+}
+
+export const config = {
+  matcher: '/api/:path*',
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,8 @@
         "@radix-ui/react-tooltip": "1.1.6",
         "@stellar/freighter-api": "^6.0.1",
         "@stellar/stellar-sdk": "^14.5.0",
+        "@upstash/ratelimit": "2.0.5",
+        "@upstash/redis": "1.34.3",
         "@vercel/analytics": "1.3.1",
         "autoprefixer": "^10.4.20",
         "class-variance-authority": "^0.7.1",
@@ -5341,6 +5343,39 @@
         "win32"
       ]
     },
+    "node_modules/@upstash/core-analytics": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@upstash/core-analytics/-/core-analytics-0.0.10.tgz",
+      "integrity": "sha512-7qJHGxpQgQr9/vmeS1PktEwvNAF7TI4iJDi8Pu2CFZ9YUGHZH4fOP5TfYlZ4aVxfopnELiE4BS4FBjyK7V1/xQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/redis": "^1.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@upstash/ratelimit": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@upstash/ratelimit/-/ratelimit-2.0.5.tgz",
+      "integrity": "sha512-1FRv0cs3ZlBjCNOCpCmKYmt9BYGIJf0J0R3pucOPE88R21rL7jNjXG+I+rN/BVOvYJhI9niRAS/JaSNjiSICxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@upstash/core-analytics": "^0.0.10"
+      },
+      "peerDependencies": {
+        "@upstash/redis": "^1.34.3"
+      }
+    },
+    "node_modules/@upstash/redis": {
+      "version": "1.34.3",
+      "resolved": "https://registry.npmjs.org/@upstash/redis/-/redis-1.34.3.tgz",
+      "integrity": "sha512-VT25TyODGy/8ljl7GADnJoMmtmJ1F8d84UXfGonRRF8fWYJz7+2J6GzW+a6ETGtk4OyuRTt7FRSvFG5GvrfSdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "crypto-js": "^4.2.0"
+      }
+    },
     "node_modules/@vercel/analytics": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-1.3.1.tgz",
@@ -6586,6 +6621,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto-js": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==",
+      "license": "MIT"
     },
     "node_modules/css-line-break": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "@radix-ui/react-tooltip": "1.1.6",
     "@stellar/freighter-api": "^6.0.1",
     "@stellar/stellar-sdk": "^14.5.0",
+    "@upstash/ratelimit": "2.0.5",
+    "@upstash/redis": "1.34.3",
     "@vercel/analytics": "1.3.1",
     "autoprefixer": "^10.4.20",
     "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary

Implements rate limiting on all `/api/*` routes using Upstash Ratelimit via Next.js middleware, as requested in #164.

## Changes

- **`middleware.ts`** — New Next.js middleware scoped to `/api/:path*`. Uses `@upstash/ratelimit` with a sliding window of **100 requests/min per IP**. Returns `429 Too Many Requests` with `Retry-After` and `X-RateLimit-*` headers when the limit is exceeded.
- **`.env.example`** — Documents the two required Upstash env vars (`UPSTASH_REDIS_REST_URL`, `UPSTASH_REDIS_REST_TOKEN`).
- **`package.json`** — Adds `@upstash/ratelimit@2.0.5` and `@upstash/redis@1.34.3` (exact versions).

## How it works

```
Request → middleware.ts → check IP against Upstash Redis
  ├── under limit  → pass through + set X-RateLimit-* headers
  └── over limit   → 429 JSON response with Retry-After
```

## Setup

Copy `.env.example` to `.env.local` and fill in your Upstash Redis credentials from [console.upstash.com](https://console.upstash.com).

## Testing

- TypeScript compiles cleanly (`tsc --noEmit` passes).
- All existing tests pass (`npm test`).

Closes #164