### PR TITLE
fix: make WalletModal responsive with touch-friendly UI and mobile bottom-sheet (closes #136)

### DIFF
--- a/components/Wallet/WalletModal.tsx
+++ b/components/Wallet/WalletModal.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react'
 import { motion, AnimatePresence } from 'framer-motion'
+import { Drawer } from 'vaul'
 import {
   Dialog,
   DialogContent,
@@ -21,6 +22,7 @@ import {
   Monitor,
 } from 'lucide-react'
 import { useWallet } from '@/hooks/useWallet'
+import { useMediaQuery } from '@/hooks/use-media-query'
 
 interface WalletModalProps {
   open: boolean
@@ -78,34 +80,54 @@ export function WalletModal({ open, onOpenChange }: WalletModalProps) {
     setManualView('connect')
   }
 
+  const isDesktop = useMediaQuery('(min-width: 640px)')
+
+  const views = (
+    <AnimatePresence mode="wait">
+      {view === 'installing' && (
+        <InstallView key="install" onCheckAgain={() => setManualView('connect')} />
+      )}
+      {view === 'connect' && (
+        <ConnectView
+          key="connect"
+          onConnect={handleConnect}
+          hasError={hasError}
+          error={error}
+          onRetry={handleRetry}
+          isFreighterInstalled={isFreighterInstalled}
+          onShowInstall={() => setManualView('installing')}
+        />
+      )}
+      {view === 'connecting' && <ConnectingView key="connecting" />}
+      {view === 'network-warning' && (
+        <NetworkWarningView
+          key="network"
+          network={network}
+          onContinue={() => onOpenChange(false)}
+          onRefresh={handleRetry}
+        />
+      )}
+    </AnimatePresence>
+  )
+
+  if (!isDesktop) {
+    return (
+      <Drawer.Root open={open} onOpenChange={handleOpenChange}>
+        <Drawer.Portal>
+          <Drawer.Overlay className="fixed inset-0 z-50 bg-black/80" />
+          <Drawer.Content className="fixed inset-x-0 bottom-0 z-50 flex flex-col rounded-t-[1.25rem] border-t border-border bg-background outline-none max-h-[90svh] overflow-y-auto">
+            <div className="mx-auto mt-3 mb-1 h-1.5 w-10 shrink-0 rounded-full bg-muted" />
+            {views}
+          </Drawer.Content>
+        </Drawer.Portal>
+      </Drawer.Root>
+    )
+  }
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent className="max-w-md p-0 overflow-hidden">
-        <AnimatePresence mode="wait">
-          {view === 'installing' && (
-            <InstallView key="install" onCheckAgain={() => setManualView('connect')} />
-          )}
-          {view === 'connect' && (
-            <ConnectView
-              key="connect"
-              onConnect={handleConnect}
-              hasError={hasError}
-              error={error}
-              onRetry={handleRetry}
-              isFreighterInstalled={isFreighterInstalled}
-              onShowInstall={() => setManualView('installing')}
-            />
-          )}
-          {view === 'connecting' && <ConnectingView key="connecting" />}
-          {view === 'network-warning' && (
-            <NetworkWarningView
-              key="network"
-              network={network}
-              onContinue={() => onOpenChange(false)}
-              onRefresh={handleRetry}
-            />
-          )}
-        </AnimatePresence>
+        {views}
       </DialogContent>
     </Dialog>
   )

--- a/hooks/use-media-query.ts
+++ b/hooks/use-media-query.ts
@@ -1,0 +1,17 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(false)
+
+  useEffect(() => {
+    const media = window.matchMedia(query)
+    setMatches(media.matches)
+    const onChange = (e: MediaQueryListEvent) => setMatches(e.matches)
+    media.addEventListener('change', onChange)
+    return () => media.removeEventListener('change', onChange)
+  }, [query])
+
+  return matches
+}


### PR DESCRIPTION
## Summary
WalletModal now renders as a vaul bottom-sheet on mobile and keeps the existing Dialog on sm: and above. All four inner views are untouched.

## Changes
- `hooks/use-media-query.ts` — new SSR-safe hook wrapping `window.matchMedia`
- `components/Wallet/WalletModal.tsx` — mobile Drawer branch added; Desktop Dialog branch unchanged

## Approach
- Uses vaul (already installed at ^1.1.2) via its native API, same pattern as navbar.tsx
- Zero new libraries introduced
- All inner views (InstallView, ConnectView, ConnectingView, NetworkWarningView) byte-for-byte untouched
- Existing CTAs already meet 44px minimum tap target (h-12)
- Bottom-sheet uses max-h-[90svh] to correctly account for mobile browser address bar
- rounded-t-[1.25rem] matches --radius token from globals.css

Closes #136