### PR TITLE
feat(admin): add gated admin panel with orders, KYC, and user views

### DIFF
--- a/app/admin/kyc/page.tsx
+++ b/app/admin/kyc/page.tsx
@@ -1,0 +1,227 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { motion } from 'framer-motion'
+import {
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  XCircle,
+} from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { KycStatus, KycSubmission } from '@/types/kyc'
+
+const PAGE_SIZE = 10
+
+type QuickFilter = 'all' | KycStatus
+
+const mockSubmissions: KycSubmission[] = [
+  { id: 'KYC-001', userId: 'USR-001', status: 'pending', step: 'review', documents: [], createdAt: 1748822400000, updatedAt: 1748822400000, expiresAt: 1749427200000 },
+  { id: 'KYC-002', userId: 'USR-002', status: 'pending', step: 'review', documents: [], createdAt: 1748736000000, updatedAt: 1748736000000, expiresAt: 1749340800000 },
+  { id: 'KYC-003', userId: 'USR-003', status: 'approved', step: 'submitted', documents: [], createdAt: 1748649600000, updatedAt: 1748736000000, expiresAt: 1780272000000 },
+  { id: 'KYC-004', userId: 'USR-004', status: 'rejected', step: 'submitted', documents: [], createdAt: 1748563200000, updatedAt: 1748649600000, expiresAt: 1749168000000, verificationNotes: 'ID document expired' },
+  { id: 'KYC-005', userId: 'USR-005', status: 'pending', step: 'review', documents: [], createdAt: 1748476800000, updatedAt: 1748476800000, expiresAt: 1749081600000 },
+  { id: 'KYC-006', userId: 'USR-006', status: 'expired', step: 'submitted', documents: [], createdAt: 1746057600000, updatedAt: 1746144000000, expiresAt: 1747612800000 },
+  { id: 'KYC-007', userId: 'USR-007', status: 'pending', step: 'review', documents: [], createdAt: 1748390400000, updatedAt: 1748390400000, expiresAt: 1748995200000 },
+  { id: 'KYC-008', userId: 'USR-008', status: 'approved', step: 'submitted', documents: [], createdAt: 1748304000000, updatedAt: 1748390400000, expiresAt: 1779926400000 },
+  { id: 'KYC-009', userId: 'USR-009', status: 'rejected', step: 'submitted', documents: [], createdAt: 1748217600000, updatedAt: 1748304000000, expiresAt: 1748822400000, verificationNotes: 'Selfie did not match ID photo' },
+  { id: 'KYC-010', userId: 'USR-010', status: 'pending', step: 'review', documents: [], createdAt: 1748131200000, updatedAt: 1748131200000, expiresAt: 1748736000000 },
+  { id: 'KYC-011', userId: 'USR-011', status: 'approved', step: 'submitted', documents: [], createdAt: 1748044800000, updatedAt: 1748131200000, expiresAt: 1779667200000 },
+  { id: 'KYC-012', userId: 'USR-012', status: 'expired', step: 'submitted', documents: [], createdAt: 1745539200000, updatedAt: 1745625600000, expiresAt: 1747094400000 },
+]
+
+const statusConfig: Record<KycStatus, { label: string; className: string; icon: typeof CheckCircle2 }> = {
+  pending: { label: 'Pending', className: 'bg-amber-500/12 text-amber-700 border-amber-500/35 dark:text-amber-400', icon: Clock },
+  approved: { label: 'Approved', className: 'bg-emerald-500/12 text-emerald-700 border-emerald-500/35 dark:text-emerald-400', icon: CheckCircle2 },
+  rejected: { label: 'Rejected', className: 'bg-rose-500/12 text-rose-700 border-rose-500/35 dark:text-rose-400', icon: XCircle },
+  expired: { label: 'Expired', className: 'bg-slate-500/12 text-slate-500 border-slate-500/35 dark:text-slate-400', icon: Clock },
+}
+
+function formatDate(ts: number) {
+  return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(new Date(ts))
+}
+
+function Pagination({
+  currentPage,
+  totalPages,
+  totalCount,
+  onPageChange,
+}: {
+  currentPage: number
+  totalPages: number
+  totalCount: number
+  onPageChange: (p: number) => void
+}) {
+  const start = totalCount === 0 ? 0 : (currentPage - 1) * PAGE_SIZE + 1
+  const end = Math.min(currentPage * PAGE_SIZE, totalCount)
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4">
+      <p className="text-sm text-muted-foreground">Showing {start}–{end} of {totalCount}</p>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" size="sm" onClick={() => onPageChange(Math.max(1, currentPage - 1))} disabled={currentPage === 1} className="h-9 px-3">
+          <ChevronLeft className="h-4 w-4" />Prev
+        </Button>
+        {Array.from({ length: totalPages }).map((_, i) => {
+          const n = i + 1
+          return (
+            <button
+              key={n}
+              type="button"
+              onClick={() => onPageChange(n)}
+              className={cn('h-9 min-w-9 rounded-md px-3 text-sm font-semibold transition-colors', n === currentPage ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:text-foreground')}
+              aria-current={n === currentPage ? 'page' : undefined}
+            >
+              {n}
+            </button>
+          )
+        })}
+        <Button variant="outline" size="sm" onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))} disabled={currentPage === totalPages} className="h-9 px-3">
+          Next<ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default function AdminKycPage() {
+  const [quickFilter, setQuickFilter] = useState<QuickFilter>('pending')
+  const [page, setPage] = useState(1)
+  const [actions, setActions] = useState<Record<string, KycStatus>>({})
+
+  const quickFilters: Array<{ key: QuickFilter; label: string }> = [
+    { key: 'all', label: 'All' },
+    { key: 'pending', label: 'Pending Review' },
+    { key: 'approved', label: 'Approved' },
+    { key: 'rejected', label: 'Rejected' },
+    { key: 'expired', label: 'Expired' },
+  ]
+
+  const filtered = useMemo(() => {
+    return mockSubmissions.filter((s) => {
+      const effectiveStatus = actions[s.id] ?? s.status
+      if (quickFilter === 'all') return true
+      return effectiveStatus === quickFilter
+    })
+  }, [quickFilter, actions])
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE))
+  const currentPage = Math.min(page, totalPages)
+  const paginated = useMemo(
+    () => filtered.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE),
+    [filtered, currentPage]
+  )
+
+  const setAction = (id: string, status: KycStatus) => {
+    setActions((prev) => ({ ...prev, [id]: status }))
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">KYC Review</h1>
+        <p className="text-sm text-muted-foreground mt-1">Review and approve or reject KYC submissions</p>
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="bg-card rounded-2xl p-6 border border-border shadow-sm"
+      >
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          {quickFilters.map((f) => (
+            <button
+              key={f.key}
+              type="button"
+              onClick={() => { setQuickFilter(f.key); setPage(1) }}
+              className={cn(
+                'h-8 rounded-full border px-3 text-sm font-medium transition-colors',
+                quickFilter === f.key
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-background border-border text-muted-foreground hover:text-foreground hover:bg-muted'
+              )}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[640px]">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Submission</th>
+                <th className="py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">User</th>
+                <th className="py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Status</th>
+                <th className="py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Submitted</th>
+                <th className="py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Notes</th>
+                <th className="py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {paginated.map((submission, index) => {
+                const effectiveStatus = actions[submission.id] ?? submission.status
+                const StatusIcon = statusConfig[effectiveStatus].icon
+                const isPending = effectiveStatus === 'pending'
+                return (
+                  <motion.tr
+                    key={submission.id}
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: index * 0.04 }}
+                    className="border-b border-border/70 transition-colors hover:bg-muted/30"
+                  >
+                    <td className="py-4 font-mono text-sm text-foreground">{submission.id}</td>
+                    <td className="py-4 text-sm text-muted-foreground">{submission.userId}</td>
+                    <td className="py-4">
+                      <Badge
+                        variant="outline"
+                        className={cn('w-fit rounded-full border px-3 py-1 text-xs font-semibold flex items-center gap-1.5', statusConfig[effectiveStatus].className)}
+                      >
+                        <StatusIcon className="h-3.5 w-3.5" />
+                        {statusConfig[effectiveStatus].label}
+                      </Badge>
+                    </td>
+                    <td className="py-4 text-sm text-muted-foreground">{formatDate(submission.createdAt)}</td>
+                    <td className="py-4 text-xs text-muted-foreground max-w-[180px] truncate">
+                      {submission.verificationNotes ?? '—'}
+                    </td>
+                    <td className="py-4">
+                      {isPending ? (
+                        <div className="flex items-center gap-2">
+                          <Button
+                            size="sm"
+                            className="h-8 px-3 text-xs bg-emerald-600 hover:bg-emerald-700 text-white"
+                            onClick={() => setAction(submission.id, 'approved')}
+                          >
+                            <CheckCircle2 className="h-3.5 w-3.5" />Approve
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="h-8 px-3 text-xs border-rose-500/40 text-rose-600 hover:bg-rose-500/10 dark:text-rose-400"
+                            onClick={() => setAction(submission.id, 'rejected')}
+                          >
+                            <XCircle className="h-3.5 w-3.5" />Reject
+                          </Button>
+                        </div>
+                      ) : (
+                        <span className="text-xs text-muted-foreground">—</span>
+                      )}
+                    </td>
+                  </motion.tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="mt-4">
+          <Pagination currentPage={currentPage} totalPages={totalPages} totalCount={filtered.length} onPageChange={setPage} />
+        </div>
+      </motion.div>
+    </div>
+  )
+}

--- a/app/admin/layout.tsx
+++ b/app/admin/layout.tsx
@@ -1,0 +1,106 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { motion } from 'framer-motion'
+import { LayoutDashboard, ArrowDownUp, ShieldCheck, Users, ChevronRight, LogOut } from 'lucide-react'
+import { Separator } from '@/components/ui/separator'
+import { cn } from '@/lib/utils'
+
+const NAV_ITEMS = [
+  { href: '/admin', label: 'Overview', icon: LayoutDashboard, exact: true },
+  { href: '/admin/orders', label: 'Orders', icon: ArrowDownUp, exact: false },
+  { href: '/admin/kyc', label: 'KYC Review', icon: ShieldCheck, exact: false },
+  { href: '/admin/users', label: 'Users', icon: Users, exact: false },
+]
+
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname()
+
+  return (
+    <div className="flex min-h-screen bg-background">
+      <motion.aside
+        initial={{ x: -20, opacity: 0 }}
+        animate={{ x: 0, opacity: 1 }}
+        transition={{ duration: 0.3 }}
+        className="hidden md:flex w-60 flex-col border-r border-border bg-card/50 backdrop-blur-md fixed inset-y-0 left-0 z-30"
+      >
+        <div className="flex h-16 items-center gap-3 px-6 border-b border-border shrink-0">
+          <Link href="/" className="flex items-center gap-2">
+            <div className="w-7 h-7 rounded-lg bg-primary flex items-center justify-center shrink-0">
+              <span className="text-primary-foreground font-bold text-sm">A</span>
+            </div>
+            <span className="font-semibold text-foreground">Aframp</span>
+          </Link>
+          <span className="rounded-md bg-primary/10 px-1.5 py-0.5 text-xs font-semibold text-primary">Admin</span>
+        </div>
+
+        <nav className="flex-1 overflow-y-auto p-3 space-y-0.5">
+          {NAV_ITEMS.map((item) => {
+            const isActive = item.exact ? pathname === item.href : pathname.startsWith(item.href)
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={cn(
+                  'flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-colors group',
+                  isActive
+                    ? 'bg-primary/10 text-primary'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-muted/50'
+                )}
+              >
+                <item.icon className={cn('h-4 w-4 shrink-0 transition-colors', isActive ? 'text-primary' : 'text-muted-foreground group-hover:text-foreground')} />
+                <span>{item.label}</span>
+                {isActive && <ChevronRight className="ml-auto h-3.5 w-3.5 text-primary" />}
+              </Link>
+            )
+          })}
+        </nav>
+
+        <div className="p-3 shrink-0">
+          <Separator className="mb-3" />
+          <Link
+            href="/dashboard"
+            className="flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+          >
+            <LogOut className="h-4 w-4 shrink-0" />
+            Exit Admin
+          </Link>
+        </div>
+      </motion.aside>
+
+      <header className="md:hidden fixed inset-x-0 top-0 z-30 flex h-14 items-center gap-3 border-b border-border bg-background/80 backdrop-blur-md px-4">
+        <Link href="/" className="flex items-center gap-1.5 shrink-0">
+          <div className="w-6 h-6 rounded-md bg-primary flex items-center justify-center">
+            <span className="text-primary-foreground font-bold text-xs">A</span>
+          </div>
+          <span className="font-semibold text-foreground text-sm">Admin</span>
+        </Link>
+        <div className="flex items-center gap-1 ml-auto overflow-x-auto">
+          {NAV_ITEMS.map((item) => {
+            const isActive = item.exact ? pathname === item.href : pathname.startsWith(item.href)
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={cn(
+                  'flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium transition-colors whitespace-nowrap',
+                  isActive ? 'bg-primary/10 text-primary' : 'text-muted-foreground hover:text-foreground'
+                )}
+              >
+                <item.icon className="h-3.5 w-3.5 shrink-0" />
+                {item.label}
+              </Link>
+            )
+          })}
+        </div>
+      </header>
+
+      <main className="flex-1 md:ml-60 pt-14 md:pt-0">
+        <div className="container mx-auto px-4 py-8 max-w-7xl">
+          {children}
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/app/admin/orders/page.tsx
+++ b/app/admin/orders/page.tsx
@@ -1,0 +1,261 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { motion } from 'framer-motion'
+import {
+  ArrowUpDown,
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  Eye,
+  XCircle,
+} from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { OnrampOrder, OrderStatus } from '@/types/onramp'
+
+const PAGE_SIZE = 10
+
+type QuickFilter = 'all' | 'pending' | 'minting' | 'completed' | 'failed'
+type SortField = 'createdAt' | 'amount' | 'status' | 'fiatCurrency'
+type SortDirection = 'asc' | 'desc'
+
+const mockOrders: OnrampOrder[] = [
+  { id: 'ORD-001', createdAt: 1748822400000, expiresAt: 1748908800000, fiatCurrency: 'NGN', cryptoAsset: 'cNGN', paymentMethod: 'bank_transfer', amount: 25000, exchangeRate: 1.01, cryptoAmount: 24750, fees: { processingFee: 200, networkFee: 50, totalFees: 250, totalCost: 25250 }, walletAddress: '0xABC1', status: 'completed', transactionHash: '0xhash1', completedAt: 1748836800000 },
+  { id: 'ORD-002', createdAt: 1748736000000, expiresAt: 1748822400000, fiatCurrency: 'KES', cryptoAsset: 'cKES', paymentMethod: 'mobile_money', amount: 5000, exchangeRate: 0.0077, cryptoAmount: 38.5, fees: { processingFee: 50, networkFee: 10, totalFees: 60, totalCost: 5060 }, walletAddress: '0xABC2', status: 'awaiting_payment' },
+  { id: 'ORD-003', createdAt: 1748649600000, expiresAt: 1748736000000, fiatCurrency: 'GHS', cryptoAsset: 'cGHS', paymentMethod: 'bank_transfer', amount: 1200, exchangeRate: 0.065, cryptoAmount: 78, fees: { processingFee: 20, networkFee: 5, totalFees: 25, totalCost: 1225 }, walletAddress: '0xABC3', status: 'minting' },
+  { id: 'ORD-004', createdAt: 1748563200000, expiresAt: 1748649600000, fiatCurrency: 'ZAR', cryptoAsset: 'USDC', paymentMethod: 'card', amount: 800, exchangeRate: 0.054, cryptoAmount: 43.2, fees: { processingFee: 15, networkFee: 5, totalFees: 20, totalCost: 820 }, walletAddress: '0xABC4', status: 'failed' },
+  { id: 'ORD-005', createdAt: 1748476800000, expiresAt: 1748563200000, fiatCurrency: 'NGN', cryptoAsset: 'USDC', paymentMethod: 'bank_transfer', amount: 150000, exchangeRate: 0.00065, cryptoAmount: 97.5, fees: { processingFee: 1000, networkFee: 200, totalFees: 1200, totalCost: 151200 }, walletAddress: '0xABC5', status: 'completed', transactionHash: '0xhash5', completedAt: 1748490000000 },
+  { id: 'ORD-006', createdAt: 1748390400000, expiresAt: 1748476800000, fiatCurrency: 'UGX', cryptoAsset: 'XLM', paymentMethod: 'mobile_money', amount: 200000, exchangeRate: 0.00027, cryptoAmount: 54, fees: { processingFee: 2000, networkFee: 500, totalFees: 2500, totalCost: 202500 }, walletAddress: '0xABC6', status: 'transferring' },
+  { id: 'ORD-007', createdAt: 1748304000000, expiresAt: 1748390400000, fiatCurrency: 'NGN', cryptoAsset: 'cNGN', paymentMethod: 'bank_transfer', amount: 50000, exchangeRate: 1.01, cryptoAmount: 49500, fees: { processingFee: 400, networkFee: 100, totalFees: 500, totalCost: 50500 }, walletAddress: '0xABC7', status: 'payment_received' },
+  { id: 'ORD-008', createdAt: 1748217600000, expiresAt: 1748304000000, fiatCurrency: 'KES', cryptoAsset: 'USDC', paymentMethod: 'mobile_money', amount: 12000, exchangeRate: 0.0077, cryptoAmount: 92.4, fees: { processingFee: 120, networkFee: 25, totalFees: 145, totalCost: 12145 }, walletAddress: '0xABC8', status: 'completed', transactionHash: '0xhash8', completedAt: 1748230800000 },
+  { id: 'ORD-009', createdAt: 1748131200000, expiresAt: 1748217600000, fiatCurrency: 'GHS', cryptoAsset: 'cGHS', paymentMethod: 'bank_transfer', amount: 3500, exchangeRate: 0.065, cryptoAmount: 227.5, fees: { processingFee: 35, networkFee: 8, totalFees: 43, totalCost: 3543 }, walletAddress: '0xABC9', status: 'created' },
+  { id: 'ORD-010', createdAt: 1748044800000, expiresAt: 1748131200000, fiatCurrency: 'NGN', cryptoAsset: 'USDC', paymentMethod: 'card', amount: 75000, exchangeRate: 0.00065, cryptoAmount: 48.75, fees: { processingFee: 600, networkFee: 150, totalFees: 750, totalCost: 75750 }, walletAddress: '0xABC10', status: 'failed' },
+  { id: 'ORD-011', createdAt: 1747958400000, expiresAt: 1748044800000, fiatCurrency: 'ZAR', cryptoAsset: 'XLM', paymentMethod: 'card', amount: 2000, exchangeRate: 0.054, cryptoAmount: 108, fees: { processingFee: 20, networkFee: 5, totalFees: 25, totalCost: 2025 }, walletAddress: '0xABC11', status: 'completed', transactionHash: '0xhash11', completedAt: 1747972000000 },
+  { id: 'ORD-012', createdAt: 1747872000000, expiresAt: 1747958400000, fiatCurrency: 'NGN', cryptoAsset: 'cNGN', paymentMethod: 'bank_transfer', amount: 10000, exchangeRate: 1.01, cryptoAmount: 9900, fees: { processingFee: 80, networkFee: 20, totalFees: 100, totalCost: 10100 }, walletAddress: '0xABC12', status: 'minting' },
+]
+
+const statusConfig: Record<OrderStatus, { label: string; className: string; icon: typeof CheckCircle2 }> = {
+  created: { label: 'Created', className: 'bg-slate-500/12 text-slate-500 border-slate-500/35 dark:text-slate-400', icon: Clock },
+  awaiting_payment: { label: 'Awaiting Payment', className: 'bg-amber-500/12 text-amber-700 border-amber-500/35 dark:text-amber-400', icon: Clock },
+  payment_received: { label: 'Payment Received', className: 'bg-sky-500/12 text-sky-700 border-sky-500/35 dark:text-sky-400', icon: CheckCircle2 },
+  minting: { label: 'Minting', className: 'bg-violet-500/12 text-violet-700 border-violet-500/35 dark:text-violet-400', icon: Clock },
+  transferring: { label: 'Transferring', className: 'bg-blue-500/12 text-blue-700 border-blue-500/35 dark:text-blue-400', icon: Clock },
+  completed: { label: 'Completed', className: 'bg-emerald-500/12 text-emerald-700 border-emerald-500/35 dark:text-emerald-400', icon: CheckCircle2 },
+  failed: { label: 'Failed', className: 'bg-rose-500/12 text-rose-700 border-rose-500/35 dark:text-rose-400', icon: XCircle },
+}
+
+function formatDate(ts: number) {
+  return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(new Date(ts))
+}
+
+function SortHeader({
+  label,
+  field,
+  sortField,
+  onSortChange,
+}: {
+  label: string
+  field: SortField
+  sortField: SortField
+  onSortChange: (f: SortField) => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSortChange(field)}
+      className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground transition-colors"
+    >
+      <span>{label}</span>
+      <ArrowUpDown className={cn('h-3.5 w-3.5', sortField === field ? 'text-foreground' : 'text-muted-foreground/70')} />
+    </button>
+  )
+}
+
+function Pagination({
+  currentPage,
+  totalPages,
+  totalCount,
+  onPageChange,
+}: {
+  currentPage: number
+  totalPages: number
+  totalCount: number
+  onPageChange: (p: number) => void
+}) {
+  const start = totalCount === 0 ? 0 : (currentPage - 1) * PAGE_SIZE + 1
+  const end = Math.min(currentPage * PAGE_SIZE, totalCount)
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4">
+      <p className="text-sm text-muted-foreground">Showing {start}–{end} of {totalCount}</p>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" size="sm" onClick={() => onPageChange(Math.max(1, currentPage - 1))} disabled={currentPage === 1} className="h-9 px-3">
+          <ChevronLeft className="h-4 w-4" />Prev
+        </Button>
+        {Array.from({ length: totalPages }).map((_, i) => {
+          const n = i + 1
+          return (
+            <button
+              key={n}
+              type="button"
+              onClick={() => onPageChange(n)}
+              className={cn('h-9 min-w-9 rounded-md px-3 text-sm font-semibold transition-colors', n === currentPage ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:text-foreground')}
+              aria-current={n === currentPage ? 'page' : undefined}
+            >
+              {n}
+            </button>
+          )
+        })}
+        <Button variant="outline" size="sm" onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))} disabled={currentPage === totalPages} className="h-9 px-3">
+          Next<ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default function AdminOrdersPage() {
+  const [quickFilter, setQuickFilter] = useState<QuickFilter>('all')
+  const [sortField, setSortField] = useState<SortField>('createdAt')
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
+  const [page, setPage] = useState(1)
+
+  const quickFilters: Array<{ key: QuickFilter; label: string }> = [
+    { key: 'all', label: 'All' },
+    { key: 'pending', label: 'Pending' },
+    { key: 'minting', label: 'Minting' },
+    { key: 'completed', label: 'Completed' },
+    { key: 'failed', label: 'Failed' },
+  ]
+
+  const filtered = useMemo(() => {
+    return mockOrders.filter((o) => {
+      if (quickFilter === 'all') return true
+      if (quickFilter === 'pending') return ['created', 'awaiting_payment', 'payment_received', 'transferring'].includes(o.status)
+      if (quickFilter === 'minting') return o.status === 'minting'
+      if (quickFilter === 'completed') return o.status === 'completed'
+      if (quickFilter === 'failed') return o.status === 'failed'
+      return true
+    })
+  }, [quickFilter])
+
+  const sorted = useMemo(() => {
+    return [...filtered].sort((a, b) => {
+      let aVal: string | number = 0
+      let bVal: string | number = 0
+      switch (sortField) {
+        case 'createdAt': aVal = a.createdAt; bVal = b.createdAt; break
+        case 'amount': aVal = a.amount; bVal = b.amount; break
+        case 'status': aVal = a.status; bVal = b.status; break
+        case 'fiatCurrency': aVal = a.fiatCurrency; bVal = b.fiatCurrency; break
+      }
+      const result = typeof aVal === 'string' ? aVal.localeCompare(bVal as string) : Number(aVal) - Number(bVal)
+      return sortDirection === 'asc' ? result : -result
+    })
+  }, [filtered, sortField, sortDirection])
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE))
+  const currentPage = Math.min(page, totalPages)
+  const paginated = useMemo(
+    () => sorted.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE),
+    [sorted, currentPage]
+  )
+
+  const onSortChange = (field: SortField) => {
+    setPage(1)
+    if (sortField === field) { setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc')); return }
+    setSortField(field)
+    setSortDirection('desc')
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">Orders</h1>
+        <p className="text-sm text-muted-foreground mt-1">Manage onramp and offramp orders</p>
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="bg-card rounded-2xl p-6 border border-border shadow-sm"
+      >
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          {quickFilters.map((f) => (
+            <button
+              key={f.key}
+              type="button"
+              onClick={() => { setQuickFilter(f.key); setPage(1) }}
+              className={cn(
+                'h-8 rounded-full border px-3 text-sm font-medium transition-colors',
+                quickFilter === f.key
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-background border-border text-muted-foreground hover:text-foreground hover:bg-muted'
+              )}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[700px]">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Order ID</th>
+                <th className="py-3 text-left"><SortHeader label="Amount" field="amount" sortField={sortField} onSortChange={onSortChange} /></th>
+                <th className="py-3 text-left"><SortHeader label="Currency" field="fiatCurrency" sortField={sortField} onSortChange={onSortChange} /></th>
+                <th className="py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Asset</th>
+                <th className="py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Method</th>
+                <th className="py-3 text-left"><SortHeader label="Status" field="status" sortField={sortField} onSortChange={onSortChange} /></th>
+                <th className="py-3 text-left"><SortHeader label="Created" field="createdAt" sortField={sortField} onSortChange={onSortChange} /></th>
+                <th className="py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {paginated.map((order, index) => {
+                const StatusIcon = statusConfig[order.status].icon
+                return (
+                  <motion.tr
+                    key={order.id}
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: index * 0.04 }}
+                    className="border-b border-border/70 transition-colors hover:bg-muted/30"
+                  >
+                    <td className="py-4 font-mono text-sm text-foreground">{order.id}</td>
+                    <td className="py-4 font-bold text-foreground">{order.amount.toLocaleString()}</td>
+                    <td className="py-4 text-sm text-muted-foreground">{order.fiatCurrency}</td>
+                    <td className="py-4 text-sm font-medium text-foreground">{order.cryptoAsset}</td>
+                    <td className="py-4 text-sm text-muted-foreground capitalize">{order.paymentMethod.replace(/_/g, ' ')}</td>
+                    <td className="py-4">
+                      <Badge
+                        variant="outline"
+                        className={cn('w-fit rounded-full border px-3 py-1 text-xs font-semibold flex items-center gap-1.5', statusConfig[order.status].className)}
+                      >
+                        <StatusIcon className="h-3.5 w-3.5" />
+                        {statusConfig[order.status].label}
+                      </Badge>
+                    </td>
+                    <td className="py-4 text-sm text-muted-foreground">{formatDate(order.createdAt)}</td>
+                    <td className="py-4">
+                      <Button variant="ghost" size="sm" className="h-8 px-3 text-xs">
+                        <Eye className="h-3.5 w-3.5" />View
+                      </Button>
+                    </td>
+                  </motion.tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="mt-4">
+          <Pagination currentPage={currentPage} totalPages={totalPages} totalCount={sorted.length} onPageChange={setPage} />
+        </div>
+      </motion.div>
+    </div>
+  )
+}

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,0 +1,102 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
+import { ArrowDownUp, ShieldCheck, Users, TrendingUp } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+const mockStats = [
+  {
+    title: 'Total Orders',
+    value: '4,821',
+    change: '+8.2% this week',
+    icon: ArrowDownUp,
+    color: 'text-sky-400',
+    bgColor: 'bg-sky-400/10',
+    borderColor: 'border-sky-400/20',
+    glowColor: 'group-hover:shadow-[0_0_30px_-5px_rgba(56,189,248,0.3)]',
+  },
+  {
+    title: 'Pending KYC',
+    value: '136',
+    change: '12 awaiting review',
+    icon: ShieldCheck,
+    color: 'text-amber-400',
+    bgColor: 'bg-amber-400/10',
+    borderColor: 'border-amber-400/20',
+    glowColor: 'group-hover:shadow-[0_0_30px_-5px_rgba(251,191,36,0.3)]',
+  },
+  {
+    title: 'Active Users',
+    value: '2,390',
+    change: '+134 this month',
+    icon: Users,
+    color: 'text-violet-400',
+    bgColor: 'bg-violet-400/10',
+    borderColor: 'border-violet-400/20',
+    glowColor: 'group-hover:shadow-[0_0_30px_-5px_rgba(167,139,250,0.3)]',
+  },
+  {
+    title: 'Total Volume',
+    value: '₦482M',
+    change: '+22.4% this month',
+    icon: TrendingUp,
+    color: 'text-emerald-400',
+    bgColor: 'bg-emerald-400/10',
+    borderColor: 'border-emerald-400/20',
+    glowColor: 'group-hover:shadow-[0_0_30px_-5px_rgba(52,211,153,0.3)]',
+  },
+]
+
+export default function AdminPage() {
+  return (
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">Overview</h1>
+        <p className="text-sm text-muted-foreground mt-1">Platform-wide metrics and activity</p>
+      </div>
+
+      <section className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-6">
+        {mockStats.map((stat, index) => (
+          <motion.div
+            key={stat.title}
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: index * 0.08, duration: 0.5, ease: 'easeOut' }}
+            className="group relative"
+          >
+            <div className={cn('absolute inset-0 rounded-2xl opacity-0 transition-opacity duration-500 pointer-events-none group-hover:opacity-100', stat.glowColor)} />
+            <Card className={cn(
+              'relative h-full overflow-hidden border-white/5 bg-gradient-to-b from-white/[0.03] to-transparent backdrop-blur-md transition-all duration-300',
+              'hover:border-white/10 hover:bg-white/[0.04] hover:-translate-y-1'
+            )}>
+              <div className={cn('absolute top-0 left-0 w-full h-[1px] bg-gradient-to-r from-transparent via-current to-transparent opacity-20', stat.color)} />
+              <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+                <CardTitle className="text-sm font-medium text-muted-foreground group-hover:text-foreground transition-colors">
+                  {stat.title}
+                </CardTitle>
+                <div className={cn('p-2.5 rounded-xl border transition-all duration-300 group-hover:scale-110', stat.bgColor, stat.borderColor)}>
+                  <stat.icon className={cn('h-4 w-4', stat.color)} />
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="text-3xl font-bold tracking-tight bg-clip-text text-transparent bg-gradient-to-br from-foreground to-muted-foreground">
+                  {stat.value}
+                </div>
+                <div className="flex items-center gap-2 mt-3">
+                  <Badge
+                    variant="outline"
+                    className={cn('text-xs font-medium px-2 py-0.5 border-none shadow-none', stat.bgColor, stat.color)}
+                  >
+                    {stat.change}
+                  </Badge>
+                </div>
+              </CardContent>
+            </Card>
+          </motion.div>
+        ))}
+      </section>
+    </div>
+  )
+}

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -1,0 +1,258 @@
+'use client'
+
+import { useState, useMemo } from 'react'
+import { motion } from 'framer-motion'
+import {
+  ArrowUpDown,
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  XCircle,
+} from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { KycStatus } from '@/types/kyc'
+
+const PAGE_SIZE = 10
+
+interface AdminUser {
+  id: string
+  walletAddress: string
+  kycStatus: KycStatus
+  orderCount: number
+  totalVolume: number
+  currency: string
+  joinedAt: number
+  lastActiveAt: number
+}
+
+type QuickFilter = 'all' | KycStatus
+type SortField = 'joinedAt' | 'orderCount' | 'totalVolume' | 'kycStatus'
+type SortDirection = 'asc' | 'desc'
+
+const mockUsers: AdminUser[] = [
+  { id: 'USR-001', walletAddress: '0x1a2b...3c4d', kycStatus: 'approved', orderCount: 12, totalVolume: 480000, currency: 'NGN', joinedAt: 1740000000000, lastActiveAt: 1748822400000 },
+  { id: 'USR-002', walletAddress: '0x5e6f...7a8b', kycStatus: 'pending', orderCount: 1, totalVolume: 5000, currency: 'KES', joinedAt: 1745000000000, lastActiveAt: 1748736000000 },
+  { id: 'USR-003', walletAddress: '0x9c0d...1e2f', kycStatus: 'approved', orderCount: 7, totalVolume: 210000, currency: 'NGN', joinedAt: 1742000000000, lastActiveAt: 1748649600000 },
+  { id: 'USR-004', walletAddress: '0x3a4b...5c6d', kycStatus: 'rejected', orderCount: 0, totalVolume: 0, currency: 'GHS', joinedAt: 1746000000000, lastActiveAt: 1748563200000 },
+  { id: 'USR-005', walletAddress: '0x7e8f...9a0b', kycStatus: 'pending', orderCount: 2, totalVolume: 15000, currency: 'NGN', joinedAt: 1747000000000, lastActiveAt: 1748476800000 },
+  { id: 'USR-006', walletAddress: '0x1c2d...3e4f', kycStatus: 'expired', orderCount: 3, totalVolume: 45000, currency: 'ZAR', joinedAt: 1738000000000, lastActiveAt: 1747000000000 },
+  { id: 'USR-007', walletAddress: '0x5a6b...7c8d', kycStatus: 'approved', orderCount: 22, totalVolume: 1200000, currency: 'NGN', joinedAt: 1735000000000, lastActiveAt: 1748822400000 },
+  { id: 'USR-008', walletAddress: '0x9e0f...1a2b', kycStatus: 'approved', orderCount: 5, totalVolume: 75000, currency: 'KES', joinedAt: 1743000000000, lastActiveAt: 1748304000000 },
+  { id: 'USR-009', walletAddress: '0x3c4d...5e6f', kycStatus: 'rejected', orderCount: 0, totalVolume: 0, currency: 'UGX', joinedAt: 1747500000000, lastActiveAt: 1748217600000 },
+  { id: 'USR-010', walletAddress: '0x7a8b...9c0d', kycStatus: 'pending', orderCount: 0, totalVolume: 0, currency: 'NGN', joinedAt: 1748000000000, lastActiveAt: 1748131200000 },
+  { id: 'USR-011', walletAddress: '0x1e2f...3a4b', kycStatus: 'approved', orderCount: 34, totalVolume: 2800000, currency: 'NGN', joinedAt: 1730000000000, lastActiveAt: 1748822400000 },
+  { id: 'USR-012', walletAddress: '0x5c6d...7e8f', kycStatus: 'expired', orderCount: 1, totalVolume: 8000, currency: 'GHS', joinedAt: 1736000000000, lastActiveAt: 1745000000000 },
+]
+
+const kycConfig: Record<KycStatus, { label: string; className: string; icon: typeof CheckCircle2 }> = {
+  approved: { label: 'Verified', className: 'bg-emerald-500/12 text-emerald-700 border-emerald-500/35 dark:text-emerald-400', icon: CheckCircle2 },
+  pending: { label: 'Pending', className: 'bg-amber-500/12 text-amber-700 border-amber-500/35 dark:text-amber-400', icon: Clock },
+  rejected: { label: 'Rejected', className: 'bg-rose-500/12 text-rose-700 border-rose-500/35 dark:text-rose-400', icon: XCircle },
+  expired: { label: 'Expired', className: 'bg-slate-500/12 text-slate-500 border-slate-500/35 dark:text-slate-400', icon: Clock },
+}
+
+function formatDate(ts: number) {
+  return new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' }).format(new Date(ts))
+}
+
+function SortHeader({
+  label,
+  field,
+  sortField,
+  onSortChange,
+}: {
+  label: string
+  field: SortField
+  sortField: SortField
+  onSortChange: (f: SortField) => void
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => onSortChange(field)}
+      className="inline-flex items-center gap-1.5 text-xs font-semibold uppercase tracking-wide text-muted-foreground hover:text-foreground transition-colors"
+    >
+      <span>{label}</span>
+      <ArrowUpDown className={cn('h-3.5 w-3.5', sortField === field ? 'text-foreground' : 'text-muted-foreground/70')} />
+    </button>
+  )
+}
+
+function Pagination({
+  currentPage,
+  totalPages,
+  totalCount,
+  onPageChange,
+}: {
+  currentPage: number
+  totalPages: number
+  totalCount: number
+  onPageChange: (p: number) => void
+}) {
+  const start = totalCount === 0 ? 0 : (currentPage - 1) * PAGE_SIZE + 1
+  const end = Math.min(currentPage * PAGE_SIZE, totalCount)
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border pt-4">
+      <p className="text-sm text-muted-foreground">Showing {start}–{end} of {totalCount}</p>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" size="sm" onClick={() => onPageChange(Math.max(1, currentPage - 1))} disabled={currentPage === 1} className="h-9 px-3">
+          <ChevronLeft className="h-4 w-4" />Prev
+        </Button>
+        {Array.from({ length: totalPages }).map((_, i) => {
+          const n = i + 1
+          return (
+            <button
+              key={n}
+              type="button"
+              onClick={() => onPageChange(n)}
+              className={cn('h-9 min-w-9 rounded-md px-3 text-sm font-semibold transition-colors', n === currentPage ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground hover:text-foreground')}
+              aria-current={n === currentPage ? 'page' : undefined}
+            >
+              {n}
+            </button>
+          )
+        })}
+        <Button variant="outline" size="sm" onClick={() => onPageChange(Math.min(totalPages, currentPage + 1))} disabled={currentPage === totalPages} className="h-9 px-3">
+          Next<ChevronRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default function AdminUsersPage() {
+  const [quickFilter, setQuickFilter] = useState<QuickFilter>('all')
+  const [sortField, setSortField] = useState<SortField>('joinedAt')
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc')
+  const [page, setPage] = useState(1)
+
+  const quickFilters: Array<{ key: QuickFilter; label: string }> = [
+    { key: 'all', label: 'All Users' },
+    { key: 'approved', label: 'Verified' },
+    { key: 'pending', label: 'Pending KYC' },
+    { key: 'rejected', label: 'Rejected' },
+    { key: 'expired', label: 'Expired' },
+  ]
+
+  const filtered = useMemo(
+    () => mockUsers.filter((u) => quickFilter === 'all' || u.kycStatus === quickFilter),
+    [quickFilter]
+  )
+
+  const sorted = useMemo(() => {
+    return [...filtered].sort((a, b) => {
+      let aVal: string | number = 0
+      let bVal: string | number = 0
+      switch (sortField) {
+        case 'joinedAt': aVal = a.joinedAt; bVal = b.joinedAt; break
+        case 'orderCount': aVal = a.orderCount; bVal = b.orderCount; break
+        case 'totalVolume': aVal = a.totalVolume; bVal = b.totalVolume; break
+        case 'kycStatus': aVal = a.kycStatus; bVal = b.kycStatus; break
+      }
+      const result = typeof aVal === 'string' ? aVal.localeCompare(bVal as string) : Number(aVal) - Number(bVal)
+      return sortDirection === 'asc' ? result : -result
+    })
+  }, [filtered, sortField, sortDirection])
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE))
+  const currentPage = Math.min(page, totalPages)
+  const paginated = useMemo(
+    () => sorted.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE),
+    [sorted, currentPage]
+  )
+
+  const onSortChange = (field: SortField) => {
+    setPage(1)
+    if (sortField === field) { setSortDirection((d) => (d === 'asc' ? 'desc' : 'asc')); return }
+    setSortField(field)
+    setSortDirection('desc')
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-foreground">Users</h1>
+        <p className="text-sm text-muted-foreground mt-1">All registered platform users with KYC status and activity</p>
+      </div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="bg-card rounded-2xl p-6 border border-border shadow-sm"
+      >
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          {quickFilters.map((f) => (
+            <button
+              key={f.key}
+              type="button"
+              onClick={() => { setQuickFilter(f.key); setPage(1) }}
+              className={cn(
+                'h-8 rounded-full border px-3 text-sm font-medium transition-colors',
+                quickFilter === f.key
+                  ? 'bg-primary text-primary-foreground border-primary'
+                  : 'bg-background border-border text-muted-foreground hover:text-foreground hover:bg-muted'
+              )}
+            >
+              {f.label}
+            </button>
+          ))}
+        </div>
+
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[680px]">
+            <thead>
+              <tr className="border-b border-border">
+                <th className="py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">User ID</th>
+                <th className="py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Wallet</th>
+                <th className="py-3 text-left"><SortHeader label="KYC" field="kycStatus" sortField={sortField} onSortChange={onSortChange} /></th>
+                <th className="py-3 text-left"><SortHeader label="Orders" field="orderCount" sortField={sortField} onSortChange={onSortChange} /></th>
+                <th className="py-3 text-left"><SortHeader label="Volume" field="totalVolume" sortField={sortField} onSortChange={onSortChange} /></th>
+                <th className="py-3 text-left"><SortHeader label="Joined" field="joinedAt" sortField={sortField} onSortChange={onSortChange} /></th>
+                <th className="py-3 text-left text-xs font-semibold uppercase tracking-wide text-muted-foreground">Last Active</th>
+              </tr>
+            </thead>
+            <tbody>
+              {paginated.map((user, index) => {
+                const KycIcon = kycConfig[user.kycStatus].icon
+                return (
+                  <motion.tr
+                    key={user.id}
+                    initial={{ opacity: 0, y: 8 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ delay: index * 0.04 }}
+                    className="border-b border-border/70 transition-colors hover:bg-muted/30"
+                  >
+                    <td className="py-4 font-mono text-sm text-foreground">{user.id}</td>
+                    <td className="py-4 font-mono text-xs text-muted-foreground">{user.walletAddress}</td>
+                    <td className="py-4">
+                      <Badge
+                        variant="outline"
+                        className={cn('w-fit rounded-full border px-3 py-1 text-xs font-semibold flex items-center gap-1.5', kycConfig[user.kycStatus].className)}
+                      >
+                        <KycIcon className="h-3.5 w-3.5" />
+                        {kycConfig[user.kycStatus].label}
+                      </Badge>
+                    </td>
+                    <td className="py-4 text-sm font-semibold text-foreground">{user.orderCount}</td>
+                    <td className="py-4 text-sm font-bold text-foreground">
+                      {user.totalVolume > 0 ? `${user.currency} ${user.totalVolume.toLocaleString()}` : '—'}
+                    </td>
+                    <td className="py-4 text-sm text-muted-foreground">{formatDate(user.joinedAt)}</td>
+                    <td className="py-4 text-sm text-muted-foreground">{formatDate(user.lastActiveAt)}</td>
+                  </motion.tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="mt-4">
+          <Pagination currentPage={currentPage} totalPages={totalPages} totalCount={sorted.length} onPageChange={setPage} />
+        </div>
+      </motion.div>
+    </div>
+  )
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -12,6 +12,16 @@ const ratelimit = new Ratelimit({
 })
 
 export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl
+
+  if (pathname.startsWith('/admin')) {
+    const role = request.cookies.get('aframp_role')?.value
+    if (role !== 'admin') {
+      return NextResponse.redirect(new URL('/dashboard', request.url))
+    }
+    return NextResponse.next()
+  }
+
   const ip = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim() ?? '127.0.0.1'
 
   const { success, limit, remaining, reset } = await ratelimit.limit(ip)
@@ -39,5 +49,5 @@ export async function middleware(request: NextRequest) {
 }
 
 export const config = {
-  matcher: '/api/:path*',
+  matcher: ['/api/:path*', '/admin/:path*'],
 }


### PR DESCRIPTION
## Summary

- Guard `/admin` routes in `middleware.ts` via `aframp_role` cookie check; admin requests short-circuit before the existing rate-limit logic; matcher extended to `['/api/:path*', '/admin/:path*']`
- Add `app/admin/layout.tsx` — fixed 240px sidebar (desktop) + horizontal scroll nav bar (mobile) with links to Overview, Orders, KYC Review, Users, and Exit Admin
- Add `app/admin/page.tsx` — overview dashboard with four metric cards (Total Orders, Pending KYC, Active Users, Total Volume) matching the glassmorphism pattern from `components/bills/transaction-stats.tsx`
- Add `app/admin/orders/page.tsx` — order management table using `OnrampOrder` / `OrderStatus` types; quick-filter pills (All / Pending / Minting / Completed / Failed); sortable columns; pagination at 10/page
- Add `app/admin/kyc/page.tsx` — KYC review queue using `KycSubmission` / `KycStatus` types; defaults to Pending Review filter; Approve / Reject buttons update local state immediately; reviewed rows reflect new status in badge
- Add `app/admin/users/page.tsx` — user list with KYC tier, order count, volume, join date, last active; filterable by KYC status; sortable columns

All pages follow existing codebase patterns: `'use client'` components, native HTML `<table>`, framer-motion row stagger, shadcn `Badge` / `Button` / `Card`, `cn()` utility, lucide-react icons.

## Auth note

`/admin` is gated by an `aframp_role` cookie check in middleware. This is placeholder access control for pre-launch scaffolding only — it stops casual navigation but is trivially bypassable client-side and binds to no user identity. All admin pages currently render mock data; no real data is exposed. Before real data is wired in, this must be replaced with proper session-based auth (issued + verified server-side, with per-request authorization enforced at the data-fetch layer, not solely in middleware).

## Test plan

- [ ] Visiting `/admin` without `aframp_role=admin` cookie redirects to `/dashboard`
- [ ] Setting `aframp_role=admin` cookie allows access to all `/admin/*` routes
- [ ] Sidebar active state highlights correct link on each route
- [ ] Mobile nav bar renders and scrolls horizontally on small screens
- [ ] Overview metric cards render with stagger animation
- [ ] Orders page: filter pills narrow table rows correctly; sort toggles asc/desc; pagination advances pages
- [ ] KYC page: defaults to Pending Review; Approve/Reject buttons update badge immediately; reviewed rows move to correct tab on filter switch
- [ ] Users page: KYC filter narrows list; sort by Orders/Volume/Joined works correctly
- [ ] Existing `/api/*` rate limiting is unaffected

Closes #331