### PR TITLE
feat: offline receipt support via IndexedDB cache (closes #179)

### DIFF
--- a/components/bills/bills-receipt-client.tsx
+++ b/components/bills/bills-receipt-client.tsx
@@ -25,7 +25,7 @@ interface BillsReceiptClientProps {
 export function BillsReceiptClient({ transactionId }: BillsReceiptClientProps) {
   const searchParams = useSearchParams()
   const statusOverride = searchParams.get('status')
-  const { transaction, loading, error, statusLabel } = useBillsTransaction(
+  const { transaction, loading, error, statusLabel, fromCache } = useBillsTransaction(
     transactionId,
     process.env.NEXT_PUBLIC_BILLS_WS_URL,
     statusOverride
@@ -163,6 +163,12 @@ export function BillsReceiptClient({ transactionId }: BillsReceiptClientProps) {
   return (
     <div className="min-h-screen bg-background px-4 py-10">
       <div className="mx-auto max-w-4xl space-y-6">
+        {fromCache && (
+          <div className="flex items-center gap-2 rounded-xl border border-yellow-400/40 bg-yellow-400/10 px-4 py-3 text-sm text-yellow-700 dark:text-yellow-400">
+            <span>⚠️</span>
+            <span>You&apos;re offline — showing cached receipt. Some details may be outdated.</span>
+          </div>
+        )}
         <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
           <div>
             <p className="text-sm font-semibold text-primary">Bills Receipt</p>

--- a/hooks/use-bills-transaction.ts
+++ b/hooks/use-bills-transaction.ts
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useMemo, useRef, useState } from 'react'
+import { saveReceipt, loadReceipt } from '@/lib/receipt-cache'
 
 export interface BillsTimelineItem {
   id: string
@@ -33,6 +34,7 @@ export function useBillsTransaction(
   const [transaction, setTransaction] = useState<BillsTransaction | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [fromCache, setFromCache] = useState(false)
   const wsRef = useRef<WebSocket | null>(null)
 
   useEffect(() => {
@@ -49,10 +51,24 @@ export function useBillsTransaction(
         if (!cancelled) {
           setTransaction(data)
           setError(null)
+          setFromCache(false)
+          saveReceipt(data).catch(() => {})
         }
       } catch (err) {
         if (!cancelled) {
-          setError(err instanceof Error ? err.message : 'Unable to load transaction')
+          // Network failure — try IDB cache
+          try {
+            const cached = await loadReceipt(transactionId)
+            if (cached) {
+              setTransaction(cached)
+              setError(null)
+              setFromCache(true)
+            } else {
+              setError(err instanceof Error ? err.message : 'Unable to load transaction')
+            }
+          } catch {
+            setError(err instanceof Error ? err.message : 'Unable to load transaction')
+          }
         }
       } finally {
         if (!cancelled) setLoading(false)
@@ -99,5 +115,5 @@ export function useBillsTransaction(
         : 'Pending'
   }, [transaction])
 
-  return { transaction, loading, error, statusLabel }
+  return { transaction, loading, error, statusLabel, fromCache }
 }

--- a/lib/receipt-cache.ts
+++ b/lib/receipt-cache.ts
@@ -1,0 +1,34 @@
+import type { BillsTransaction } from '@/hooks/use-bills-transaction'
+
+const DB_NAME = 'aframp-receipts'
+const STORE = 'receipts'
+const VERSION = 1
+
+function openDB(): Promise<IDBDatabase> {
+  return new Promise((resolve, reject) => {
+    const req = indexedDB.open(DB_NAME, VERSION)
+    req.onupgradeneeded = () => req.result.createObjectStore(STORE, { keyPath: 'id' })
+    req.onsuccess = () => resolve(req.result)
+    req.onerror = () => reject(req.error)
+  })
+}
+
+export async function saveReceipt(tx: BillsTransaction): Promise<void> {
+  const db = await openDB()
+  return new Promise((resolve, reject) => {
+    const store = db.transaction(STORE, 'readwrite').objectStore(STORE)
+    const req = store.put(tx)
+    req.onsuccess = () => resolve()
+    req.onerror = () => reject(req.error)
+  })
+}
+
+export async function loadReceipt(id: string): Promise<BillsTransaction | null> {
+  const db = await openDB()
+  return new Promise((resolve, reject) => {
+    const store = db.transaction(STORE, 'readonly').objectStore(STORE)
+    const req = store.get(id)
+    req.onsuccess = () => resolve((req.result as BillsTransaction) ?? null)
+    req.onerror = () => reject(req.error)
+  })
+}


### PR DESCRIPTION
## Summary

Implements offline receipt viewing via IndexedDB as specified in #179. Users can now go to airplane mode and still view (and download PDF of) a previously loaded receipt.

## Changes

**`lib/receipt-cache.ts`** (new)
- `saveReceipt(tx)` — writes a `BillsTransaction` to IndexedDB (`aframp-receipts` store)
- `loadReceipt(id)` — reads a cached transaction by ID; returns `null` if not found

**`hooks/use-bills-transaction.ts`**
- On successful network fetch → calls `saveReceipt` to persist to IDB
- On network failure → calls `loadReceipt`; if a cached entry exists, serves it and sets `fromCache: true`
- Exposes `fromCache` boolean in the hook return value

**`components/bills/bills-receipt-client.tsx`**
- Destructures `fromCache` from the hook
- Renders a yellow warning banner when `fromCache` is true: _"You're offline — showing cached receipt. Some details may be outdated."_

## How it works

```
Online:  fetch API → setTransaction → saveReceipt(IDB) → fromCache=false
Offline: fetch fails → loadReceipt(IDB) → setTransaction → fromCache=true → banner shown
```

## Acceptance criteria

- ✅ IDB caches receipts on fetch
- ✅ Airplane mode → receipt still loads from cache
- ✅ PDF download still works from cached data (all data is in-memory)

Closes #179