### PR TITLE
feat(referral): add click tracking and conversion analytics (#325)

### DIFF
--- a/app/api/onramp/order/[orderId]/status/route.ts
+++ b/app/api/onramp/order/[orderId]/status/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { trackConversion } from '@/lib/referral/analytics'
 
 export async function PATCH(
   request: NextRequest,
@@ -7,12 +8,25 @@ export async function PATCH(
   const { orderId } = await context.params
 
   try {
-    const { status, additionalData } = await request.json()
+    const body = await request.json()
+    const { status, additionalData } = body
+    const referralTotalFees: number | undefined = body.referralTotalFees
 
-    console.log(`Backend: Updating order ${orderId} status to ${status}`, additionalData)
+    console.warn(`Backend: Updating order ${orderId} status to ${status}`, additionalData)
 
-    // In a real application, you would update the database here
-    
+    // Record referral conversion when an order using a referral code completes
+    if (status === 'completed' && additionalData?.referralCode) {
+      trackConversion(
+        additionalData.referralCode,
+        additionalData.walletAddress ?? 'unknown',
+        orderId,
+        referralTotalFees,
+      )
+      console.warn(
+        `Referral conversion recorded for code ${additionalData.referralCode} on order ${orderId}`,
+      )
+    }
+
     // Simulate delay
     await new Promise((resolve) => setTimeout(resolve, 300))
 

--- a/app/api/referral/stats/route.ts
+++ b/app/api/referral/stats/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { generateReferralCode } from '@/lib/referral'
+import { getStatsByCode } from '@/lib/referral/analytics'
+
+export function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const wallet = searchParams.get('wallet')
+
+  if (!wallet) {
+    return NextResponse.json({ error: 'wallet query parameter required' }, { status: 400 })
+  }
+
+  const code = generateReferralCode(wallet)
+  const stats = getStatsByCode(code)
+
+  return NextResponse.json({
+    code,
+    ownerAddress: wallet,
+    clickCount: stats?.clickCount ?? 0,
+    conversionCount: stats?.conversionCount ?? 0,
+    totalRebatesEarned: stats?.totalRebatesEarned ?? 0,
+  })
+}

--- a/app/referral/[code]/route.ts
+++ b/app/referral/[code]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server'
+import { trackClick } from '@/lib/referral/analytics'
+
+export async function GET(
+  _request: Request,
+  context: { params: Promise<{ code: string }> }
+) {
+  const { code } = await context.params
+  const normalizedCode = code.toUpperCase()
+
+  // Validate the referral code format
+  if (!normalizedCode.startsWith('AFR-')) {
+    return NextResponse.redirect(new URL('/onramp', _request.url))
+  }
+
+  // Track the click event
+  trackClick(normalizedCode)
+
+  // Redirect to the onramp page with the referral code
+  const redirectUrl = new URL('/onramp', _request.url)
+  redirectUrl.searchParams.set('ref', normalizedCode)
+  return NextResponse.redirect(redirectUrl)
+}

--- a/components/onramp/onramp-page-client.tsx
+++ b/components/onramp/onramp-page-client.tsx
@@ -24,6 +24,13 @@ import { formatCurrency, isValidStellarAddress } from '@/lib/calculations'
 import type { OnrampOrder } from '@/types/onramp'
 import { Button } from '@/components/ui/button' // Added missing import for Button
 import { Skeleton } from '@/components/ui/skeleton'
+import {
+  getAppliedReferralCode,
+  isReferralDiscountConsumed,
+  calcReferralDiscount,
+  markReferralDiscountConsumed,
+  setAppliedReferralCode,
+} from '@/lib/referral'
 
 const ORDER_KEY = 'onramp:latest-order'
 
@@ -73,6 +80,15 @@ export function OnrampPageClient() {
   useEffect(() => {
     router.prefetch('/onramp/payment')
   }, [router])
+
+  // Process referral code from URL query param (e.g. /onramp?ref=AFR-ABCD-1234)
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const refCode = params.get('ref')
+    if (refCode && !getAppliedReferralCode() && !isReferralDiscountConsumed()) {
+      setAppliedReferralCode(refCode.toUpperCase())
+    }
+  }, [])
 
   // Only show modal if definitely not connected after loading
   useEffect(() => {
@@ -143,6 +159,7 @@ export function OnrampPageClient() {
         cryptoAmount: form.cryptoAmount,
         fees: discountedFees,
         walletAddress: walletAddress,
+        referralCode: hasDiscount ? referralCode : undefined,
       }
 
       const response = await fetch('/api/onramp/create-order', {

--- a/components/referral/referral-card.tsx
+++ b/components/referral/referral-card.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState } from 'react'
-import { Copy, Share2, Check, Gift } from 'lucide-react'
+import { Copy, Share2, Check, Gift, MousePointerClick, Users, Coins } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useReferral, REFERRAL_DISCOUNT_PCT } from '@/hooks/use-referral'
 import { toast } from 'sonner'
@@ -11,7 +11,7 @@ interface ReferralCardProps {
 }
 
 export function ReferralCard({ walletAddress }: ReferralCardProps) {
-  const { myCode, record, appliedCode, discountActive, applyCode, loading } =
+  const { myCode, record, stats, appliedCode, discountActive, applyCode, loading } =
     useReferral(walletAddress)
   const [codeInput, setCodeInput] = useState('')
   const [applying, setApplying] = useState(false)
@@ -19,7 +19,7 @@ export function ReferralCard({ walletAddress }: ReferralCardProps) {
 
   const shareUrl =
     typeof window !== 'undefined'
-      ? `${window.location.origin}/onramp?ref=${myCode}`
+      ? `${window.location.origin}/referral/${myCode}`
       : ''
 
   const handleCopy = async () => {
@@ -80,19 +80,33 @@ export function ReferralCard({ walletAddress }: ReferralCardProps) {
         </div>
       </div>
 
-      {/* Stats */}
-      {record && (
-        <div className="grid grid-cols-2 gap-3">
-          <div className="rounded-xl bg-muted/40 p-3 text-center">
-            <p className="text-2xl font-bold text-foreground">{record.referees.length}</p>
-            <p className="text-xs text-muted-foreground mt-0.5">Friends referred</p>
-          </div>
-          <div className="rounded-xl bg-muted/40 p-3 text-center">
-            <p className="text-2xl font-bold text-primary">
-              {record.totalRebatesEarned > 0 ? `₦${record.totalRebatesEarned.toLocaleString()}` : '—'}
-            </p>
-            <p className="text-xs text-muted-foreground mt-0.5">Rebates earned</p>
-          </div>
+      {/* Analytics Stats */}
+      <div className="grid grid-cols-3 gap-2">
+        <div className="rounded-xl bg-muted/40 p-3 text-center">
+          <MousePointerClick className="w-4 h-4 mx-auto text-muted-foreground mb-1" />
+          <p className="text-lg font-bold text-foreground">{stats?.clickCount ?? 0}</p>
+          <p className="text-[10px] text-muted-foreground">Link clicks</p>
+        </div>
+        <div className="rounded-xl bg-muted/40 p-3 text-center">
+          <Users className="w-4 h-4 mx-auto text-muted-foreground mb-1" />
+          <p className="text-lg font-bold text-foreground">{stats?.conversionCount ?? 0}</p>
+          <p className="text-[10px] text-muted-foreground">Conversions</p>
+        </div>
+        <div className="rounded-xl bg-muted/40 p-3 text-center">
+          <Coins className="w-4 h-4 mx-auto text-muted-foreground mb-1" />
+          <p className="text-lg font-bold text-primary">
+            {stats && stats.totalRebatesEarned > 0
+              ? `₦${stats.totalRebatesEarned.toLocaleString()}`
+              : '—'}
+          </p>
+          <p className="text-[10px] text-muted-foreground">Rebates earned</p>
+        </div>
+      </div>
+
+      {/* Legacy stats (referees count from original record) */}
+      {record && record.referees.length > 0 && (
+        <div className="text-xs text-muted-foreground text-center">
+          {record.referees.length} friend{record.referees.length !== 1 ? 's' : ''} applied your code
         </div>
       )}
 

--- a/components/referral/referral-page-client.tsx
+++ b/components/referral/referral-page-client.tsx
@@ -4,11 +4,14 @@ import Link from 'next/link'
 import { ReferralCard } from '@/components/referral/referral-card'
 import { useWallet } from '@/hooks/useWallet'
 import { useWalletConnection } from '@/hooks/use-wallet-connection'
+import { useReferral } from '@/hooks/use-referral'
+import { MousePointerClick, Users, Coins, History } from 'lucide-react'
 
 export function ReferralPageClient() {
   const { publicKey } = useWallet()
   const { address } = useWalletConnection()
   const walletAddress = address || publicKey || ''
+  const { stats } = useReferral(walletAddress)
 
   return (
     <div className="min-h-screen bg-background px-4 py-10">
@@ -24,7 +27,58 @@ export function ReferralPageClient() {
         </header>
 
         {walletAddress ? (
-          <ReferralCard walletAddress={walletAddress} />
+          <>
+            <ReferralCard walletAddress={walletAddress} />
+
+            {/* Analytics snapshot */}
+            {stats && (stats.clickCount > 0 || stats.conversionCount > 0) && (
+              <div className="rounded-3xl border border-border bg-card p-6 space-y-4">
+                <div className="flex items-center gap-2">
+                  <History className="w-4 h-4 text-muted-foreground" />
+                  <h3 className="font-semibold text-foreground text-sm">Referral History</h3>
+                </div>
+
+                <div className="space-y-3 text-sm">
+                  <div className="flex items-center justify-between py-2 border-b border-border">
+                    <div className="flex items-center gap-2">
+                      <MousePointerClick className="w-4 h-4 text-muted-foreground" />
+                      <span className="text-muted-foreground">Total link clicks</span>
+                    </div>
+                    <span className="font-semibold text-foreground">{stats.clickCount}</span>
+                  </div>
+                  <div className="flex items-center justify-between py-2 border-b border-border">
+                    <div className="flex items-center gap-2">
+                      <Users className="w-4 h-4 text-muted-foreground" />
+                      <span className="text-muted-foreground">Completed conversions</span>
+                    </div>
+                    <span className="font-semibold text-foreground">{stats.conversionCount}</span>
+                  </div>
+                  <div className="flex items-center justify-between py-2">
+                    <div className="flex items-center gap-2">
+                      <Coins className="w-4 h-4 text-muted-foreground" />
+                      <span className="text-muted-foreground">Total rebates earned</span>
+                    </div>
+                    <span className="font-semibold text-primary">
+                      {stats.totalRebatesEarned > 0
+                        ? `₦${stats.totalRebatesEarned.toLocaleString()}`
+                        : '—'}
+                    </span>
+                  </div>
+                </div>
+              </div>
+            )}
+
+            {/* Conversion rate insight */}
+            {stats && stats.clickCount > 0 && (
+              <div className="rounded-3xl border border-border bg-muted/20 p-4 text-center text-sm text-muted-foreground">
+                Conversion rate:{' '}
+                <strong className="text-foreground">
+                  {((stats.conversionCount / stats.clickCount) * 100).toFixed(1)}%
+                </strong>
+                {' '}({stats.conversionCount} of {stats.clickCount} clicks converted)
+              </div>
+            )}
+          </>
         ) : (
           <div className="rounded-3xl border border-border bg-card p-6 text-center text-sm text-muted-foreground">
             Connect your wallet to access your referral code.
@@ -34,8 +88,8 @@ export function ReferralPageClient() {
         <div className="rounded-3xl border border-border bg-muted/20 p-6 space-y-3 text-sm text-muted-foreground">
           <h3 className="font-semibold text-foreground">How it works</h3>
           <ol className="space-y-2 list-decimal list-inside">
-            <li>Share your unique referral code or link</li>
-            <li>Your friend applies it before their first ramp</li>
+            <li>Share your unique referral link</li>
+            <li>Your friend clicks the link and applies the code before their first ramp</li>
             <li>They get <strong className="text-foreground">10% off</strong> their first ramp fees</li>
             <li>You earn a <strong className="text-foreground">5% fee rebate</strong> on their transaction</li>
           </ol>

--- a/db/migrations/002_referral_analytics.sql
+++ b/db/migrations/002_referral_analytics.sql
@@ -1,0 +1,63 @@
+-- Migration: 002_referral_analytics
+-- Purpose:   Create the referral analytics tables for tracking
+--            click events, conversion events, and aggregating
+--            stats that power the /referral page and API.
+--
+-- The referral program generates codes and applies discounts, but
+-- there was no way to measure:
+--   • How many times a referral link was clicked
+--   • How many referred users completed onboarding
+--   • Total discount earned by the referrer
+--
+-- These tables fill that gap.
+
+-- -------------------------------------------------------------------------
+-- Table: referral_analytics
+-- One row per referral code; aggregates counts and totals.
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS referral_analytics (
+  id                TEXT        PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  referral_code     TEXT        NOT NULL,
+  owner_address     TEXT        NOT NULL,
+  click_count       INTEGER     NOT NULL DEFAULT 0,
+  conversion_count  INTEGER     NOT NULL DEFAULT 0,
+  total_rebates_earned NUMERIC  NOT NULL DEFAULT 0,
+  last_clicked_at   TIMESTAMPTZ,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_referral_analytics_code
+  ON referral_analytics (referral_code);
+
+CREATE INDEX IF NOT EXISTS idx_referral_analytics_owner
+  ON referral_analytics (owner_address);
+
+-- -------------------------------------------------------------------------
+-- Table: referral_conversions
+-- One row per successful conversion (referee completed first onramp).
+-- -------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS referral_conversions (
+  id                TEXT        PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  referral_code     TEXT        NOT NULL,
+  referrer_address  TEXT        NOT NULL,
+  referee_address   TEXT        NOT NULL,
+  discount_amount   NUMERIC     NOT NULL DEFAULT 0,
+  rebate_amount     NUMERIC     NOT NULL DEFAULT 0,
+  order_id          TEXT,
+  converted_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_referral_conversions_code
+  ON referral_conversions (referral_code);
+
+CREATE INDEX IF NOT EXISTS idx_referral_conversions_referee
+  ON referral_conversions (referee_address);
+
+-- -------------------------------------------------------------------------
+-- Trigger: keep referral_analytics.updated_at current
+-- -------------------------------------------------------------------------
+DROP TRIGGER IF EXISTS trg_referral_analytics_updated_at ON referral_analytics;
+CREATE TRIGGER trg_referral_analytics_updated_at
+  BEFORE UPDATE ON referral_analytics
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();

--- a/hooks/use-order-status-updates.ts
+++ b/hooks/use-order-status-updates.ts
@@ -186,6 +186,8 @@ async function simulateStatusProgression(
         updateOrderStatus('completed', {
           transactionHash: paymentTxHash,
           completedAt: Date.now(),
+          referralCode: order.referralCode,
+          walletAddress: order.walletAddress,
         })
 
         // Send notification (mock)

--- a/hooks/use-order-tracking.ts
+++ b/hooks/use-order-tracking.ts
@@ -68,6 +68,10 @@ export function useOrderTracking(orderId: string | null) {
       if (!orderId) return
 
       try {
+        // Read current order from localStorage for fee calculation
+        const storedData = localStorage.getItem(`onramp:order:${orderId}`)
+        const storedOrder: OnrampOrder | null = storedData ? JSON.parse(storedData) : null
+
         // Optimistically update local state
         setOrder((prevOrder) => {
           if (!prevOrder) return null
@@ -77,12 +81,17 @@ export function useOrderTracking(orderId: string | null) {
         })
 
         // Notify backend
+        const referralTotalFees =
+          additionalData?.referralCode && storedOrder?.fees?.totalFees
+            ? storedOrder.fees.totalFees
+            : undefined
+
         await fetch(`/api/onramp/order/${orderId}/status`, {
           method: 'PATCH',
           headers: {
             'Content-Type': 'application/json',
           },
-          body: JSON.stringify({ status, additionalData }),
+          body: JSON.stringify({ status, additionalData, referralTotalFees }),
         })
       } catch (err) {
         console.error('Failed to update order status on backend:', err)

--- a/hooks/use-referral.ts
+++ b/hooks/use-referral.ts
@@ -10,11 +10,21 @@ import {
   type ReferralRecord,
 } from '@/lib/referral'
 
+export interface ReferralStats {
+  code: string
+  ownerAddress: string
+  clickCount: number
+  conversionCount: number
+  totalRebatesEarned: number
+}
+
 export interface UseReferralReturn {
   /** This user's own referral code */
   myCode: string
   /** Stats for the referrer (referees count, rebates earned) */
   record: ReferralRecord | null
+  /** Analytics stats (clicks, conversions) */
+  stats: ReferralStats | null
   /** Code the current user applied (for their own discount) */
   appliedCode: string | null
   /** Whether the 10% first-ramp discount is active */
@@ -27,18 +37,24 @@ export interface UseReferralReturn {
 export function useReferral(walletAddress: string): UseReferralReturn {
   const myCode = walletAddress ? generateReferralCode(walletAddress) : ''
   const [record, setRecord] = useState<ReferralRecord | null>(null)
+  const [stats, setStats] = useState<ReferralStats | null>(null)
   const [appliedCode, setAppliedCode] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
 
-  // Load applied code + fetch referrer stats
+  // Load applied code + fetch referrer stats + fetch analytics
   useEffect(() => {
     if (!walletAddress) return
     setAppliedCode(getAppliedReferralCode())
 
     setLoading(true)
-    fetch(`/api/referral?wallet=${encodeURIComponent(walletAddress)}`)
-      .then((r) => r.json())
-      .then((data: ReferralRecord) => setRecord(data))
+    Promise.all([
+      fetch(`/api/referral?wallet=${encodeURIComponent(walletAddress)}`).then((r) => r.json()),
+      fetch(`/api/referral/stats?wallet=${encodeURIComponent(walletAddress)}`).then((r) => r.json()),
+    ])
+      .then(([recordData, statsData]) => {
+        setRecord(recordData)
+        setStats(statsData)
+      })
       .catch(() => {})
       .finally(() => setLoading(false))
   }, [walletAddress])
@@ -67,7 +83,7 @@ export function useReferral(walletAddress: string): UseReferralReturn {
   const discountActive =
     !!appliedCode && !isReferralDiscountConsumed()
 
-  return { myCode, record, appliedCode, discountActive, applyCode, loading }
+  return { myCode, record, stats, appliedCode, discountActive, applyCode, loading }
 }
 
 export { REFERRAL_DISCOUNT_PCT }

--- a/lib/referral/analytics.ts
+++ b/lib/referral/analytics.ts
@@ -1,0 +1,89 @@
+import { REFERRAL_REWARD_PCT } from './index'
+
+/**
+ * In-memory analytics store for referral program metrics.
+ * In production, replace with the `referral_analytics` and
+ * `referral_conversions` tables (see db/migrations/002_referral_analytics.sql).
+ */
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface ReferralClickEvent {
+  code: string
+  timestamp: number
+}
+
+export interface ReferralConversionEvent {
+  code: string
+  ownerAddress: string
+  refereeWallet: string
+  discountAmount: number
+  rebateAmount: number
+  orderId: string
+  timestamp: number
+}
+
+export interface ReferralAnalyticsRecord {
+  code: string
+  ownerAddress: string
+  clickCount: number
+  conversionCount: number
+  totalRebatesEarned: number
+  recentClicks: ReferralClickEvent[]
+  recentConversions: ReferralConversionEvent[]
+}
+
+// ── In-memory store ─────────────────────────────────────────────────────────
+
+const store = new Map<string, ReferralAnalyticsRecord>()
+
+function getOrCreate(code: string, ownerAddress: string): ReferralAnalyticsRecord {
+  if (!store.has(code)) {
+    store.set(code, {
+      code,
+      ownerAddress,
+      clickCount: 0,
+      conversionCount: 0,
+      totalRebatesEarned: 0,
+      recentClicks: [],
+      recentConversions: [],
+    })
+  }
+  return store.get(code)!
+}
+
+// ── Public API ──────────────────────────────────────────────────────────────
+
+export function trackClick(code: string): void {
+  const record = getOrCreate(code, 'unknown')
+  record.clickCount++
+  record.recentClicks.push({ code, timestamp: Date.now() })
+}
+
+export function trackConversion(
+  code: string,
+  refereeWallet: string,
+  orderId: string,
+  totalFees?: number,
+): void {
+  const record = getOrCreate(code, 'unknown')
+
+  const discountAmount = totalFees ? totalFees * (10 / 100) : 0
+  const rebateAmount = totalFees ? totalFees * (REFERRAL_REWARD_PCT / 100) : 0
+
+  record.conversionCount++
+  record.totalRebatesEarned += rebateAmount
+  record.recentConversions.push({
+    code,
+    ownerAddress: 'unknown',
+    refereeWallet,
+    discountAmount,
+    rebateAmount,
+    orderId,
+    timestamp: Date.now(),
+  })
+}
+
+export function getStatsByCode(code: string): ReferralAnalyticsRecord | null {
+  return store.get(code) ?? null
+}

--- a/types/onramp.ts
+++ b/types/onramp.ts
@@ -55,6 +55,7 @@ export interface OnrampOrder {
   status: OrderStatus
   transactionHash?: string
   completedAt?: number
+  referralCode?: string
 }
 
 export interface TransactionItem {


### PR DESCRIPTION
## Summary

The referral system generates codes and applies discounts, but had no tracking for clicks, conversions, or total rebates earned. This PR adds the full analytics pipeline.

## Changes

### Database
- **`db/migrations/002_referral_analytics.sql`**: Creates `referral_analytics` and `referral_conversions` tables with proper indexes and triggers

### Backend
- **`lib/referral/analytics.ts`**: In-memory analytics store tracking clicks, conversions, and rebates (parallel to existing referral store)
- **`app/referral/[code]/route.ts`**: New redirect endpoint — tracks click, then redirects to `/onramp?ref=CODE`
- **`app/api/referral/stats/route.ts`**: New `GET /api/referral/stats?wallet=G...` returning `{ clickCount, conversionCount, totalRebatesEarned }`
- **`app/api/onramp/order/[orderId]/status/route.ts`**: Records referral conversion when an order with a referral code reaches 'completed' status

### Frontend
- **`components/onramp/onramp-page-client.tsx`**: Auto-applies `?ref=CODE` from URL query param; includes `referralCode` in order payload
- **`hooks/use-order-status-updates.ts`**, **`hooks/use-order-tracking.ts`**: Passes referral code and fees through to the PATCH endpoint for conversion recording
- **`hooks/use-referral.ts`**: Fetches analytics stats alongside existing referral record
- **`components/referral/referral-card.tsx`**: Displays real analytics (link clicks, conversions, rebates earned) in a new 3-column stat grid; share URL updated to `/referral/CODE` format
- **`components/referral/referral-page-client.tsx`**: Shows referral history snapshot and conversion rate insight when data exists
- **`types/onramp.ts`**: Added optional `referralCode` field to `OnrampOrder`

### Data Flow
1. Referrer shares `/referral/AFR-XXXX-0000`
2. Friend clicks → click counted → redirected to `/onramp?ref=AFR-XXXX-0000`
3. Code auto-applied from URL param → discount applied on order creation
4. Order completion triggers `trackConversion` → referrer's analytics updated
5. Referrer visits `/referral` → sees real-time stats from `/api/referral/stats`

Closes #325