### PR TITLE
feat: mobile nav — drawer + gesture nav + bottom nav (closes #176)

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -1,13 +1,14 @@
 'use client'
 
-import { useState, useRef } from 'react'
+import { useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { motion } from 'framer-motion'
-import { Menu, X, ArrowRight } from 'lucide-react'
+import { Menu, ArrowRight, LayoutDashboard, ArrowDownUp, Wallet, Receipt } from 'lucide-react'
 import Link from 'next/link'
-import { Button } from '@/components/ui/button'
+import { Drawer } from 'vaul'
 import { ThemeToggle } from '@/components/theme-toggle'
 import { ConnectButton } from '@/components/Wallet'
+import { cn } from '@/lib/utils'
 
 const navItems = [
   { label: 'Dashboard', href: '/dashboard' },
@@ -16,45 +17,53 @@ const navItems = [
   { label: 'Settings', href: '/dashboard/settings' },
 ]
 
+const bottomNavItems = [
+  { label: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
+  { label: 'Onramp', href: '/onramp', icon: ArrowDownUp },
+  { label: 'Bills', href: '/bills', icon: Receipt },
+  { label: 'Wallet', href: '/dashboard/wallets', icon: Wallet },
+]
+
 export function Navbar() {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null)
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
-  const navRef = useRef<HTMLDivElement>(null)
+  const [drawerOpen, setDrawerOpen] = useState(false)
   const pathname = usePathname()
 
-  return (
-    <motion.header
-      initial={{ y: -100, opacity: 0 }}
-      animate={{ y: 0, opacity: 1 }}
-      transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
-      className="fixed top-4 left-1/2 -translate-x-1/2 z-50 w-[calc(100%-2rem)] max-w-4xl"
-    >
-      <nav
-        ref={navRef}
-        className="relative flex items-center justify-between px-4 py-3 rounded-full bg-card/80 backdrop-blur-md border border-border shadow-sm"
-      >
-        <Link href="/" className="flex items-center gap-2">
-          <div className="w-9 h-9 rounded-xl bg-primary flex items-center justify-center">
-            <span className="text-primary-foreground font-bold text-base">A</span>
-          </div>
-          <span className="font-semibold text-foreground hidden sm:block text-lg">Aframp</span>
-        </Link>
+  const isActive = (href: string) =>
+    pathname === href || (href !== '/' && pathname.startsWith(href))
 
-        {/* Desktop Nav Items */}
-        <div className="hidden md:flex items-center gap-1 relative">
-          {navItems.map((item, index) => {
-            const isActive = pathname === item.href || (item.href !== '/' && pathname.startsWith(item.href))
-            return (
+  return (
+    <>
+      <motion.header
+        initial={{ y: -100, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        transition={{ duration: 0.6, ease: [0.22, 1, 0.36, 1] }}
+        className="fixed top-4 left-1/2 -translate-x-1/2 z-50 w-[calc(100%-2rem)] max-w-4xl"
+      >
+        <nav className="relative flex items-center justify-between px-4 py-3 rounded-full bg-card/80 backdrop-blur-md border border-border shadow-sm">
+          <Link href="/" className="flex items-center gap-2">
+            <div className="w-9 h-9 rounded-xl bg-primary flex items-center justify-center">
+              <span className="text-primary-foreground font-bold text-base">A</span>
+            </div>
+            <span className="font-semibold text-foreground hidden sm:block text-lg">Aframp</span>
+          </Link>
+
+          {/* Desktop Nav Items */}
+          <div className="hidden md:flex items-center gap-1 relative">
+            {navItems.map((item, index) => (
               <Link
                 key={item.label}
                 href={item.href}
-                className={`relative px-4 py-2 text-sm rounded-full transition-colors font-medium
-                  ${isActive ? 'bg-primary text-white' : 'text-muted-foreground hover:text-foreground hover:bg-muted'}
-                `}
+                className={cn(
+                  'relative px-4 py-2 text-sm rounded-full transition-colors font-medium',
+                  isActive(item.href)
+                    ? 'bg-primary text-white'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+                )}
                 onMouseEnter={() => setHoveredIndex(index)}
                 onMouseLeave={() => setHoveredIndex(null)}
               >
-                {hoveredIndex === index && !isActive && (
+                {hoveredIndex === index && !isActive(item.href) && (
                   <motion.div
                     layoutId="navbar-hover"
                     className="absolute inset-0 bg-muted rounded-full"
@@ -64,79 +73,103 @@ export function Navbar() {
                 )}
                 <span className="relative z-10">{item.label}</span>
               </Link>
+            ))}
+          </div>
+
+          <div className="flex items-center gap-3">
+            <ThemeToggle />
+            <ConnectButton />
+
+            {/* Hamburger — mobile only */}
+            <Drawer.Root open={drawerOpen} onOpenChange={setDrawerOpen} direction="left">
+              <Drawer.Trigger asChild>
+                <button
+                  className="p-2 md:hidden text-muted-foreground hover:text-foreground"
+                  aria-label="Open menu"
+                >
+                  <Menu size={20} />
+                </button>
+              </Drawer.Trigger>
+
+              <Drawer.Portal>
+                <Drawer.Overlay className="fixed inset-0 z-50 bg-black/40" />
+                <Drawer.Content className="fixed left-0 top-0 bottom-0 z-50 flex w-72 flex-col bg-card border-r border-border outline-none">
+                  {/* Drag handle */}
+                  <div className="mx-auto mt-3 h-1.5 w-10 rounded-full bg-muted" />
+
+                  <div className="flex flex-col gap-1 p-6 flex-1 overflow-y-auto">
+                    <Link href="/" className="flex items-center gap-2 mb-6" onClick={() => setDrawerOpen(false)}>
+                      <div className="w-9 h-9 rounded-xl bg-primary flex items-center justify-center">
+                        <span className="text-primary-foreground font-bold text-base">A</span>
+                      </div>
+                      <span className="font-semibold text-foreground text-lg">Aframp</span>
+                    </Link>
+
+                    {navItems.map((item) => (
+                      <Link
+                        key={item.label}
+                        href={item.href}
+                        className={cn(
+                          'px-4 py-3 text-sm rounded-lg transition-colors font-medium',
+                          isActive(item.href)
+                            ? 'bg-primary text-white'
+                            : 'text-muted-foreground hover:text-foreground hover:bg-muted'
+                        )}
+                        onClick={() => setDrawerOpen(false)}
+                      >
+                        {item.label}
+                      </Link>
+                    ))}
+
+                    <hr className="border-border my-3" />
+
+                    <Link
+                      href="/onramp"
+                      className="px-4 py-3 text-sm text-muted-foreground hover:text-foreground hover:bg-muted rounded-lg transition-colors flex items-center justify-between"
+                      onClick={() => setDrawerOpen(false)}
+                    >
+                      Buy Crypto (Onramp) <ArrowRight className="w-4 h-4" />
+                    </Link>
+                    <Link
+                      href="/offramp"
+                      className="px-4 py-3 text-sm text-muted-foreground hover:text-foreground hover:bg-muted rounded-lg transition-colors flex items-center justify-between"
+                      onClick={() => setDrawerOpen(false)}
+                    >
+                      Sell Crypto (Offramp) <ArrowRight className="w-4 h-4" />
+                    </Link>
+                  </div>
+
+                  <div className="p-6 border-t border-border" onClick={() => setDrawerOpen(false)}>
+                    <ConnectButton className="w-full" />
+                  </div>
+                </Drawer.Content>
+              </Drawer.Portal>
+            </Drawer.Root>
+          </div>
+        </nav>
+      </motion.header>
+
+      {/* Bottom Nav — mobile only */}
+      <nav className="fixed bottom-0 left-0 right-0 z-40 md:hidden border-t border-border bg-card/95 backdrop-blur-md">
+        <div className="flex items-center justify-around px-2 py-2">
+          {bottomNavItems.map(({ label, href, icon: Icon }) => {
+            const active = isActive(href)
+            return (
+              <Link
+                key={label}
+                href={href}
+                className={cn(
+                  'flex flex-col items-center gap-1 px-3 py-1.5 rounded-xl transition-colors',
+                  active ? 'text-primary' : 'text-muted-foreground'
+                )}
+              >
+                <Icon size={20} strokeWidth={active ? 2.5 : 1.8} />
+                <span className="text-[10px] font-medium">{label}</span>
+              </Link>
             )
           })}
         </div>
-
-        {/* Right side: Theme Toggle and Connect Button */}
-        <div className="flex items-center gap-3">
-          <ThemeToggle />
-          <ConnectButton />
-
-          {/* Mobile Menu Button - inside the right group */}
-          <button
-            className="p-2 md:hidden text-muted-foreground hover:text-foreground"
-            onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
-            aria-label="Toggle menu"
-          >
-            {mobileMenuOpen ? <X size={20} /> : <Menu size={20} />}
-          </button>
-        </div>
       </nav>
-
-      {/* Mobile Menu */}
-      {mobileMenuOpen && (
-        <motion.div
-          initial={{ opacity: 0, y: -10 }}
-          animate={{ opacity: 1, y: 0 }}
-          exit={{ opacity: 0, y: -10 }}
-          className="absolute top-full left-0 right-0 mt-2 p-4 rounded-2xl bg-card/95 backdrop-blur-md border border-border shadow-lg"
-        >
-          <div className="flex flex-col gap-2">
-            {navItems.map((item) => {
-              const isActive = pathname === item.href || (item.href !== '/' && pathname.startsWith(item.href))
-              return (
-                <Link
-                  key={item.label}
-                  href={item.href}
-                  className={`px-4 py-3 text-sm rounded-lg transition-colors font-medium flex items-center
-                    ${isActive ? 'bg-primary text-white' : 'text-muted-foreground hover:text-foreground hover:bg-muted'}
-                  `}
-                  onClick={() => setMobileMenuOpen(false)}
-                >
-                  {item.label}
-                </Link>
-              )
-            })}
-            <Link
-              href="/onramp"
-              className="px-4 py-3 text-sm text-muted-foreground hover:text-foreground hover:bg-muted rounded-lg transition-colors flex items-center justify-between"
-              onClick={() => setMobileMenuOpen(false)}
-            >
-              Buy Crypto (Onramp)
-              <ArrowRight className="w-4 h-4" />
-            </Link>
-            <Link
-              href="/offramp"
-              className="px-4 py-3 text-sm text-muted-foreground hover:text-foreground hover:bg-muted rounded-lg transition-colors flex items-center justify-between"
-              onClick={() => setMobileMenuOpen(false)}
-            >
-              Sell Crypto (Offramp)
-              <ArrowRight className="w-4 h-4" />
-            </Link>
-            <hr className="border-border my-2" />
-            <Button
-              variant="ghost"
-              className="justify-start text-muted-foreground hover:text-foreground"
-            >
-              Explore
-            </Button>
-            <div onClick={() => setMobileMenuOpen(false)}>
-              <ConnectButton className="w-full" />
-            </div>
-          </div>
-        </motion.div>
-      )}
-    </motion.header>
+    </>
   )
 }


### PR DESCRIPTION
## Summary

Implements mobile navigation improvements as specified in #176.

## Changes

**`components/navbar.tsx`** — single file change:

### Hamburger → Drawer (gesture nav)
- Replaced the dropdown mobile menu with a **vaul `Drawer`** sliding in from the left
- Vaul provides **swipe-to-close gesture** natively — no extra code needed
- Drawer contains logo, all nav links, onramp/offramp links, and a ConnectButton at the bottom
- Backdrop overlay closes drawer on tap

### Bottom Nav
- Added a **persistent bottom navigation bar** (`md:hidden`) fixed to the bottom of the screen
- 4 tabs: Dashboard, Onramp, Bills, Wallet — each with icon + label
- Active tab highlighted with `text-primary` and bolder stroke weight
- Frosted glass background (`bg-card/95 backdrop-blur-md`) matching the top nav style

## Acceptance criteria

- ✅ Hamburger → opens left-side drawer
- ✅ Gesture nav (swipe left to close via vaul)
- ✅ Bottom nav on mobile

Closes #176