### PR TITLE
feat: add AML transaction monitoring, sanctions screening and SAR wor…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,39 @@ LHCI_GITHUB_APP_TOKEN=
 # Get these from https://console.upstash.com after creating a Redis database
 UPSTASH_REDIS_REST_URL=https://<your-upstash-redis-url>.upstash.io
 UPSTASH_REDIS_REST_TOKEN=<your-upstash-redis-token>
+
+# ── AML / Compliance ──────────────────────────────────────────────────────────
+# Transaction monitoring, sanctions screening and SAR workflow.
+# Full operating notes: docs/AML_COMPLIANCE.md
+#
+# Locally, everything below can be left at its default: screening runs against
+# the bundled development fixture list with no vendor account required.  That is
+# NOT true in production — /api/admin/compliance/health reports CRITICAL until a
+# real sanctions snapshot is loaded and a hash salt is set.
+
+# Salt for hashing counterparty identifiers (bank accounts, addresses) before
+# they reach the monitoring ledger.  REQUIRED — screening throws without it.
+# Generate with:  openssl rand -hex 32
+# Must stay stable for the life of the data: rotating it re-keys every
+# counterparty and silently resets fan-out detection.
+COMPLIANCE_HASH_SALT=
+
+# Analyst access to /admin/compliance.  Format: analystId:token,analystId:token
+# Each analyst needs their own token — every case decision is attributed to the
+# id attached to the token that made it.
+# Generate tokens with:  openssl rand -base64 32
+COMPLIANCE_ADMIN_TOKENS=
+
+# Blockchain analytics provider — wallet risk.  chainalysis | elliptic | local
+COMPLIANCE_WALLET_PROVIDER=local
+CHAINALYSIS_API_KEY=
+# CHAINALYSIS_BASE_URL=https://api.chainalysis.com
+ELLIPTIC_API_KEY=
+ELLIPTIC_API_SECRET=
+# ELLIPTIC_BASE_URL=https://aml-api.elliptic.co
+
+# Entity screening provider — sanctions, PEP and adverse media on names.
+# complyadvantage | local
+COMPLIANCE_NAME_PROVIDER=local
+COMPLYADVANTAGE_API_KEY=
+# COMPLYADVANTAGE_BASE_URL=https://api.complyadvantage.com

--- a/app/admin/compliance/page.tsx
+++ b/app/admin/compliance/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next'
+import { ComplianceConsole } from '@/components/admin/compliance-console'
+
+/**
+ * /admin/compliance — internal AML review console.
+ *
+ * `noindex, nofollow` because this page lists customer names, account
+ * identifiers and sanctions determinations.  It is not a substitute for access
+ * control (see lib/compliance/admin-auth.ts) — it just stops the URL from
+ * turning up in a search index if the route is ever reachable from the public
+ * internet.
+ *
+ * The page itself renders nothing sensitive: everything is fetched client-side
+ * with the analyst's bearer token, so an unauthenticated visitor gets a sign-in
+ * form rather than a server-rendered page containing case data.
+ */
+export const metadata: Metadata = {
+  title: 'Compliance console · Aframp',
+  robots: { index: false, follow: false },
+}
+
+export default function ComplianceAdminPage() {
+  return (
+    <main className="mx-auto max-w-5xl px-4 py-8">
+      <ComplianceConsole />
+    </main>
+  )
+}

--- a/app/api/admin/compliance/cases/[caseId]/route.ts
+++ b/app/api/admin/compliance/cases/[caseId]/route.ts
@@ -1,0 +1,137 @@
+/**
+ * /api/admin/compliance/cases/[caseId]
+ *
+ * GET    Full case file — signals, evidence metadata and the audit trail.
+ *
+ * PATCH  Records an analyst action.  One of:
+ *          { action: "assign" }
+ *          { action: "note",   note: string }
+ *          { action: "decide", status, disposition?, rationale }
+ *          { action: "reopen", reason: string }
+ *
+ *        The acting analyst comes from the bearer token, never from the body —
+ *        letting a caller name the actor would make the audit trail worthless.
+ *
+ * 200 { case }
+ * 400 invalid body
+ * 401 / 403 auth
+ * 404 no such case
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { authenticateAdmin } from '@/lib/compliance/admin-auth'
+import {
+  addCaseNote,
+  assignCase,
+  decideCase,
+  getCase,
+  reopenCase,
+  retentionExpiryFor,
+} from '@/lib/compliance/case-store'
+
+const NO_STORE = { 'Cache-Control': 'no-store, private' }
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ caseId: string }> }
+) {
+  const auth = authenticateAdmin(request)
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const { caseId } = await params
+  const record = getCase(caseId)
+  if (!record) {
+    return NextResponse.json({ error: 'Case not found' }, { status: 404 })
+  }
+
+  return NextResponse.json(
+    { case: record, retentionExpiresAt: retentionExpiryFor(record) },
+    { status: 200, headers: NO_STORE }
+  )
+}
+
+/**
+ * Discriminated on `action` so each variant validates only its own fields —
+ * `rationale` is required for a decision and meaningless for an assignment,
+ * and a single flat schema could not express that.
+ */
+const PatchSchema = z.discriminatedUnion('action', [
+  z.object({ action: z.literal('assign') }),
+  z.object({
+    action: z.literal('note'),
+    note: z.string().trim().min(1).max(4_000),
+  }),
+  z.object({
+    action: z.literal('decide'),
+    status: z.enum(['CLEARED', 'CONFIRMED_SUSPICIOUS', 'ESCALATED']),
+    disposition: z.enum(['FALSE_POSITIVE', 'TRUE_POSITIVE', 'INCONCLUSIVE']).optional(),
+    // Non-empty by schema: closing an alert with no recorded reason is the
+    // single most common examination finding against a monitoring programme.
+    rationale: z.string().trim().min(1).max(4_000),
+  }),
+  z.object({
+    action: z.literal('reopen'),
+    reason: z.string().trim().min(1).max(4_000),
+  }),
+])
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ caseId: string }> }
+) {
+  const auth = authenticateAdmin(request)
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const { caseId } = await params
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const parsed = PatchSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid request', details: parsed.error.flatten() },
+      { status: 400 }
+    )
+  }
+
+  const { analystId } = auth.identity
+  const input = parsed.data
+
+  let updated
+  switch (input.action) {
+    case 'assign':
+      updated = assignCase(caseId, analystId)
+      break
+    case 'note':
+      updated = addCaseNote(caseId, analystId, input.note)
+      break
+    case 'decide':
+      updated = decideCase({
+        caseId,
+        analystId,
+        status: input.status,
+        disposition: input.disposition,
+        rationale: input.rationale,
+      })
+      break
+    case 'reopen':
+      updated = reopenCase(caseId, analystId, input.reason)
+      break
+  }
+
+  if (!updated) {
+    return NextResponse.json({ error: 'Case not found' }, { status: 404 })
+  }
+
+  return NextResponse.json({ case: updated }, { status: 200, headers: NO_STORE })
+}

--- a/app/api/admin/compliance/cases/route.ts
+++ b/app/api/admin/compliance/cases/route.ts
@@ -1,0 +1,79 @@
+/**
+ * GET /api/admin/compliance/cases
+ *
+ * The analyst work queue.  Lists flagged transactions with filters and paging,
+ * plus the summary counts the console header shows.
+ *
+ * Query:
+ *   status?       OPEN | IN_REVIEW | ESCALATED | CLEARED | CONFIRMED_SUSPICIOUS
+ *   jurisdiction? NG | KE | GH | ZA | UG
+ *   assignedTo?   analyst id
+ *   userId?       wallet address — every case for one account
+ *   minRiskScore? 0-100
+ *   limit?        1-100 (default 25)
+ *   offset?       default 0
+ *
+ * 200 { cases, total, stats }
+ * 401 missing/invalid bearer token
+ * 403 console not provisioned
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { authenticateAdmin } from '@/lib/compliance/admin-auth'
+import { getCaseStats, listCases } from '@/lib/compliance/case-store'
+
+const QuerySchema = z.object({
+  status: z
+    .enum(['OPEN', 'IN_REVIEW', 'ESCALATED', 'CLEARED', 'CONFIRMED_SUSPICIOUS'])
+    .optional(),
+  jurisdiction: z.enum(['NG', 'KE', 'GH', 'ZA', 'UG']).optional(),
+  assignedTo: z.string().trim().min(1).max(64).optional(),
+  userId: z.string().trim().min(1).max(128).optional(),
+  minRiskScore: z.coerce.number().int().min(0).max(100).optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(25),
+  offset: z.coerce.number().int().min(0).default(0),
+})
+
+export function GET(request: NextRequest) {
+  const auth = authenticateAdmin(request)
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const { searchParams } = request.nextUrl
+  const parsed = QuerySchema.safeParse({
+    status: searchParams.get('status') ?? undefined,
+    jurisdiction: searchParams.get('jurisdiction') ?? undefined,
+    assignedTo: searchParams.get('assignedTo') ?? undefined,
+    userId: searchParams.get('userId') ?? undefined,
+    minRiskScore: searchParams.get('minRiskScore') ?? undefined,
+    limit: searchParams.get('limit') ?? undefined,
+    offset: searchParams.get('offset') ?? undefined,
+  })
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid query', details: parsed.error.flatten() },
+      { status: 400 }
+    )
+  }
+
+  const { cases, total } = listCases(parsed.data)
+
+  return NextResponse.json(
+    {
+      cases,
+      total,
+      // Returned alongside the page so the header counts stay consistent with
+      // the rows — two round trips would let them drift mid-triage.
+      stats: getCaseStats(),
+    },
+    {
+      status: 200,
+      // Case data is customer PII under a live investigation.  Nothing between
+      // here and the analyst's browser may retain a copy.
+      headers: { 'Cache-Control': 'no-store, private' },
+    }
+  )
+}

--- a/app/api/admin/compliance/health/route.ts
+++ b/app/api/admin/compliance/health/route.ts
@@ -1,0 +1,85 @@
+/**
+ * GET /api/admin/compliance/health
+ *
+ * Reports whether the AML controls are actually operating, as opposed to
+ * merely deployed.
+ *
+ * This endpoint exists because every failure mode in this module is silent by
+ * nature.  Screening against a stale sanctions list, or against the development
+ * fixture, produces clean results that look identical to genuinely clean ones.
+ * A control that cannot be observed cannot be relied on, and "we didn't know it
+ * had stopped working" is not a defence anyone has successfully run.
+ *
+ * 200 { status, checks }  — status is OK | DEGRADED | CRITICAL
+ * 401 / 403 auth
+ *
+ * `status` is deliberately CRITICAL, not DEGRADED, when the list is a fixture:
+ * that state means there is effectively no sanctions screening at all.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { authenticateAdmin } from '@/lib/compliance/admin-auth'
+import { FAIL_CLOSED } from '@/lib/compliance/config'
+import { isRunningOnLocalOnly } from '@/lib/compliance/providers'
+import { getSnapshotStatus } from '@/lib/compliance/sanctions/list'
+import { getCaseStats } from '@/lib/compliance/case-store'
+
+/**
+ * Days after which a sanctions snapshot is considered stale.
+ *
+ * OFAC and the UN amend their lists several times a week, and designations take
+ * effect on publication — not on our next refresh — so a week-old list is a
+ * week of transactions screened against the wrong corpus.
+ */
+const SNAPSHOT_STALE_DAYS = 7
+
+export function GET(request: NextRequest) {
+  const auth = authenticateAdmin(request)
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const snapshot = getSnapshotStatus()
+  const localOnly = isRunningOnLocalOnly()
+  const stats = getCaseStats()
+
+  const checks = {
+    sanctionsList: {
+      loaded: snapshot.loaded,
+      generatedAt: snapshot.generatedAt,
+      ageDays: snapshot.ageDays,
+      entityCount: snapshot.entityCount,
+      addressCount: snapshot.addressCount,
+      stale: snapshot.ageDays != null && snapshot.ageDays > SNAPSHOT_STALE_DAYS,
+    },
+    providers: {
+      wallet: process.env.COMPLIANCE_WALLET_PROVIDER ?? 'local',
+      name: process.env.COMPLIANCE_NAME_PROVIDER ?? 'local',
+      localOnly,
+    },
+    policy: {
+      failClosed: FAIL_CLOSED,
+      hashSaltConfigured: Boolean(process.env.COMPLIANCE_HASH_SALT),
+    },
+    queue: {
+      openCases: stats.byStatus.OPEN + stats.byStatus.IN_REVIEW + stats.byStatus.ESCALATED,
+      overdueFilings: stats.overdueFilings,
+    },
+  }
+
+  // An overdue filing is a live regulatory breach, not a warning — it is graded
+  // alongside the outright control failures.
+  const critical =
+    !checks.sanctionsList.loaded ||
+    !checks.policy.hashSaltConfigured ||
+    checks.queue.overdueFilings > 0
+
+  const degraded = checks.sanctionsList.stale || localOnly || !FAIL_CLOSED
+
+  const status = critical ? 'CRITICAL' : degraded ? 'DEGRADED' : 'OK'
+
+  return NextResponse.json(
+    { status, checks },
+    { status: 200, headers: { 'Cache-Control': 'no-store, private' } }
+  )
+}

--- a/app/api/admin/compliance/sars/route.ts
+++ b/app/api/admin/compliance/sars/route.ts
@@ -1,0 +1,136 @@
+/**
+ * /api/admin/compliance/sars
+ *
+ * GET   Lists SAR/STR filings, soonest deadline first.
+ *
+ *   Query: ?status=DRAFT|SUBMITTED|ACKNOWLEDGED|REJECTED
+ *          &jurisdiction=NG|KE|GH|ZA|UG
+ *          &overdueOnly=true
+ *   200:   { sars }
+ *
+ * POST  Drafts a SAR against a case, or advances an existing one.
+ *
+ *   Draft:   { caseId, narrative }
+ *   Advance: { sarId, status, regulatorReference? }
+ *   200:     { sar }
+ *   409:     the case already has a SAR, or the status transition is invalid
+ *
+ * The filing deadline is computed from when suspicion was formed — the case's
+ * creation — not from when the analyst opened the draft.  See draftSar().
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { authenticateAdmin } from '@/lib/compliance/admin-auth'
+import { SarError, draftSar, listSars, updateSarStatus } from '@/lib/compliance/case-store'
+import { JURISDICTIONS } from '@/lib/compliance/config'
+
+const NO_STORE = { 'Cache-Control': 'no-store, private' }
+
+const QuerySchema = z.object({
+  status: z.enum(['DRAFT', 'SUBMITTED', 'ACKNOWLEDGED', 'REJECTED']).optional(),
+  jurisdiction: z.enum(['NG', 'KE', 'GH', 'ZA', 'UG']).optional(),
+  overdueOnly: z
+    .enum(['true', 'false'])
+    .transform((v) => v === 'true')
+    .optional(),
+  limit: z.coerce.number().int().min(1).max(100).default(50),
+})
+
+export function GET(request: NextRequest) {
+  const auth = authenticateAdmin(request)
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  const { searchParams } = request.nextUrl
+  const parsed = QuerySchema.safeParse({
+    status: searchParams.get('status') ?? undefined,
+    jurisdiction: searchParams.get('jurisdiction') ?? undefined,
+    overdueOnly: searchParams.get('overdueOnly') ?? undefined,
+    limit: searchParams.get('limit') ?? undefined,
+  })
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid query', details: parsed.error.flatten() },
+      { status: 400 }
+    )
+  }
+
+  return NextResponse.json(
+    {
+      sars: listSars(parsed.data),
+      // The console renders regulator names and filing windows next to each
+      // row; shipping the policy table avoids duplicating it client-side where
+      // it would drift from config.ts.
+      jurisdictions: JURISDICTIONS,
+    },
+    { status: 200, headers: NO_STORE }
+  )
+}
+
+const BodySchema = z.discriminatedUnion('action', [
+  z.object({
+    action: z.literal('draft'),
+    caseId: z.string().trim().min(1).max(64),
+    // A filing is the narrative — a bare form with no explanation is not a
+    // report, so this has a real minimum length rather than min(1).
+    narrative: z.string().trim().min(50).max(20_000),
+  }),
+  z.object({
+    action: z.literal('advance'),
+    sarId: z.string().trim().min(1).max(64),
+    status: z.enum(['SUBMITTED', 'ACKNOWLEDGED', 'REJECTED']),
+    regulatorReference: z.string().trim().min(1).max(128).optional(),
+  }),
+])
+
+export async function POST(request: NextRequest) {
+  const auth = authenticateAdmin(request)
+  if (!auth.ok) {
+    return NextResponse.json({ error: auth.error }, { status: auth.status })
+  }
+
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const parsed = BodySchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid request', details: parsed.error.flatten() },
+      { status: 400 }
+    )
+  }
+
+  const { analystId } = auth.identity
+
+  try {
+    const sar =
+      parsed.data.action === 'draft'
+        ? draftSar({
+            caseId: parsed.data.caseId,
+            analystId,
+            narrative: parsed.data.narrative,
+          })
+        : updateSarStatus(
+            parsed.data.sarId,
+            analystId,
+            parsed.data.status,
+            parsed.data.regulatorReference
+          )
+
+    return NextResponse.json({ sar }, { status: 200, headers: NO_STORE })
+  } catch (error) {
+    if (error instanceof SarError) {
+      const status =
+        error.code === 'CASE_NOT_FOUND' || error.code === 'SAR_NOT_FOUND' ? 404 : 409
+      return NextResponse.json({ error: error.code, message: error.message }, { status })
+    }
+    throw error
+  }
+}

--- a/app/api/bills/initiate/route.ts
+++ b/app/api/bills/initiate/route.ts
@@ -1,10 +1,45 @@
+/**
+ * POST /api/bills/initiate
+ *
+ * Initiates a bill payment through the selected gateway.  Screens before
+ * handing anything to the gateway — same control and same entry point as
+ * /api/withdrawals and /api/payments/mobile-money/initiate.
+ *
+ * Bill payment is a genuine laundering channel, not an afterthought: paying a
+ * third party's utility or airtime account settles value to someone other than
+ * the payer, which is exactly what a mule network wants.  The biller account
+ * number is therefore screened as the counterparty, so fan-out across many
+ * distinct bill accounts registers the way fan-out across bank accounts does.
+ *
+ * Request body extends BillPaymentFormData with optional screening inputs:
+ *   userId?   — wallet public key when connected; falls back to hashed email
+ *   currency? — ISO 4217, defaults to NGN as the gateway call does
+ *
+ * 200 { success, authorization_url, reference }
+ * 400 missing required fields
+ * 403 held or blocked by screening   (COMPLIANCE_BLOCKED)
+ * 422 unsupported market
+ * 500 gateway failure
+ * 503 screening could not be performed
+ */
+
 import { NextRequest, NextResponse } from 'next/server'
 import { getPaymentGatewayService } from '@/lib/bills/payment-gateway'
 import { BillPaymentFormData } from '@/lib/bills/types'
+import { screenTransaction } from '@/lib/compliance/monitor'
+import { payerIdentity } from '@/lib/compliance/identity'
+import { resolveMarket, toUsdCents, UnsupportedMarketError } from '@/lib/compliance/markets'
+
+interface BillInitiateBody extends BillPaymentFormData {
+  /** Wallet public key, when the payer has one connected. */
+  userId?: string
+  /** ISO 4217.  Defaults to NGN, matching the gateway call below. */
+  currency?: string
+}
 
 export async function POST(request: NextRequest) {
   try {
-    const body: BillPaymentFormData = await request.json()
+    const body: BillInitiateBody = await request.json()
 
     // Validate required fields
     if (!body.billerId || !body.accountNumber || !body.amount || !body.customerEmail) {
@@ -17,6 +52,61 @@ export async function POST(request: NextRequest) {
     // Generate unique reference
     const reference = `BILL-${Date.now()}-${Math.random().toString(36).substring(7).toUpperCase()}`
 
+    const currency = (body.currency || 'NGN').toUpperCase()
+
+    // -- AML screening --------------------------------------------------------
+    let screening
+    try {
+      screening = await screenTransaction({
+        transactionId: reference,
+        // Email is the only payer identifier every bill payment carries.  See
+        // lib/compliance/identity.ts for why a per-request id will not do.
+        userId: body.userId ?? payerIdentity('email', body.customerEmail),
+        kind: 'billpay',
+        amountCents: toUsdCents(body.amount, currency),
+        asset: currency,
+        chain: 'fiat',
+        jurisdiction: resolveMarket(currency),
+        accountNumber: body.accountNumber,
+        // The biller account is the counterparty — one payer settling to many
+        // distinct bill accounts is the fan-out pattern the rule looks for.
+        counterpartyId: `${body.billerId}:${body.accountNumber}`,
+      })
+    } catch (error) {
+      if (error instanceof UnsupportedMarketError) {
+        return NextResponse.json(
+          {
+            error: 'UNSUPPORTED_MARKET',
+            message: `Bill payments in ${error.currency} are not available.`,
+          },
+          { status: 422 }
+        )
+      }
+
+      console.error('[bills/initiate] screening failed', error)
+      return NextResponse.json(
+        {
+          error: 'SCREENING_UNAVAILABLE',
+          message: 'We could not complete required checks. Please try again shortly.',
+        },
+        { status: 503 }
+      )
+    }
+
+    if (screening.decision === 'BLOCK' || screening.decision === 'REVIEW') {
+      // Identical response for both — see the tipping-off note in
+      // app/api/withdrawals/route.ts.
+      return NextResponse.json(
+        {
+          error: 'COMPLIANCE_BLOCKED',
+          message:
+            'This payment is being reviewed by our compliance team. We will contact you if anything further is needed.',
+          referenceId: screening.caseId,
+        },
+        { status: 403 }
+      )
+    }
+
     // Initialize payment with selected gateway
     const gateway = body.gateway || 'paystack'
     const paymentService = getPaymentGatewayService(gateway)
@@ -24,7 +114,7 @@ export async function POST(request: NextRequest) {
     const paymentData = {
       email: body.customerEmail,
       amount: body.amount,
-      currency: 'NGN', // Default to NGN, can be made dynamic
+      currency,
       reference,
       metadata: {
         billerId: body.billerId,

--- a/app/api/compliance/screen/route.ts
+++ b/app/api/compliance/screen/route.ts
@@ -1,0 +1,116 @@
+/**
+ * POST /api/compliance/screen
+ *
+ * Screens a transaction for AML risk and returns the decision.  This is the
+ * server-side control — the frontend cannot bypass it, and no payment path may
+ * form its own view of risk.
+ *
+ * Request body (JSON):
+ *   {
+ *     transactionId: string
+ *     userId:        string    — wallet public key
+ *     kind:          "onramp" | "offramp" | "billpay"
+ *     amountCents:   number    — integer USD cents
+ *     asset:         string
+ *     chain:         string
+ *     jurisdiction:  "NG" | "KE" | "GH" | "ZA" | "UG"
+ *     walletAddress?: string   — counterparty address
+ *     accountName?:   string   — bank / mobile-money account holder
+ *     accountNumber?: string   — hashed before storage, never persisted raw
+ *     kycTier?:       string
+ *   }
+ *
+ * 200 { decision, riskScore, riskLevel, signals, caseId? }
+ *     ALLOW  — caller proceeds
+ *     REVIEW — caller must hold the transaction; a case is open
+ *     BLOCK  — caller must reject
+ * 400 invalid body
+ * 503 screening could not be performed (see the note on fail-closed below)
+ *
+ * The response is intentionally verbose about *why* a transaction was flagged.
+ * That detail is for the caller's audit log, not for the end user — surfacing
+ * signal detail to a customer tells them which threshold to stay under next
+ * time, and in most jurisdictions telling the subject of a SAR that they are
+ * under review is itself an offence ("tipping off").  See the note in
+ * app/api/withdrawals/route.ts for what the user-facing message should say.
+ */
+
+import { NextRequest, NextResponse } from 'next/server'
+import { z } from 'zod'
+import { screenTransaction } from '@/lib/compliance/monitor'
+import type { ScreeningSubject } from '@/lib/compliance/types'
+
+const RequestSchema = z.object({
+  transactionId: z.string().trim().min(1).max(128),
+  userId: z.string().trim().min(1).max(128),
+  kind: z.enum(['onramp', 'offramp', 'billpay']),
+  amountCents: z.number().int().positive(),
+  asset: z.string().trim().min(1).max(32),
+  chain: z.string().trim().min(1).max(32),
+  jurisdiction: z.enum(['NG', 'KE', 'GH', 'ZA', 'UG']),
+  walletAddress: z.string().trim().min(1).max(128).optional(),
+  accountName: z.string().trim().min(1).max(256).optional(),
+  accountNumber: z.string().trim().min(1).max(64).optional(),
+  counterpartyId: z.string().trim().min(1).max(256).optional(),
+  kycTier: z.string().trim().max(32).optional(),
+  accountCreatedAt: z.coerce.date().optional(),
+})
+
+export async function POST(request: NextRequest) {
+  let body: unknown
+  try {
+    body = await request.json()
+  } catch {
+    return NextResponse.json({ error: 'Invalid JSON body' }, { status: 400 })
+  }
+
+  const parsed = RequestSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid request', details: parsed.error.flatten() },
+      { status: 400 }
+    )
+  }
+
+  const subject: ScreeningSubject = {
+    ...parsed.data,
+    // Fall back to the counterparty identifiers the transaction already
+    // carries, so fan-out detection works without every caller having to
+    // construct a key itself.
+    counterpartyId:
+      parsed.data.counterpartyId ??
+      parsed.data.accountNumber ??
+      parsed.data.walletAddress,
+  }
+
+  try {
+    const result = await screenTransaction(subject)
+
+    return NextResponse.json(
+      {
+        transactionId: result.transactionId,
+        decision: result.decision,
+        riskScore: result.riskScore,
+        riskLevel: result.riskLevel,
+        signals: result.signals,
+        caseId: result.caseId,
+        screenedAt: result.screenedAt,
+      },
+      { status: 200 }
+    )
+  } catch (error) {
+    // screenTransaction() does not throw for compliance outcomes — a BLOCK is a
+    // return value.  Reaching here means the control itself is broken
+    // (misconfigured provider, missing hash salt), and the only safe response
+    // is to refuse the transaction rather than let it proceed unscreened.
+    console.error('[compliance] screening failed', error)
+
+    return NextResponse.json(
+      {
+        error: 'SCREENING_UNAVAILABLE',
+        message: 'Transaction screening could not be completed. Please try again.',
+      },
+      { status: 503 }
+    )
+  }
+}

--- a/app/api/payments/mobile-money/initiate/route.ts
+++ b/app/api/payments/mobile-money/initiate/route.ts
@@ -1,7 +1,49 @@
+/**
+ * POST /api/payments/mobile-money/initiate
+ *
+ * Initiates an M-Pesa / MTN MoMo collection.  This is a money-movement path, so
+ * it screens before it debits — same control and same entry point as
+ * /api/withdrawals, and for the same reason: a payment route may act on a
+ * screening decision but must never form its own view of risk.
+ *
+ * Screening runs *before* the provider call, not after.  An STK push that has
+ * already prompted the customer's handset has moved money as far as they are
+ * concerned; holding it afterwards means reversing a settled collection rather
+ * than declining an attempt.
+ *
+ * Request body (JSON):
+ *   {
+ *     provider:         "mpesa" | "mtn_momo"
+ *     phoneNumber:      string  — E.164, e.g. +254712345678
+ *     amount:           number  — major units of `currency`
+ *     currency:         string  — ISO 4217; determines which market's AML
+ *                                 policy applies (see resolveMarket())
+ *     accountReference: string
+ *     transactionDesc:  string
+ *     externalId:       string  — caller's idempotency key; also the id the
+ *                                 case file and the ledger reference
+ *     kind?:            "onramp" | "billpay"   — defaults to "onramp"
+ *     userId?:          string  — wallet public key when one is connected;
+ *                                 falls back to the hashed payer MSISDN
+ *     accountName?:     string  — payer name where the caller knows it;
+ *                                 screened against sanctions and PEP lists
+ *     kycTier?:         string
+ *   }
+ *
+ * 202 { transactionId, status, provider }
+ * 400 invalid JSON
+ * 403 held or blocked by screening   (COMPLIANCE_BLOCKED)
+ * 422 validation failed, unsupported market, or provider rejection
+ * 503 screening could not be performed
+ */
+
 import { NextRequest, NextResponse } from 'next/server'
 import { z } from 'zod'
 import { getProvider, MobileMoneyError } from '@/lib/payments'
 import type { MobileMoneyProviderName } from '@/lib/payments'
+import { screenTransaction } from '@/lib/compliance/monitor'
+import { payerIdentity } from '@/lib/compliance/identity'
+import { resolveMarket, toUsdCents, UnsupportedMarketError } from '@/lib/compliance/markets'
 
 const bodySchema = z.object({
   provider: z.enum(['mpesa', 'mtn_momo']),
@@ -13,6 +55,12 @@ const bodySchema = z.object({
   accountReference: z.string().min(1).max(12),
   transactionDesc: z.string().min(1).max(13),
   externalId: z.string().min(1),
+  // Screening inputs.  Optional so existing callers keep working; the route
+  // degrades to a hashed-MSISDN identity rather than skipping the control.
+  kind: z.enum(['onramp', 'billpay']).default('onramp'),
+  userId: z.string().trim().min(1).max(128).optional(),
+  accountName: z.string().trim().min(1).max(256).optional(),
+  kycTier: z.string().trim().max(32).optional(),
 })
 
 export async function POST(request: NextRequest) {
@@ -31,8 +79,67 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const { provider: providerName, ...params } = parsed.data
+  const { provider: providerName, kind, userId, accountName, kycTier, ...params } = parsed.data
 
+  // -- 1. AML screening -------------------------------------------------------
+  let screening
+  try {
+    screening = await screenTransaction({
+      transactionId: params.externalId,
+      // Velocity and fan-out rules only mean anything if the same human keys to
+      // the same id across legs.  A connected wallet is that id; without one,
+      // the MSISDN is the most stable payer identifier this route has, hashed
+      // so the ledger never holds a raw phone number.
+      userId: userId ?? payerIdentity('msisdn', params.phoneNumber),
+      kind,
+      amountCents: toUsdCents(params.amount, params.currency),
+      asset: params.currency.toUpperCase(),
+      chain: 'fiat',
+      jurisdiction: resolveMarket(params.currency),
+      accountName,
+      accountNumber: params.phoneNumber,
+      counterpartyId: params.phoneNumber,
+      kycTier,
+    })
+  } catch (error) {
+    // A currency we hold no policy for is a client error, not an outage: there
+    // is no threshold to measure the payment against, so it cannot be screened
+    // and must not be collected.
+    if (error instanceof UnsupportedMarketError) {
+      return NextResponse.json(
+        {
+          error: 'UNSUPPORTED_MARKET',
+          message: `Payments in ${error.currency} are not available.`,
+        },
+        { status: 422 }
+      )
+    }
+
+    console.error('[mobile-money/initiate] screening failed', error)
+    return NextResponse.json(
+      {
+        error: 'SCREENING_UNAVAILABLE',
+        message: 'We could not complete required checks. Please try again shortly.',
+      },
+      { status: 503 }
+    )
+  }
+
+  if (screening.decision === 'BLOCK' || screening.decision === 'REVIEW') {
+    // Identical response for both, deliberately — see the tipping-off note in
+    // app/api/withdrawals/route.ts.
+    return NextResponse.json(
+      {
+        error: 'COMPLIANCE_BLOCKED',
+        message:
+          'This payment is being reviewed by our compliance team. We will contact you if anything further is needed.',
+        referenceId: screening.caseId,
+      },
+      { status: 403 }
+    )
+  }
+
+  // -- 2. Collect -------------------------------------------------------------
   try {
     const provider = getProvider(providerName as MobileMoneyProviderName)
     const result = await provider.initiatePayment(params)

--- a/app/api/withdrawals/route.ts
+++ b/app/api/withdrawals/route.ts
@@ -1,8 +1,16 @@
 /**
  * POST /api/withdrawals
  *
- * Initiates a fiat withdrawal (offramp).  The KYC-tier limit is enforced here
- * on the backend — the frontend cannot bypass it.
+ * Initiates a fiat withdrawal (offramp).  Two independent controls run here on
+ * the backend, and the frontend cannot bypass either:
+ *
+ *   1. **KYC tier limit** — how much this customer is permitted to move.
+ *   2. **AML screening**  — whether this particular movement is suspicious.
+ *
+ * They are separate on purpose.  A customer well inside their limit can still
+ * be structuring; a customer over their limit is not thereby suspicious.  The
+ * limit check runs first because it is local and cheap, so an over-limit
+ * request never spends a paid screening call.
  *
  * Request body (JSON):
  *   {
@@ -11,13 +19,24 @@
  *     asset:       string   — e.g. "cNGN", "USDC"
  *     chain:       string   — e.g. "Stellar"
  *     kycTier:     KycTier  — "TIER_0" | "TIER_1" | "TIER_2" | "TIER_3"
+ *     jurisdiction: "NG" | "KE" | "GH" | "ZA" | "UG"
+ *                            — required: reporting thresholds and SAR filing
+ *                              deadlines are per-market, so screening cannot be
+ *                              performed correctly without it
+ *     accountName?:   string — bank / mobile-money account holder; screened
+ *                              against sanctions and PEP lists
+ *     accountNumber?: string — destination account; hashed before it reaches
+ *                              the monitoring ledger, never stored raw
+ *     walletAddress?: string — counterparty address; screened for wallet risk
  *   }
  *
  * Success 200:
- *   { orderId, remaining, resetAt }
+ *   { orderId, status, remaining, resetAt }
  *
  * Error 400: invalid request body
- * Error 403: limit exceeded or KYC required  (WithdrawalLimitError body)
+ * Error 403: limit exceeded or KYC required   (WithdrawalLimitError body)
+ * Error 403: held or blocked by screening     (COMPLIANCE_BLOCKED body)
+ * Error 503: screening could not be performed
  */
 
 import { NextRequest, NextResponse } from 'next/server'
@@ -25,6 +44,7 @@ import { z } from 'zod'
 import { canWithdraw } from '@/lib/kyc/withdrawalLimitService'
 import { WithdrawalLimitError } from '@/lib/kyc/errors'
 import { isKycTier } from '@/lib/kyc/tiers'
+import { screenTransaction } from '@/lib/compliance/monitor'
 
 const RequestSchema = z.object({
   userId: z.string().min(1),
@@ -32,6 +52,10 @@ const RequestSchema = z.object({
   asset: z.string().min(1),
   chain: z.string().min(1),
   kycTier: z.string().refine(isKycTier, { message: 'Invalid KYC tier' }),
+  jurisdiction: z.enum(['NG', 'KE', 'GH', 'ZA', 'UG']),
+  accountName: z.string().trim().min(1).max(256).optional(),
+  accountNumber: z.string().trim().min(1).max(64).optional(),
+  walletAddress: z.string().trim().min(1).max(128).optional(),
 })
 
 export async function POST(request: NextRequest) {
@@ -50,8 +74,19 @@ export async function POST(request: NextRequest) {
     )
   }
 
-  const { userId, amountCents, asset, chain, kycTier } = parsed.data
+  const {
+    userId,
+    amountCents,
+    asset,
+    chain,
+    kycTier,
+    jurisdiction,
+    accountName,
+    accountNumber,
+    walletAddress,
+  } = parsed.data
 
+  // -- 1. KYC tier limit ------------------------------------------------------
   // Enforce the rolling 24-hour limit — this is the source of truth.
   const result = await canWithdraw(userId, amountCents, kycTier)
 
@@ -66,10 +101,68 @@ export async function POST(request: NextRequest) {
     return NextResponse.json(limitError.toResponseBody(), { status: 403 })
   }
 
-  // Limit check passed — proceed with order creation.
-  // In production: persist the order to the DB, trigger the settlement flow.
+  // The id is minted before screening so the case file and the monitoring
+  // ledger reference the same transaction the customer sees.
   const orderId = `OFF-${Date.now()}-${Math.random().toString(36).slice(2, 8).toUpperCase()}`
 
+  // -- 2. AML screening -------------------------------------------------------
+  let screening
+  try {
+    screening = await screenTransaction({
+      transactionId: orderId,
+      userId,
+      kind: 'offramp',
+      amountCents,
+      asset,
+      chain,
+      jurisdiction,
+      accountName,
+      accountNumber,
+      walletAddress,
+      counterpartyId: accountNumber ?? walletAddress,
+      kycTier,
+    })
+  } catch (error) {
+    // Screening is broken rather than adverse — a misconfigured provider or a
+    // missing hash salt.  Refuse the withdrawal instead of settling it
+    // unscreened, which is the exact failure this module exists to prevent.
+    console.error('[withdrawals] screening failed', error)
+    return NextResponse.json(
+      {
+        error: 'SCREENING_UNAVAILABLE',
+        message: 'We could not complete required checks. Please try again shortly.',
+      },
+      { status: 503 }
+    )
+  }
+
+  if (screening.decision === 'BLOCK' || screening.decision === 'REVIEW') {
+    /*
+     * BLOCK and REVIEW deliberately return the same response.
+     *
+     * Telling the customer which rule fired hands anyone probing our
+     * thresholds a map of exactly where they sit.  More seriously, in all five
+     * markets it is a separate criminal offence to tell the subject of a
+     * suspicious-activity report that they are being reported ("tipping off"),
+     * and a message distinguishing "under review" from "declined" leaks
+     * precisely that.  The reasoning lives on the case file, which only
+     * analysts can read.
+     */
+    return NextResponse.json(
+      {
+        error: 'COMPLIANCE_BLOCKED',
+        message:
+          'This withdrawal is being reviewed by our compliance team. We will contact you if anything further is needed.',
+        // Safe to return: lets support correlate a customer enquiry to a case
+        // without revealing anything about why it was flagged.
+        referenceId: screening.caseId,
+      },
+      { status: 403 }
+    )
+  }
+
+  // Both controls passed — proceed with order creation.
+  // In production: persist the order to the DB, trigger the settlement flow.
   return NextResponse.json(
     {
       orderId,

--- a/components/admin/case-detail.tsx
+++ b/components/admin/case-detail.tsx
@@ -1,0 +1,393 @@
+'use client'
+
+/**
+ * Case detail — the analyst's working view of one flagged transaction.
+ *
+ * Layout follows the order an analyst actually works in:
+ *
+ *   1. What fired, and how strongly       (signals, with their evidence)
+ *   2. What has already been done         (audit trail)
+ *   3. What I am doing about it           (actions)
+ *
+ * Every signal renders its own `metadata` verbatim.  That is deliberate: a
+ * screening decision an analyst cannot reconstruct is one they cannot defend,
+ * and hiding the observed values behind a friendly summary is how alert review
+ * degrades into rubber-stamping.
+ */
+
+import { useState } from 'react'
+import {
+  AlertTriangle,
+  ArrowLeft,
+  CheckCircle2,
+  FileWarning,
+  Loader2,
+  ShieldAlert,
+  UserCheck,
+} from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Separator } from '@/components/ui/separator'
+import { Textarea } from '@/components/ui/textarea'
+import { cn } from '@/lib/utils'
+import {
+  actOnCase,
+  draftSar,
+  type CaseAction,
+} from '@/lib/compliance/admin-client'
+import type { ComplianceCase, RiskLevel, RiskSignal } from '@/lib/compliance/types'
+
+const RISK_STYLES: Record<RiskLevel, string> = {
+  LOW: 'bg-emerald-500/10 text-emerald-600 border-emerald-500/20',
+  MEDIUM: 'bg-amber-500/10 text-amber-600 border-amber-500/20',
+  HIGH: 'bg-orange-500/10 text-orange-600 border-orange-500/20',
+  SEVERE: 'bg-red-500/10 text-red-600 border-red-500/20',
+}
+
+interface CaseDetailProps {
+  record: ComplianceCase
+  onBack: () => void
+  onUpdated: (updated: ComplianceCase) => void
+}
+
+export function CaseDetail({ record, onBack, onUpdated }: CaseDetailProps) {
+  const [busy, setBusy] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [note, setNote] = useState('')
+  const [rationale, setRationale] = useState('')
+  const [narrative, setNarrative] = useState('')
+  const [sarDrafted, setSarDrafted] = useState(false)
+
+  const closed = record.status === 'CLEARED' || record.status === 'CONFIRMED_SUSPICIOUS'
+
+  async function run(label: string, action: () => Promise<void>) {
+    setBusy(label)
+    setError(null)
+    try {
+      await action()
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Action failed')
+    } finally {
+      setBusy(null)
+    }
+  }
+
+  const act = (label: string, action: CaseAction) =>
+    run(label, async () => {
+      const { case: updated } = await actOnCase(record.id, action)
+      onUpdated(updated)
+      if (action.action === 'note') setNote('')
+      if (action.action === 'decide') setRationale('')
+    })
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-3">
+        <Button variant="ghost" size="sm" onClick={onBack} className="gap-1.5">
+          <ArrowLeft className="h-4 w-4" />
+          Queue
+        </Button>
+        <span className="font-mono text-sm text-muted-foreground">{record.id}</span>
+      </div>
+
+      {/* ---- Summary ------------------------------------------------------ */}
+      <Card>
+        <CardHeader className="pb-3">
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <CardTitle className="text-base">
+              {record.kind} · {formatUsd(record.amountCents)} {record.asset}
+            </CardTitle>
+            <div className="flex items-center gap-2">
+              <Badge variant="outline" className={cn('border', RISK_STYLES[record.riskLevel])}>
+                {record.riskLevel} · {record.riskScore}
+              </Badge>
+              <Badge variant="secondary">{record.status.replace(/_/g, ' ')}</Badge>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="grid gap-x-6 gap-y-2 text-sm sm:grid-cols-2">
+          <Field label="Account" value={record.userId} mono />
+          <Field label="Transaction" value={record.transactionId} mono />
+          <Field label="Jurisdiction" value={record.jurisdiction} />
+          <Field label="Screening decision" value={record.decision} />
+          <Field label="Opened" value={new Date(record.createdAt).toLocaleString()} />
+          <Field
+            label="Assigned to"
+            value={record.assignedTo ?? 'Unassigned'}
+          />
+        </CardContent>
+      </Card>
+
+      {/* ---- Signals ------------------------------------------------------ */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">
+            Why this was flagged ({record.signals.length})
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {record.signals.map((signal, index) => (
+            <SignalRow key={`${signal.code}-${index}`} signal={signal} />
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* ---- Audit trail -------------------------------------------------- */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Audit trail</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-0">
+          {record.events.map((event, index) => (
+            <div key={index} className="flex gap-3 py-2 text-sm">
+              <span className="w-36 shrink-0 text-xs text-muted-foreground">
+                {new Date(event.at).toLocaleString()}
+              </span>
+              <div className="min-w-0">
+                <span className="font-medium">{event.actor}</span>{' '}
+                <span className="text-muted-foreground">
+                  {event.action.toLowerCase().replace(/_/g, ' ')}
+                </span>
+                {event.detail && (
+                  <p className="mt-0.5 break-words text-muted-foreground">{event.detail}</p>
+                )}
+              </div>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      {/* ---- Actions ------------------------------------------------------ */}
+      <Card>
+        <CardHeader className="pb-3">
+          <CardTitle className="text-base">Actions</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-5">
+          {error && (
+            <p className="rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+              {error}
+            </p>
+          )}
+
+          {!record.assignedTo && !closed && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="gap-1.5"
+              disabled={busy !== null}
+              onClick={() => act('assign', { action: 'assign' })}
+            >
+              {busy === 'assign' ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <UserCheck className="h-4 w-4" />
+              )}
+              Assign to me
+            </Button>
+          )}
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">Add a note</label>
+            <Textarea
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              placeholder="Findings, customer contact, source-of-funds evidence…"
+              rows={3}
+            />
+            <Button
+              size="sm"
+              variant="outline"
+              disabled={busy !== null || note.trim().length === 0}
+              onClick={() => act('note', { action: 'note', note: note.trim() })}
+            >
+              {busy === 'note' ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Add note'}
+            </Button>
+          </div>
+
+          {!closed && (
+            <>
+              <Separator />
+              <div className="space-y-2">
+                <label className="text-sm font-medium">
+                  Decision rationale <span className="text-destructive">*</span>
+                </label>
+                <Textarea
+                  value={rationale}
+                  onChange={(e) => setRationale(e.target.value)}
+                  placeholder="Required. Explain what you checked and what you concluded."
+                  rows={3}
+                />
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="gap-1.5"
+                    disabled={busy !== null || rationale.trim().length === 0}
+                    onClick={() =>
+                      act('clear', {
+                        action: 'decide',
+                        status: 'CLEARED',
+                        disposition: 'FALSE_POSITIVE',
+                        rationale: rationale.trim(),
+                      })
+                    }
+                  >
+                    <CheckCircle2 className="h-4 w-4" />
+                    Clear
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className="gap-1.5"
+                    disabled={busy !== null || rationale.trim().length === 0}
+                    onClick={() =>
+                      act('escalate', {
+                        action: 'decide',
+                        status: 'ESCALATED',
+                        rationale: rationale.trim(),
+                      })
+                    }
+                  >
+                    <AlertTriangle className="h-4 w-4" />
+                    Escalate
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="destructive"
+                    className="gap-1.5"
+                    disabled={busy !== null || rationale.trim().length === 0}
+                    onClick={() =>
+                      act('confirm', {
+                        action: 'decide',
+                        status: 'CONFIRMED_SUSPICIOUS',
+                        disposition: 'TRUE_POSITIVE',
+                        rationale: rationale.trim(),
+                      })
+                    }
+                  >
+                    <ShieldAlert className="h-4 w-4" />
+                    Confirm suspicious
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+
+          {/* A SAR is drafted against a case, so the form lives here rather
+              than in a separate screen — the narrative is written while the
+              evidence above is still on screen. */}
+          {!record.sarId && !sarDrafted && (
+            <>
+              <Separator />
+              <div className="space-y-2">
+                <label className="text-sm font-medium">
+                  Draft {record.jurisdiction} suspicious transaction report
+                </label>
+                <p className="text-xs text-muted-foreground">
+                  The filing deadline runs from when this case was opened
+                  ({new Date(record.createdAt).toLocaleString()}), not from now.
+                </p>
+                <Textarea
+                  value={narrative}
+                  onChange={(e) => setNarrative(e.target.value)}
+                  placeholder="Who, what, when, and why it is suspicious. Minimum 50 characters."
+                  rows={6}
+                />
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="gap-1.5"
+                  disabled={busy !== null || narrative.trim().length < 50}
+                  onClick={() =>
+                    run('sar', async () => {
+                      await draftSar(record.id, narrative.trim())
+                      setSarDrafted(true)
+                      // Drafting also moves the case to CONFIRMED_SUSPICIOUS
+                      // server-side, so re-read rather than patching locally.
+                      const { case: updated } = await actOnCase(record.id, {
+                        action: 'note',
+                        note: 'SAR narrative drafted.',
+                      })
+                      onUpdated(updated)
+                    })
+                  }
+                >
+                  {busy === 'sar' ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <FileWarning className="h-4 w-4" />
+                  )}
+                  Draft SAR
+                </Button>
+              </div>
+            </>
+          )}
+
+          {(record.sarId || sarDrafted) && (
+            <p className="rounded-md border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-sm text-amber-700 dark:text-amber-400">
+              SAR {record.sarId ?? '(drafted)'} is on file for this case.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+function SignalRow({ signal }: { signal: RiskSignal }) {
+  const [open, setOpen] = useState(false)
+  const hasEvidence = signal.metadata && Object.keys(signal.metadata).length > 0
+
+  return (
+    <div className="rounded-lg border p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <Badge variant="outline" className={cn('border text-xs', RISK_STYLES[signal.severity])}>
+              {signal.severity}
+            </Badge>
+            <span className="font-mono text-xs text-muted-foreground">{signal.code}</span>
+          </div>
+          <p className="mt-1.5 text-sm">{signal.description}</p>
+        </div>
+        <span className="text-sm font-semibold tabular-nums">{signal.score}</span>
+      </div>
+
+      {hasEvidence && (
+        <>
+          <button
+            type="button"
+            onClick={() => setOpen((v) => !v)}
+            className="mt-2 text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground"
+          >
+            {open ? 'Hide evidence' : 'Show evidence'}
+          </button>
+          {open && (
+            <pre className="mt-2 max-h-64 overflow-auto rounded-md bg-muted p-2 text-xs">
+              {JSON.stringify(signal.metadata, null, 2)}
+            </pre>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+function Field({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="min-w-0">
+      <span className="text-muted-foreground">{label}</span>
+      <p className={cn('truncate', mono && 'font-mono text-xs')} title={value}>
+        {value}
+      </p>
+    </div>
+  )
+}
+
+function formatUsd(cents: number): string {
+  return `$${(cents / 100).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`
+}

--- a/components/admin/compliance-console.tsx
+++ b/components/admin/compliance-console.tsx
@@ -1,0 +1,434 @@
+'use client'
+
+/**
+ * Compliance console — the internal review interface for flagged transactions.
+ *
+ * Three states: sign-in, queue, case detail.  Kept in one component because
+ * they share the loaded case list and the token, and splitting them across
+ * routes would mean re-fetching the queue every time an analyst closes a case —
+ * the single most repeated action in the workflow.
+ *
+ * The health banner is not decoration.  Every failure mode in the AML module is
+ * silent (see app/api/admin/compliance/health/route.ts), so the state of the
+ * controls is shown on the same screen as the work rather than on a dashboard
+ * nobody opens.
+ */
+
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react'
+import {
+  AlertOctagon,
+  Filter,
+  Loader2,
+  LogOut,
+  RefreshCcw,
+  ShieldCheck,
+} from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
+import { CaseDetail } from './case-detail'
+import {
+  AdminApiError,
+  clearStoredToken,
+  getHealth,
+  getServerTokenSnapshot,
+  getStoredToken,
+  listCases,
+  setStoredToken,
+  subscribeToToken,
+  type CaseStats,
+  type HealthResponse,
+} from '@/lib/compliance/admin-client'
+import type { CaseStatus, ComplianceCase, Jurisdiction, RiskLevel } from '@/lib/compliance/types'
+
+const RISK_STYLES: Record<RiskLevel, string> = {
+  LOW: 'bg-emerald-500/10 text-emerald-600 border-emerald-500/20',
+  MEDIUM: 'bg-amber-500/10 text-amber-600 border-amber-500/20',
+  HIGH: 'bg-orange-500/10 text-orange-600 border-orange-500/20',
+  SEVERE: 'bg-red-500/10 text-red-600 border-red-500/20',
+}
+
+/** Queue statuses in the order they are worked, closed states last. */
+const STATUS_FILTERS: Array<{ value: CaseStatus | 'ALL'; label: string }> = [
+  { value: 'ALL', label: 'All' },
+  { value: 'OPEN', label: 'Open' },
+  { value: 'IN_REVIEW', label: 'In review' },
+  { value: 'ESCALATED', label: 'Escalated' },
+  { value: 'CONFIRMED_SUSPICIOUS', label: 'Confirmed' },
+  { value: 'CLEARED', label: 'Cleared' },
+]
+
+const JURISDICTIONS: Array<Jurisdiction | 'ALL'> = ['ALL', 'NG', 'KE', 'GH', 'ZA', 'UG']
+
+export function ComplianceConsole() {
+  // The token lives in sessionStorage, which is an external store — subscribed
+  // to rather than mirrored into state, so signing in or out anywhere in the
+  // tree re-renders this without a effect-driven correction pass.
+  const token = useSyncExternalStore(
+    subscribeToToken,
+    getStoredToken,
+    getServerTokenSnapshot
+  )
+
+  return token ? <Queue /> : <SignIn />
+}
+
+// ---------------------------------------------------------------------------
+// Sign-in
+// ---------------------------------------------------------------------------
+
+function SignIn() {
+  const [value, setValue] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  async function submit(event: React.FormEvent) {
+    event.preventDefault()
+    setBusy(true)
+    setError(null)
+
+    // Stored before verifying because the API client reads the token from
+    // storage; a failed check clears it again below.
+    setStoredToken(value.trim())
+    try {
+      // Verify against the health endpoint rather than trusting the input —
+      // otherwise a wrong token shows an empty queue, which reads as "no cases"
+      // rather than "not signed in".
+      await getHealth()
+      // No state update needed: the store emitted on write, and the console
+      // re-rendered into the queue via useSyncExternalStore.
+    } catch (caught) {
+      clearStoredToken()
+      setError(
+        caught instanceof AdminApiError ? caught.message : 'Could not verify the token'
+      )
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center px-4">
+      <Card className="w-full max-w-sm">
+        <CardContent className="space-y-4 pt-6">
+          <div className="flex items-center gap-2">
+            <ShieldCheck className="h-5 w-5 text-primary" />
+            <h1 className="font-semibold">Compliance console</h1>
+          </div>
+          <p className="text-sm text-muted-foreground">
+            Enter your analyst access token. It is held for this tab only and
+            cleared when you close it.
+          </p>
+          <form onSubmit={submit} className="space-y-3">
+            <Input
+              type="password"
+              value={value}
+              onChange={(e) => setValue(e.target.value)}
+              placeholder="Access token"
+              autoComplete="off"
+            />
+            {error && <p className="text-sm text-destructive">{error}</p>}
+            <Button type="submit" className="w-full" disabled={busy || !value.trim()}>
+              {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : 'Sign in'}
+            </Button>
+          </form>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Queue
+// ---------------------------------------------------------------------------
+
+function Queue() {
+  const [cases, setCases] = useState<ComplianceCase[]>([])
+  const [stats, setStats] = useState<CaseStats | null>(null)
+  const [health, setHealth] = useState<HealthResponse | null>(null)
+  const [selected, setSelected] = useState<ComplianceCase | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const [status, setStatus] = useState<CaseStatus | 'ALL'>('OPEN')
+  const [jurisdiction, setJurisdiction] = useState<Jurisdiction | 'ALL'>('ALL')
+  const [userId, setUserId] = useState('')
+
+  // Clearing the token emits to the store, which drops the console back to the
+  // sign-in form — no local flag to keep in sync.
+  const signOut = useCallback(() => {
+    clearStoredToken()
+  }, [])
+
+  const load = useCallback(async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const [caseResponse, healthResponse] = await Promise.all([
+        listCases({
+          status: status === 'ALL' ? undefined : status,
+          jurisdiction: jurisdiction === 'ALL' ? undefined : jurisdiction,
+          userId: userId.trim() || undefined,
+          limit: 50,
+        }),
+        getHealth(),
+      ])
+      setCases(caseResponse.cases)
+      setStats(caseResponse.stats)
+      setHealth(healthResponse)
+    } catch (caught) {
+      // An expired or revoked token must drop the analyst back to sign-in
+      // rather than showing an empty queue they might read as "all clear".
+      if (caught instanceof AdminApiError && caught.isAuthError) {
+        signOut()
+        return
+      }
+      setError(caught instanceof Error ? caught.message : 'Could not load cases')
+    } finally {
+      setLoading(false)
+    }
+  }, [status, jurisdiction, userId, signOut])
+
+  useEffect(() => {
+    void load()
+  }, [load])
+
+  if (selected) {
+    return (
+      <CaseDetail
+        record={selected}
+        onBack={() => {
+          setSelected(null)
+          void load()
+        }}
+        onUpdated={(updated) => {
+          setSelected(updated)
+          setCases((current) => current.map((c) => (c.id === updated.id ? updated : c)))
+        }}
+      />
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <ShieldCheck className="h-5 w-5 text-primary" />
+          <h1 className="text-lg font-semibold">Transaction monitoring</h1>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button variant="ghost" size="sm" onClick={() => void load()} className="gap-1.5">
+            <RefreshCcw className={cn('h-4 w-4', loading && 'animate-spin')} />
+            Refresh
+          </Button>
+          <Button variant="ghost" size="sm" onClick={signOut} className="gap-1.5">
+            <LogOut className="h-4 w-4" />
+            Sign out
+          </Button>
+        </div>
+      </header>
+
+      {health && health.status !== 'OK' && <HealthBanner health={health} />}
+
+      {stats && (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          <Stat label="Open" value={stats.byStatus.OPEN} />
+          <Stat label="In review" value={stats.byStatus.IN_REVIEW} />
+          <Stat label="Escalated" value={stats.byStatus.ESCALATED} />
+          <Stat
+            label="Overdue filings"
+            value={stats.overdueFilings}
+            emphasis={stats.overdueFilings > 0}
+          />
+        </div>
+      )}
+
+      <Card>
+        <CardContent className="flex flex-wrap items-center gap-2 pt-6">
+          <Filter className="h-4 w-4 text-muted-foreground" />
+          {STATUS_FILTERS.map((option) => (
+            <Button
+              key={option.value}
+              size="sm"
+              variant={status === option.value ? 'default' : 'outline'}
+              onClick={() => setStatus(option.value)}
+            >
+              {option.label}
+            </Button>
+          ))}
+          <select
+            value={jurisdiction}
+            onChange={(e) => setJurisdiction(e.target.value as Jurisdiction | 'ALL')}
+            className="h-9 rounded-md border border-input bg-transparent px-3 text-sm"
+            aria-label="Jurisdiction"
+          >
+            {JURISDICTIONS.map((code) => (
+              <option key={code} value={code}>
+                {code === 'ALL' ? 'All markets' : code}
+              </option>
+            ))}
+          </select>
+          <Input
+            value={userId}
+            onChange={(e) => setUserId(e.target.value)}
+            placeholder="Filter by account…"
+            className="h-9 w-full sm:w-64"
+          />
+        </CardContent>
+      </Card>
+
+      {error && (
+        <p className="rounded-md border border-destructive/20 bg-destructive/10 px-3 py-2 text-sm text-destructive">
+          {error}
+        </p>
+      )}
+
+      {loading && cases.length === 0 ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : cases.length === 0 ? (
+        <Card>
+          <CardContent className="py-12 text-center text-sm text-muted-foreground">
+            No cases match these filters.
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardContent className="divide-y p-0">
+            {cases.map((record) => (
+              <button
+                key={record.id}
+                type="button"
+                onClick={() => setSelected(record)}
+                className="flex w-full flex-wrap items-center gap-3 px-4 py-3 text-left transition-colors hover:bg-muted/50"
+              >
+                <Badge
+                  variant="outline"
+                  className={cn('border shrink-0', RISK_STYLES[record.riskLevel])}
+                >
+                  {record.riskScore}
+                </Badge>
+                <div className="min-w-0 flex-1">
+                  <p className="truncate text-sm font-medium">
+                    {record.kind} · {formatUsd(record.amountCents)} {record.asset} ·{' '}
+                    {record.jurisdiction}
+                  </p>
+                  <p className="truncate text-xs text-muted-foreground">
+                    {record.signals.map((s) => s.code).join(' · ') || 'No signals recorded'}
+                  </p>
+                </div>
+                <div className="shrink-0 text-right">
+                  <Badge variant="secondary" className="text-xs">
+                    {record.status.replace(/_/g, ' ')}
+                  </Badge>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {new Date(record.createdAt).toLocaleDateString()}
+                  </p>
+                </div>
+              </button>
+            ))}
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}
+
+function HealthBanner({ health }: { health: HealthResponse }) {
+  const { checks } = health
+  const problems: string[] = []
+
+  if (!checks.sanctionsList.loaded) {
+    problems.push(
+      'No sanctions snapshot is loaded — screening is running against development fixture data only.'
+    )
+  } else if (checks.sanctionsList.stale) {
+    problems.push(
+      `Sanctions list is ${checks.sanctionsList.ageDays} days old. Re-run the refresh job.`
+    )
+  }
+  if (!checks.policy.hashSaltConfigured) {
+    problems.push('COMPLIANCE_HASH_SALT is not set — counterparty monitoring cannot record.')
+  }
+  if (checks.providers.localOnly) {
+    problems.push(
+      `No commercial screening provider configured (wallet: ${checks.providers.wallet}, name: ${checks.providers.name}).`
+    )
+  }
+  if (!checks.policy.failClosed) {
+    problems.push('FAIL_CLOSED is disabled — provider outages will not hold transactions.')
+  }
+  if (checks.queue.overdueFilings > 0) {
+    problems.push(
+      `${checks.queue.overdueFilings} SAR${checks.queue.overdueFilings === 1 ? '' : 's'} past the filing deadline.`
+    )
+  }
+
+  const critical = health.status === 'CRITICAL'
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border px-4 py-3',
+        critical
+          ? 'border-destructive/30 bg-destructive/10'
+          : 'border-amber-500/30 bg-amber-500/10'
+      )}
+    >
+      <div className="flex items-start gap-2">
+        <AlertOctagon
+          className={cn(
+            'mt-0.5 h-4 w-4 shrink-0',
+            critical ? 'text-destructive' : 'text-amber-600'
+          )}
+        />
+        <div className="min-w-0 text-sm">
+          <p className={cn('font-medium', critical ? 'text-destructive' : 'text-amber-700 dark:text-amber-400')}>
+            Controls {health.status === 'CRITICAL' ? 'not fully operational' : 'degraded'}
+          </p>
+          <ul className="mt-1 list-inside list-disc space-y-0.5 text-muted-foreground">
+            {problems.map((problem) => (
+              <li key={problem}>{problem}</li>
+            ))}
+          </ul>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Stat({
+  label,
+  value,
+  emphasis,
+}: {
+  label: string
+  value: number
+  emphasis?: boolean
+}) {
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <p className="text-xs text-muted-foreground">{label}</p>
+        <p
+          className={cn(
+            'mt-1 text-2xl font-semibold tabular-nums',
+            emphasis && 'text-destructive'
+          )}
+        >
+          {value}
+        </p>
+      </CardContent>
+    </Card>
+  )
+}
+
+function formatUsd(cents: number): string {
+  return `$${(cents / 100).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`
+}

--- a/components/bills/payment-form.tsx
+++ b/components/bills/payment-form.tsx
@@ -28,6 +28,7 @@ import { motion, AnimatePresence } from 'framer-motion'
 import { cn } from '@/lib/utils'
 import { Checkbox } from '@/components/ui/checkbox'
 import { generateInvoiceId, type QRInvoiceData } from '@/lib/bills/qr-invoice'
+import { useWalletStore } from '@/lib/wallet/walletStore'
 
 interface PaymentFormProps {
   schema: BillerSchema
@@ -45,6 +46,7 @@ export function PaymentForm({ schema, countryCode }: PaymentFormProps) {
   const [isProcessing, setIsProcessing] = useState(false)
   const [showSchedule, setShowSchedule] = useState(false)
   const [invoice, setInvoice] = useState<QRInvoiceData | null>(null)
+  const publicKey = useWalletStore((s) => s.publicKey)
 
   const formSchemaObject: Record<string, z.ZodTypeAny> = {}
   schema.fields.forEach((field) => {
@@ -130,12 +132,22 @@ export function PaymentForm({ schema, countryCode }: PaymentFormProps) {
             accountReference: schema.id.slice(0, 12),
             transactionDesc: `Pay ${schema.name}`.slice(0, 13),
             externalId: crypto.randomUUID(),
+            kind: 'billpay',
+            // Lets AML screening key this payment to the customer's account
+            // rather than to their handset alone.  Omitted when no wallet is
+            // connected; the route falls back to a hashed MSISDN.
+            userId: publicKey ?? undefined,
           }),
         })
 
         if (!initiateRes.ok) {
-          const err = await initiateRes.json().catch(() => ({}))
-          throw new Error((err as { error?: string }).error ?? 'Payment initiation failed')
+          const err = (await initiateRes.json().catch(() => ({}))) as {
+            error?: string
+            message?: string
+          }
+          // Prefer `message`: compliance holds return a customer-safe string
+          // there, while `error` is a machine code (COMPLIANCE_BLOCKED).
+          throw new Error(err.message ?? err.error ?? 'Payment initiation failed')
         }
 
         const { transactionId, provider } = (await initiateRes.json()) as {

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        'placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-input field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]',
+        'aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/db/migrations/003_create_compliance.sql
+++ b/db/migrations/003_create_compliance.sql
@@ -86,7 +86,14 @@ CREATE TABLE IF NOT EXISTS compliance_cases (
   transaction_id TEXT        NOT NULL UNIQUE,
   user_id        TEXT        NOT NULL,
   kind           TEXT        NOT NULL CHECK (kind IN ('onramp', 'offramp', 'billpay')),
-  jurisdiction   TEXT        NOT NULL CHECK (jurisdiction IN ('NG', 'KE', 'GH', 'ZA', 'UG')),
+  -- Wider than compliance_sars.jurisdiction below, and deliberately so: the
+  -- mobile-money footprint reaches markets with no local AML registration.
+  -- Those transactions are still screened and still open cases; what they
+  -- cannot do is produce a filing.  See UNLICENSED_MARKET_POLICY in
+  -- lib/compliance/config.ts.
+  jurisdiction   TEXT        NOT NULL
+                   CHECK (jurisdiction IN ('NG', 'KE', 'GH', 'ZA', 'UG',
+                                           'TZ', 'CM', 'CI', 'RW', 'ZM')),
   amount_cents   BIGINT      NOT NULL,
   asset          TEXT        NOT NULL,
   status         TEXT        NOT NULL
@@ -132,6 +139,10 @@ CREATE TABLE IF NOT EXISTS compliance_sars (
   id                    TEXT        PRIMARY KEY,
   case_id               TEXT        NOT NULL REFERENCES compliance_cases (id),
   user_id               TEXT        NOT NULL,
+  -- Licensed markets only.  This is the database-level counterpart of the
+  -- NO_FILING_ROUTE check in draftSar(): a SAR addressed to no regulator would
+  -- set compliance_cases.sar_id and make a live review obligation read as
+  -- discharged in every queue and count.
   jurisdiction          TEXT        NOT NULL CHECK (jurisdiction IN ('NG', 'KE', 'GH', 'ZA', 'UG')),
   regulator             TEXT        NOT NULL,
   status                TEXT        NOT NULL

--- a/db/migrations/003_create_compliance.sql
+++ b/db/migrations/003_create_compliance.sql
@@ -1,0 +1,236 @@
+-- Migration: 003_create_compliance
+-- Purpose:   Persistence for AML transaction monitoring, case management and
+--            SAR/STR filings.
+--
+-- Regulatory context:
+--   Operating a crypto on/off ramp in Nigeria, Kenya, Ghana, South Africa and
+--   Uganda requires transaction monitoring, sanctions screening and suspicious
+--   activity reporting.  The tables below are the record of those controls
+--   operating.  Two properties follow from that and constrain the schema:
+--
+--     1. **Records are retained for five years** after the relationship or
+--        transaction ends, in every one of the five markets.  Nothing here is
+--        deleted by the application; a retention job purges past the window.
+--     2. **The audit trail is append-only.**  Case decisions are evidence.  A
+--        case whose history can be rewritten proves nothing, so `events` is
+--        appended to and a trigger below refuses shrinking updates.
+--
+--   See lib/compliance/config.ts for the thresholds these tables are queried
+--   against, and docs/AML_COMPLIANCE.md for the operating procedure.
+--
+-- Money:
+--   All amounts are integer USD cents, matching lib/kyc/withdrawalLimitService.ts
+--   and lib/compliance/*.  Never store money as FLOAT.
+
+-- ===========================================================================
+-- compliance_transactions — the monitoring ledger
+-- ===========================================================================
+-- Every screened transaction, in every direction, INCLUDING ones that were
+-- blocked.  A blocked attempt is evidence of behaviour: dropping it would make
+-- an account probing our limits look quieter than a legitimate one.
+--
+-- This is distinct from the `withdrawals` records used for KYC limits, which
+-- exist to enforce a cap and only cover offramps.  This table exists to
+-- establish a behavioural baseline.
+--
+-- No PII.  Counterparties are stored as `counterparty_key`, a salted SHA-256
+-- of the account number or address (see hashCounterparty() in
+-- lib/compliance/ledger.ts).  Names and account numbers live only on cases,
+-- where access is gated and audited.  An unsalted hash of a 10-digit NUBAN is
+-- reversible by brute force in seconds and would not qualify as
+-- pseudonymisation under NDPA 2023 (NG) or POPIA (ZA).
+CREATE TABLE IF NOT EXISTS compliance_transactions (
+  transaction_id   TEXT        PRIMARY KEY,
+  user_id          TEXT        NOT NULL,
+  kind             TEXT        NOT NULL CHECK (kind IN ('onramp', 'offramp', 'billpay')),
+  amount_cents     BIGINT      NOT NULL CHECK (amount_cents > 0),
+  asset            TEXT        NOT NULL,
+  chain            TEXT        NOT NULL,
+  counterparty_key TEXT,
+  decision         TEXT        NOT NULL CHECK (decision IN ('ALLOW', 'REVIEW', 'BLOCK')),
+  risk_score       SMALLINT    NOT NULL CHECK (risk_score BETWEEN 0 AND 100),
+  occurred_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Every velocity rule is "this user, this rolling window", so the composite
+-- index is (user_id, occurred_at DESC).  Without it, each screening call table
+-- scans — and screening sits in the payment path.
+--
+-- amount_cents and kind are INCLUDEd because the count/sum/reversal rules read
+-- only those two columns, making the common queries index-only.
+CREATE INDEX IF NOT EXISTS idx_compliance_tx_user_time
+  ON compliance_transactions (user_id, occurred_at DESC)
+  INCLUDE (amount_cents, kind);
+
+-- Fan-out detection counts DISTINCT counterparty_key per user per window.
+-- Partial, because rows without a counterparty are irrelevant to it and are a
+-- large share of the table.
+CREATE INDEX IF NOT EXISTS idx_compliance_tx_counterparty
+  ON compliance_transactions (user_id, counterparty_key, occurred_at DESC)
+  WHERE counterparty_key IS NOT NULL;
+
+-- ===========================================================================
+-- compliance_cases — flagged transactions under human review
+-- ===========================================================================
+-- One case per flagged transaction.  `transaction_id` is UNIQUE rather than a
+-- plain column: the screening endpoint is retried by clients on flaky
+-- networks, and duplicate cases for one transaction get worked and closed
+-- inconsistently by different analysts.
+--
+-- `signals` and `events` are JSONB rather than child tables.  Signals are
+-- written once and read whole; the signal shape changes as rules are added,
+-- and a migration per rule would slow the thing that most needs to move fast
+-- when a new typology appears.
+CREATE TABLE IF NOT EXISTS compliance_cases (
+  id             TEXT        PRIMARY KEY,
+  transaction_id TEXT        NOT NULL UNIQUE,
+  user_id        TEXT        NOT NULL,
+  kind           TEXT        NOT NULL CHECK (kind IN ('onramp', 'offramp', 'billpay')),
+  jurisdiction   TEXT        NOT NULL CHECK (jurisdiction IN ('NG', 'KE', 'GH', 'ZA', 'UG')),
+  amount_cents   BIGINT      NOT NULL,
+  asset          TEXT        NOT NULL,
+  status         TEXT        NOT NULL
+                   CHECK (status IN ('OPEN', 'IN_REVIEW', 'ESCALATED', 'CLEARED', 'CONFIRMED_SUSPICIOUS')),
+  risk_score     SMALLINT    NOT NULL CHECK (risk_score BETWEEN 0 AND 100),
+  risk_level     TEXT        NOT NULL CHECK (risk_level IN ('LOW', 'MEDIUM', 'HIGH', 'SEVERE')),
+  decision       TEXT        NOT NULL CHECK (decision IN ('ALLOW', 'REVIEW', 'BLOCK')),
+  signals        JSONB       NOT NULL DEFAULT '[]'::JSONB,
+  assigned_to    TEXT,
+  disposition    TEXT        CHECK (disposition IN ('FALSE_POSITIVE', 'TRUE_POSITIVE', 'INCONCLUSIVE')),
+  sar_id         TEXT,
+  events         JSONB       NOT NULL DEFAULT '[]'::JSONB,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- The analyst queue: open cases, newest first.  Partial index because closed
+-- cases are the overwhelming majority once the system has been running and are
+-- never in the working queue.
+CREATE INDEX IF NOT EXISTS idx_compliance_cases_queue
+  ON compliance_cases (created_at DESC)
+  WHERE status IN ('OPEN', 'IN_REVIEW', 'ESCALATED');
+
+-- "Show me everything for this account" — the first thing an analyst does
+-- after opening a case, and the basis of any account-level review.
+CREATE INDEX IF NOT EXISTS idx_compliance_cases_user
+  ON compliance_cases (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_compliance_cases_jurisdiction
+  ON compliance_cases (jurisdiction, status, created_at DESC);
+
+-- ===========================================================================
+-- compliance_sars — suspicious activity / transaction reports
+-- ===========================================================================
+-- `suspicion_formed_at` is the case's creation time, NOT the draft time, and
+-- `due_at` is derived from it.  Dating the clock from when an analyst got round
+-- to drafting would let a backlog quietly extinguish every filing deadline —
+-- which is the precise failure the deadline exists to prevent.
+--
+-- Deadlines per market are in JURISDICTIONS (lib/compliance/config.ts) and must
+-- be confirmed with local counsel; they are configuration, not settled fact.
+CREATE TABLE IF NOT EXISTS compliance_sars (
+  id                    TEXT        PRIMARY KEY,
+  case_id               TEXT        NOT NULL REFERENCES compliance_cases (id),
+  user_id               TEXT        NOT NULL,
+  jurisdiction          TEXT        NOT NULL CHECK (jurisdiction IN ('NG', 'KE', 'GH', 'ZA', 'UG')),
+  regulator             TEXT        NOT NULL,
+  status                TEXT        NOT NULL
+                          CHECK (status IN ('DRAFT', 'SUBMITTED', 'ACKNOWLEDGED', 'REJECTED')),
+  narrative             TEXT        NOT NULL,
+  grounds_for_suspicion JSONB       NOT NULL DEFAULT '[]'::JSONB,
+  amount_cents          BIGINT      NOT NULL,
+  filed_by              TEXT        NOT NULL,
+  suspicion_formed_at   TIMESTAMPTZ NOT NULL,
+  due_at                TIMESTAMPTZ NOT NULL,
+  submitted_at          TIMESTAMPTZ,
+  regulator_reference   TEXT,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  -- One filing per case.  A second SAR for the same case is a data error, and
+  -- duplicate filings against one FIU reference are their own problem.
+  CONSTRAINT uq_compliance_sars_case UNIQUE (case_id)
+);
+
+-- Drives the overdue-filings alert, which is the single most time-critical
+-- query in the system: an unfiled SAR past its deadline is a live breach.
+CREATE INDEX IF NOT EXISTS idx_compliance_sars_due
+  ON compliance_sars (due_at)
+  WHERE status = 'DRAFT';
+
+CREATE INDEX IF NOT EXISTS idx_compliance_sars_status
+  ON compliance_sars (jurisdiction, status, due_at);
+
+-- ===========================================================================
+-- Triggers
+-- ===========================================================================
+-- set_updated_at() is created by 001_index_withdrawals_created_at.sql.
+-- CREATE OR REPLACE so this migration can also run standalone.
+CREATE OR REPLACE FUNCTION set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at = NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_compliance_cases_updated_at ON compliance_cases;
+CREATE TRIGGER trg_compliance_cases_updated_at
+  BEFORE UPDATE ON compliance_cases
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+DROP TRIGGER IF EXISTS trg_compliance_sars_updated_at ON compliance_sars;
+CREATE TRIGGER trg_compliance_sars_updated_at
+  BEFORE UPDATE ON compliance_sars
+  FOR EACH ROW EXECUTE FUNCTION set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- Append-only enforcement on the case audit trail
+-- ---------------------------------------------------------------------------
+-- The application always appends to `events`, but the application is not the
+-- only thing that can reach this table.  This makes the guarantee structural:
+-- an update that shortens the trail is rejected at the database.
+--
+-- It checks length, not content, which is a deliberate limit — it stops
+-- truncation and wholesale replacement, not a same-length edit of one entry.
+-- Genuine tamper-evidence needs either an append-only WAL-backed audit table or
+-- per-entry hash chaining; both are the right next step and neither belongs in
+-- the first migration.  Documented as a known gap in docs/AML_COMPLIANCE.md.
+CREATE OR REPLACE FUNCTION compliance_events_append_only()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+  IF JSONB_ARRAY_LENGTH(NEW.events) < JSONB_ARRAY_LENGTH(OLD.events) THEN
+    RAISE EXCEPTION
+      'compliance_cases.events is append-only (attempted to shrink from % to % entries on case %)',
+      JSONB_ARRAY_LENGTH(OLD.events), JSONB_ARRAY_LENGTH(NEW.events), OLD.id;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_compliance_cases_append_only ON compliance_cases;
+CREATE TRIGGER trg_compliance_cases_append_only
+  BEFORE UPDATE ON compliance_cases
+  FOR EACH ROW EXECUTE FUNCTION compliance_events_append_only();
+
+-- ===========================================================================
+-- Retention
+-- ===========================================================================
+-- Five years, per RECORD_RETENTION_YEARS in lib/compliance/config.ts.  Run from
+-- a scheduled job, not from the application.
+--
+-- Ordering matters: SARs reference cases, and monitoring rows are only purged
+-- once no case still points at the transaction — an account under
+-- investigation must keep its full history even where individual rows have
+-- aged out.
+--
+--   DELETE FROM compliance_sars
+--   WHERE  created_at < NOW() - INTERVAL '5 years';
+--
+--   DELETE FROM compliance_cases
+--   WHERE  created_at < NOW() - INTERVAL '5 years'
+--     AND  id NOT IN (SELECT case_id FROM compliance_sars);
+--
+--   DELETE FROM compliance_transactions
+--   WHERE  occurred_at < NOW() - INTERVAL '5 years'
+--     AND  transaction_id NOT IN (SELECT transaction_id FROM compliance_cases);

--- a/docs/AML_COMPLIANCE.md
+++ b/docs/AML_COMPLIANCE.md
@@ -1,0 +1,329 @@
+# AML / CFT Controls
+
+Transaction monitoring, sanctions screening, velocity rules and suspicious
+activity reporting for Aframp's on/off ramp.
+
+Operating a crypto ramp in Nigeria, Kenya, Ghana, South Africa and Uganda
+requires all four as a licensing condition. This document describes what is
+implemented, what it deliberately does not do, and what still has to be true
+before it can be relied on in production.
+
+> **Read the "Known gaps" section before go-live.** Several things here are
+> load-bearing configuration that only a compliance officer and local counsel
+> can sign off, and the code cannot check them for you.
+
+---
+
+## Architecture
+
+```
+                       ┌──────────────────────────────┐
+  payment routes ─────►│  screenTransaction()         │
+  /api/withdrawals     │  lib/compliance/monitor.ts   │
+  /api/compliance/screen└──────────────┬───────────────┘
+                                       │
+              ┌────────────────────────┼────────────────────────┐
+              ▼                        ▼                        ▼
+      wallet screening         name screening            velocity rules
+   Chainalysis / Elliptic      ComplyAdvantage        lib/compliance/velocity.ts
+              │                        │                        │
+              └────────► local sanctions list ◄─────────┐       │
+                     lib/compliance/sanctions/           │       │
+                                       │                 │       │
+                                       ▼                 │       ▼
+                              risk aggregation ◄─────────┴───────┘
+                              lib/compliance/risk.ts
+                                       │
+                       ALLOW ──────────┼────────── REVIEW / BLOCK
+                          │                              │
+                          ▼                              ▼
+                  monitoring ledger              case + SAR workflow
+                  lib/compliance/ledger.ts       lib/compliance/case-store.ts
+                                                         │
+                                                         ▼
+                                                 /admin/compliance
+```
+
+| Concern | Module |
+| --- | --- |
+| Policy — every threshold, window and score | `lib/compliance/config.ts` |
+| Risk aggregation and decisions | `lib/compliance/risk.ts` |
+| Velocity / behavioural rules | `lib/compliance/velocity.ts` |
+| Monitoring ledger | `lib/compliance/ledger.ts` |
+| Sanctions corpus and matching | `lib/compliance/sanctions/` |
+| Vendor adapters | `lib/compliance/providers/` |
+| Cases and SAR workflow | `lib/compliance/case-store.ts` |
+| Orchestration | `lib/compliance/monitor.ts` |
+| Schema | `db/migrations/003_create_compliance.sql` |
+
+**One rule matters above the others:** payment paths call `screenTransaction()`
+and act on the returned decision. They never assemble their own view of risk. A
+control implemented twice is a control implemented differently.
+
+---
+
+## What runs on every transaction
+
+### 1. Sanctions and wallet screening
+
+Runs concurrently with the velocity rules — both are on the payment path.
+
+- **Wallet addresses** → Chainalysis or Elliptic, normalised to a 0–100 score.
+- **Account holder names** → ComplyAdvantage (sanctions, PEP, adverse media).
+- **Both** → also matched against the local corpus, which is the failover leg.
+
+Name matching is fuzzy, and has to be. The same person appears across lists as
+`Mohammed Al-Hassan`, `Muhammad al Hassan`, `HASSAN, Mohamed` and
+`Alhaji Mohammed Hassan`. Exact matching catches none of them. The matcher
+normalises (case, diacritics, punctuation, honorifics), compares as token sets
+so name order does not matter, and scores individual tokens with Jaro-Winkler,
+which is tuned for the short shared-prefix strings transliteration produces.
+
+The threshold is `NAME_SCREENING.matchThreshold` (0.85). It is asymmetric on
+purpose — surplus name parts are penalised gently, because false positives cost
+analyst minutes and false negatives cost a licence. Regulators expect this
+number to be justified and periodically tested; do not change it casually.
+
+### 2. Velocity rules
+
+| Rule | Catches | Stage |
+| --- | --- | --- |
+| `VELOCITY_TX_COUNT` | More transactions than a retail user makes | Volume |
+| `VELOCITY_VOLUME` | Throughput over the ceiling | Volume |
+| `VELOCITY_SPIKE` | Today far above the account's *own* average | Volume |
+| `STRUCTURING` | Repeated amounts just under the reporting threshold | Placement |
+| `RAPID_RAMP_REVERSAL` | Onramp reversed by offramp within hours | Layering |
+| `COUNTERPARTY_FANOUT` | Payouts split across many recipients | Layering |
+| `NEW_ACCOUNT_HIGH_VALUE` | Large transaction with no track record | Placement |
+| `DORMANT_REACTIVATION` | Large transaction after long silence | Placement |
+
+No single velocity rule can hold a payment on its own — each scores below the
+review threshold. It takes a severe signal or corroboration between rules. That
+is deliberate: rules that individually block generate enough noise that analysts
+stop reading them.
+
+`VELOCITY_SPIKE` is relative rather than absolute, so it catches an account
+whose normal is $50 suddenly moving $900. Absolute ceilings alone are exactly
+what a competent launderer sizes their transactions against.
+
+### 3. Scoring
+
+```
+score = max(signal scores) + 0.35 × Σ(the rest)     capped at 100
+```
+
+A plain sum was rejected: three unremarkable signals would outrank one
+dangerous one, and analysts end up triaging noise ahead of danger. Taking the
+max alone was also rejected: corroboration is genuine evidence. The model is
+order-independent and monotone — adding a signal can never lower the score,
+which is the property that makes it defensible. See `lib/compliance/risk.ts`.
+
+Bands: `<25` LOW, `<50` MEDIUM, `<75` HIGH, `≥75` SEVERE.
+Decisions: `≥50` REVIEW, `≥90` BLOCK.
+
+**Sanctions hits bypass the score entirely and block.** A designation is a legal
+prohibition, not a risk-appetite question. A PEP match never blocks — the
+obligation there is enhanced due diligence, not refusal.
+
+### 4. Recording
+
+Every screened transaction is written to the monitoring ledger **including ones
+that were blocked**. A blocked attempt is evidence of behaviour; dropping it
+would make an account probing our limits look quieter than a legitimate one.
+
+The ledger holds no PII. Counterparties are stored as a salted SHA-256 of the
+account number or address. Names and account numbers exist only on case files,
+where access is gated and attributed.
+
+---
+
+## Fail-closed
+
+A provider that times out or errors **never produces a clean result**. It raises
+`PROVIDER_UNAVAILABLE`, the local list is still consulted so designations are
+caught during an outage, and with `FAIL_CLOSED` (default, and required in
+production) the transaction is held for review rather than allowed through
+unscreened.
+
+Turning `FAIL_CLOSED` off makes a vendor outage a hole in the control, which is
+precisely what examiners look for. It exists only so a market can be brought up
+before its provider contract is signed.
+
+---
+
+## Tipping off
+
+`BLOCK` and `REVIEW` return an identical response to the customer:
+
+> This withdrawal is being reviewed by our compliance team.
+
+This is not vagueness for its own sake. Disclosing which rule fired hands anyone
+probing our thresholds a map of where they sit. More seriously, in all five
+markets it is a **separate criminal offence** to tell the subject of a
+suspicious activity report that they are being reported. A message
+distinguishing "under review" from "declined" leaks exactly that.
+
+Support staff get a `referenceId` (the case id) so they can correlate an enquiry
+to a case without seeing why it was flagged.
+
+---
+
+## Jurisdictions
+
+| Market | Regulator | Filing window | Structuring anchor |
+| --- | --- | --- | --- |
+| Nigeria | NFIU | 24 h | ≈ ₦5,000,000 (MLPPA 2022) |
+| Kenya | FRC | 7 days | ≈ KES 1,000,000 (POCAMLA) |
+| Ghana | FIC | 24 h | ≈ GHS 50,000 (AMLA 2020) |
+| South Africa | FIC | 15 days | ≈ R49,999.99 (FICA) |
+| Uganda | FIA | 48 h | ≈ UGX 20,000,000 (AMLA 2013) |
+
+> ⚠️ **These are starting values, not legal advice.** They are drawn from the
+> headline requirements of each market's AML statute, and both the windows and
+> the thresholds move with statutory instruments and FX. Confirm every row with
+> local counsel and the relevant FIU before go-live, and re-confirm on a
+> schedule. The thresholds are stored in USD cents and must be re-derived when
+> exchange rates move materially. See `JURISDICTIONS` in
+> `lib/compliance/config.ts`.
+
+The code says "SAR" because that is the term in the requirement. Every regulator
+above calls the same artefact a Suspicious Transaction Report (STR).
+
+---
+
+## Analyst workflow
+
+The console lives at `/admin/compliance`.
+
+1. **Queue** — open cases, newest first. Oldest-unworked is what breaches a
+   filing deadline first, so that is the end analysts work from.
+2. **Case file** — every signal with its evidence rendered verbatim: the
+   observed values, the threshold breached, the matched alias. A determination
+   an analyst cannot reconstruct is one they cannot defend.
+3. **Decide** — clear, escalate, or confirm suspicious. **A rationale is
+   mandatory**, enforced by the API schema rather than by convention. Alerts
+   closed with no recorded reason are the single most common examination
+   finding against a monitoring programme.
+4. **File** — draft the SAR narrative while the evidence is still on screen.
+
+The audit trail is append-only. Cases close; they do not disappear, and there is
+no `deleteCase()` anywhere in the codebase. Records carry a five-year retention
+obligation in all five markets.
+
+Filing deadlines run from **when suspicion was formed** — the case's creation —
+not from when an analyst opened the draft. Dating the clock from draft time
+would let a backlog quietly extinguish every deadline.
+
+---
+
+## Setup
+
+### Environment
+
+```bash
+# Required
+COMPLIANCE_HASH_SALT=          # openssl rand -hex 32
+COMPLIANCE_ADMIN_TOKENS=       # analystId:token,analystId:token
+
+# Providers (default `local` — bundled fixture list, no vendor account)
+COMPLIANCE_WALLET_PROVIDER=chainalysis     # chainalysis | elliptic | local
+CHAINALYSIS_API_KEY=
+COMPLIANCE_NAME_PROVIDER=complyadvantage   # complyadvantage | local
+COMPLYADVANTAGE_API_KEY=
+```
+
+### Sanctions corpus
+
+```bash
+node scripts/refresh-sanctions-lists.mjs
+```
+
+Fetches the OFAC SDN and UN Consolidated lists and writes
+`data/sanctions/snapshot.json`. The snapshot is **not** committed — it is large,
+it changes several times a week, and a stale committed copy is worse than no
+copy because it looks current.
+
+Run it **on every deploy** and **daily thereafter**. Designations take effect on
+publication, not on our next refresh.
+
+With no snapshot loaded, screening runs against `DEV_FIXTURE_ENTITIES` —
+synthetic entries invented so no real person is represented as sanctioned
+anywhere in this repository. That state is reported as `CRITICAL` by the health
+endpoint and bannered in the console, because it means there is effectively no
+sanctions screening at all.
+
+### Health
+
+`GET /api/admin/compliance/health` reports whether the controls are *operating*,
+not merely deployed. Every failure mode in this module is silent by nature —
+screening against a stale or fixture list produces clean results indistinguishable
+from genuinely clean ones. Alert on `status != "OK"`.
+
+---
+
+## Testing
+
+```bash
+npx jest lib/compliance
+```
+
+The matching tests are the ones that matter most. A screening control is only as
+good as its matcher, and the "must not match" cases are as important as the
+"must match" ones — a matcher that flags every shared surname trains analysts to
+clear reflexively, which is worse than no matcher.
+
+---
+
+## Known gaps
+
+Ordered by what blocks production first.
+
+1. **No persistent database.** The stores are in-memory, shaped to mirror
+   `003_create_compliance.sql`, matching the existing convention in
+   `lib/orders/order-store.ts` and `lib/kyc/withdrawalLimitService.ts`. **Case
+   files and SARs do not survive a restart**, which is incompatible with the
+   five-year retention obligation. Wiring the migration up is the first
+   production task.
+
+2. **Admin authentication is a stopgap.** Shared-secret bearer tokens in an env
+   var, held in `sessionStorage`. It gates the console and attributes decisions
+   to a named human — the part the audit trail depends on — but before this
+   handles real customer data it needs per-user accounts with individually
+   revocable credentials, mandatory MFA, session expiry, and alerting on bulk
+   case reads (which is how insider misuse presents). See
+   `lib/compliance/admin-auth.ts`.
+
+3. **Vendor API contracts are unverified.** The adapters follow each vendor's
+   published contract at time of writing. Verify against current documentation
+   and each sandbox before enabling. The Chainalysis adapter deliberately throws
+   on an unrecognised risk verdict rather than defaulting to LOW, so a
+   vendor-side rename fails loudly instead of becoming a silent bypass — keep
+   that property in any adapter you add.
+
+4. **Jurisdictional figures need legal sign-off.** Filing deadlines and
+   reporting thresholds are configuration, not settled fact. See the warning
+   above.
+
+5. **No screening result caching.** ComplyAdvantage bills per search, and every
+   transaction re-screens the same counterparty. The production shape is to
+   screen a counterparty once, persist it, and re-screen on list update or after
+   a staleness window. This is deliberately not hidden inside the HTTP client:
+   caching a *screening decision* is a compliance policy choice, and burying it
+   in transport is how teams end up unable to answer "when was this person last
+   screened?".
+
+6. **Audit trail is append-only by convention plus a length check.** The SQL
+   trigger rejects an update that shortens `events`, which stops truncation and
+   wholesale replacement but not a same-length edit of one entry. Genuine
+   tamper-evidence needs per-entry hash chaining or a WAL-backed audit table.
+
+7. **No periodic re-screening.** Customers are screened at transaction time
+   only. New designations do not retroactively flag existing counterparties. A
+   batch job re-screening active counterparties against each new snapshot is the
+   standard control and is not implemented. `screenTransaction()` accepts
+   `skipLedger` specifically so that job can re-screen without double-counting.
+
+8. **Onramp and bill payments are not yet wired in.** Only `/api/withdrawals`
+   calls `screenTransaction()`. `/api/compliance/screen` exists for the other
+   paths to call; they do not call it yet. The offramp leg was done first
+   because that is where a designated person actually receives value.

--- a/docs/AML_COMPLIANCE.md
+++ b/docs/AML_COMPLIANCE.md
@@ -18,9 +18,12 @@ before it can be relied on in production.
 
 ```
                        ┌──────────────────────────────┐
-  payment routes ─────►│  screenTransaction()         │
-  /api/withdrawals     │  lib/compliance/monitor.ts   │
-  /api/compliance/screen└──────────────┬───────────────┘
+payment routes ───────►│  screenTransaction()         │
+/api/withdrawals       │  lib/compliance/monitor.ts   │
+/api/payments/…        │                              │
+/api/bills/initiate    │                              │
+/api/compliance/screen │                              │
+                       └───────────────┬──────────────┘
                                        │
               ┌────────────────────────┼────────────────────────┐
               ▼                        ▼                        ▼
@@ -47,6 +50,7 @@ before it can be relied on in production.
 | Concern | Module |
 | --- | --- |
 | Policy — every threshold, window and score | `lib/compliance/config.ts` |
+| Market resolution, FX and payer identity | `lib/compliance/markets.ts`, `identity.ts` |
 | Risk aggregation and decisions | `lib/compliance/risk.ts` |
 | Velocity / behavioural rules | `lib/compliance/velocity.ts` |
 | Monitoring ledger | `lib/compliance/ledger.ts` |
@@ -189,6 +193,28 @@ to a case without seeing why it was flagged.
 The code says "SAR" because that is the term in the requirement. Every regulator
 above calls the same artefact a Suspicious Transaction Report (STR).
 
+### Markets without a local registration
+
+Mobile money is available in five countries beyond the licensed five — TZ, CM,
+CI, RW and ZM. A payment from one of them is screened in full: sanctions,
+wallet risk and every velocity rule behave identically, because a designated
+person is designated everywhere. What it cannot produce is a filing.
+`draftSar()` refuses on these cases with `NO_FILING_ROUTE`, and the SQL `CHECK`
+on `compliance_sars.jurisdiction` refuses the row independently, so an analyst
+can only disposition them internally and escalate to the MLRO.
+
+Their structuring anchor is `UNLICENSED_MARKET_POLICY` — the lowest of the five
+licensed thresholds rather than an average, because under-detecting in a market
+with no filing route is the worse error. See gap 10.
+
+### Currency
+
+Screening thresholds are USD cents throughout. `resolveMarket()` maps the
+payment currency to the market whose policy applies, and `toUsdCents()`
+converts the amount using the static table in `FX_USD_CENTS_PER_UNIT`. A
+currency in neither table is refused (`UNSUPPORTED_MARKET`, HTTP 422) rather
+than screened against a guessed market — see gap 8.
+
 ---
 
 ## Analyst workflow
@@ -323,7 +349,31 @@ Ordered by what blocks production first.
    standard control and is not implemented. `screenTransaction()` accepts
    `skipLedger` specifically so that job can re-screen without double-counting.
 
-8. **Onramp and bill payments are not yet wired in.** Only `/api/withdrawals`
-   calls `screenTransaction()`. `/api/compliance/screen` exists for the other
-   paths to call; they do not call it yet. The offramp leg was done first
-   because that is where a designated person actually receives value.
+8. **FX rates are configuration, not a feed.** Thresholds are in USD cents;
+   mobile-money and bill payments arrive in local currency, so
+   `FX_USD_CENTS_PER_UNIT` converts them. It is a static table, deliberately —
+   a rate API in the payment path turns every rate outage into a payments
+   outage under `FAIL_CLOSED`, and a band that drifts with spot makes "was this
+   transaction in the band?" unanswerable after the fact. The cost is drift.
+   Review it on the same cycle as `reportingThresholdCents`, and re-derive both
+   together: revising rates without revising thresholds silently retunes every
+   rule.
+
+9. **Anonymous payers are identified by instrument.** Bill and mobile-money
+   payers without a connected wallet are keyed to a salted hash of their phone
+   number or email (`lib/compliance/identity.ts`). One person with two handsets
+   is two accounts to the velocity rules; a shared handset is one account for
+   two people. Both resolve once the payer connects a wallet, which is why the
+   wallet key is preferred whenever the client sends one. Proper identity
+   resolution — linking instruments to a customer record — is the real fix and
+   is not implemented.
+
+10. **Markets without a local registration are screened but not filable.**
+    Mobile money reaches TZ, CM, CI, RW and ZM, where Aframp holds no AML
+    registration. Those transactions are screened in full under
+    `UNLICENSED_MARKET_POLICY`, and `draftSar()` refuses on the resulting cases
+    because there is no FIU to receive a filing. An analyst can disposition
+    them internally and nothing more. This is a stopgap that keeps the payment
+    path from moving money unscreened — it is not a substitute for either
+    registering in those markets or withdrawing from them, and that decision
+    should not sit with engineering.

--- a/lib/compliance/__tests__/case-store.test.ts
+++ b/lib/compliance/__tests__/case-store.test.ts
@@ -1,0 +1,391 @@
+/**
+ * Case management and SAR workflow tests.
+ *
+ * The properties pinned here are the ones an examiner actually tests: that
+ * decisions are attributed, that the audit trail only grows, that filing
+ * deadlines run from suspicion rather than from convenience, and that a case
+ * cannot be reported twice.
+ */
+
+import {
+  SarError,
+  _clearCases,
+  addCaseNote,
+  assignCase,
+  decideCase,
+  draftSar,
+  getCase,
+  getCaseByTransaction,
+  getCaseStats,
+  listCases,
+  listSars,
+  openCase,
+  reopenCase,
+  retentionExpiryFor,
+  updateSarStatus,
+} from '../case-store'
+import { JURISDICTIONS, RECORD_RETENTION_YEARS } from '../config'
+import type { Jurisdiction, ScreeningResult, ScreeningSubject } from '../types'
+
+const USER = 'GTESTWALLET000000000000000000000000000000000000000000'
+
+let sequence = 0
+
+function subject(overrides: Partial<ScreeningSubject> = {}): ScreeningSubject {
+  return {
+    transactionId: `tx_${sequence++}`,
+    userId: USER,
+    kind: 'offramp',
+    amountCents: 500_00,
+    asset: 'USDC',
+    chain: 'Stellar',
+    jurisdiction: 'NG',
+    ...overrides,
+  }
+}
+
+function result(overrides: Partial<ScreeningResult> = {}): Omit<ScreeningResult, 'caseId'> {
+  return {
+    transactionId: 'tx',
+    userId: USER,
+    decision: 'REVIEW',
+    riskScore: 65,
+    riskLevel: 'HIGH',
+    signals: [
+      { code: 'STRUCTURING', severity: 'HIGH', score: 70, description: 'structured' },
+    ],
+    providers: [],
+    screenedAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+/** Opens a case and returns it. */
+function open(overrides: Partial<ScreeningSubject> = {}) {
+  const input = subject(overrides)
+  return openCase(input, result({ transactionId: input.transactionId }))
+}
+
+beforeEach(() => {
+  _clearCases()
+  sequence = 0
+})
+
+// ---------------------------------------------------------------------------
+
+describe('openCase', () => {
+  it('opens a case with a system-authored creation event', () => {
+    const record = open()
+
+    expect(record.status).toBe('OPEN')
+    expect(record.events).toHaveLength(1)
+    expect(record.events[0]).toMatchObject({ actor: 'system', action: 'CREATED' })
+    expect(record.events[0].detail).toContain('STRUCTURING')
+  })
+
+  it('is idempotent per transaction', () => {
+    const input = subject()
+    const first = openCase(input, result({ transactionId: input.transactionId }))
+    const second = openCase(input, result({ transactionId: input.transactionId }))
+
+    expect(second.id).toBe(first.id)
+    expect(listCases().total).toBe(1)
+  })
+
+  it('is findable by transaction id', () => {
+    const input = subject()
+    const record = openCase(input, result({ transactionId: input.transactionId }))
+    expect(getCaseByTransaction(input.transactionId)?.id).toBe(record.id)
+  })
+})
+
+describe('audit trail', () => {
+  it('attributes every action to the analyst who took it', () => {
+    const record = open()
+
+    assignCase(record.id, 'ada.okafor')
+    addCaseNote(record.id, 'ada.okafor', 'Called the customer.')
+    decideCase({
+      caseId: record.id,
+      analystId: 'ben.mwangi',
+      status: 'CLEARED',
+      disposition: 'FALSE_POSITIVE',
+      rationale: 'Salary payment, payslip provided.',
+    })
+
+    const actors = getCase(record.id)!.events.map((e) => e.actor)
+    expect(actors).toEqual(['system', 'ada.okafor', 'ada.okafor', 'ben.mwangi'])
+  })
+
+  it('only ever grows', () => {
+    const record = open()
+    const lengths: number[] = [getCase(record.id)!.events.length]
+
+    assignCase(record.id, 'ada.okafor')
+    lengths.push(getCase(record.id)!.events.length)
+    addCaseNote(record.id, 'ada.okafor', 'note')
+    lengths.push(getCase(record.id)!.events.length)
+    reopenCase(record.id, 'ada.okafor', 'new information')
+    lengths.push(getCase(record.id)!.events.length)
+
+    expect(lengths).toEqual([1, 2, 3, 4])
+  })
+
+  it('preserves the rationale of a decision verbatim', () => {
+    const record = open()
+    decideCase({
+      caseId: record.id,
+      analystId: 'ada.okafor',
+      status: 'CLEARED',
+      disposition: 'FALSE_POSITIVE',
+      rationale: 'Verified against a utility bill dated 2026-02-01.',
+    })
+
+    const trail = getCase(record.id)!.events.map((e) => e.detail).join(' ')
+    expect(trail).toContain('Verified against a utility bill dated 2026-02-01.')
+  })
+})
+
+describe('assignCase', () => {
+  it('moves an open case into review', () => {
+    const record = open()
+    expect(assignCase(record.id, 'ada.okafor')).toMatchObject({
+      assignedTo: 'ada.okafor',
+      status: 'IN_REVIEW',
+    })
+  })
+
+  it('does not drag a closed case back into the queue', () => {
+    const record = open()
+    decideCase({
+      caseId: record.id,
+      analystId: 'ada.okafor',
+      status: 'CLEARED',
+      rationale: 'cleared',
+    })
+
+    expect(assignCase(record.id, 'ben.mwangi')?.status).toBe('CLEARED')
+  })
+
+  it('returns null for an unknown case', () => {
+    expect(assignCase('CASE-NOPE', 'ada.okafor')).toBeNull()
+  })
+})
+
+describe('reopenCase', () => {
+  it('clears the disposition but keeps its history', () => {
+    const record = open()
+    decideCase({
+      caseId: record.id,
+      analystId: 'ada.okafor',
+      status: 'CLEARED',
+      disposition: 'FALSE_POSITIVE',
+      rationale: 'Looked fine.',
+    })
+
+    const reopened = reopenCase(record.id, 'qa.reviewer', 'QA sample')!
+    expect(reopened.status).toBe('IN_REVIEW')
+    expect(reopened.disposition).toBeUndefined()
+    // The original conclusion must remain visible.
+    expect(reopened.events.map((e) => e.detail).join(' ')).toContain('Looked fine.')
+  })
+})
+
+describe('listCases', () => {
+  beforeEach(() => {
+    open({ jurisdiction: 'NG' })
+    open({ jurisdiction: 'KE' })
+    const third = open({ jurisdiction: 'NG' })
+    assignCase(third.id, 'ada.okafor')
+  })
+
+  it('filters by status', () => {
+    expect(listCases({ status: 'OPEN' }).total).toBe(2)
+    expect(listCases({ status: 'IN_REVIEW' }).total).toBe(1)
+  })
+
+  it('filters by jurisdiction', () => {
+    expect(listCases({ jurisdiction: 'NG' }).total).toBe(2)
+  })
+
+  it('filters by assignee', () => {
+    expect(listCases({ assignedTo: 'ada.okafor' }).total).toBe(1)
+  })
+
+  it('reports the pre-paging total alongside the page', () => {
+    const { cases, total } = listCases({ limit: 1 })
+    expect(cases).toHaveLength(1)
+    expect(total).toBe(3)
+  })
+
+  it('filters by minimum risk score', () => {
+    expect(listCases({ minRiskScore: 90 }).total).toBe(0)
+    expect(listCases({ minRiskScore: 65 }).total).toBe(3)
+  })
+})
+
+describe('getCaseStats', () => {
+  it('counts cases by status', () => {
+    open()
+    const second = open()
+    assignCase(second.id, 'ada.okafor')
+
+    const stats = getCaseStats()
+    expect(stats.total).toBe(2)
+    expect(stats.byStatus.OPEN).toBe(1)
+    expect(stats.byStatus.IN_REVIEW).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// SAR workflow
+// ---------------------------------------------------------------------------
+
+const NARRATIVE =
+  'Customer received three sub-threshold transfers within seven days totalling more than the reporting threshold, with no documented source of funds.'
+
+describe('draftSar', () => {
+  it('routes the filing to the jurisdiction regulator', () => {
+    const record = open({ jurisdiction: 'KE' })
+    const sar = draftSar({ caseId: record.id, analystId: 'ada.okafor', narrative: NARRATIVE })
+
+    expect(sar.regulator).toBe(JURISDICTIONS.KE.regulator)
+    expect(sar.status).toBe('DRAFT')
+  })
+
+  it('runs the deadline from when suspicion was formed, not from draft time', () => {
+    // Dating the clock from drafting would let a backlog quietly extinguish
+    // every deadline — the precise failure the deadline exists to prevent.
+    const record = open({ jurisdiction: 'NG' })
+    const sar = draftSar({ caseId: record.id, analystId: 'ada.okafor', narrative: NARRATIVE })
+
+    expect(sar.suspicionFormedAt).toBe(record.createdAt)
+
+    const expectedDue =
+      new Date(record.createdAt).getTime() + JURISDICTIONS.NG.filingDeadlineHours * 3_600_000
+    expect(new Date(sar.dueAt).getTime()).toBe(expectedDue)
+  })
+
+  it('applies each market own filing window', () => {
+    const cases: Record<string, string> = {}
+    for (const code of ['NG', 'KE', 'ZA'] as Jurisdiction[]) {
+      const record = open({ jurisdiction: code })
+      const sar = draftSar({ caseId: record.id, analystId: 'a', narrative: NARRATIVE })
+      cases[code] = sar.dueAt
+    }
+
+    // ZA allows materially longer than NG, so the deadlines must differ.
+    expect(new Date(cases.ZA).getTime()).toBeGreaterThan(new Date(cases.NG).getTime())
+  })
+
+  it('marks the case confirmed suspicious', () => {
+    const record = open()
+    const sar = draftSar({ caseId: record.id, analystId: 'ada.okafor', narrative: NARRATIVE })
+
+    const updated = getCase(record.id)!
+    expect(updated.status).toBe('CONFIRMED_SUSPICIOUS')
+    expect(updated.sarId).toBe(sar.id)
+  })
+
+  it('copies the grounds for suspicion from the case', () => {
+    const record = open()
+    const sar = draftSar({ caseId: record.id, analystId: 'ada.okafor', narrative: NARRATIVE })
+    expect(sar.groundsForSuspicion).toEqual(['STRUCTURING'])
+  })
+
+  it('refuses a second filing for the same case', () => {
+    const record = open()
+    draftSar({ caseId: record.id, analystId: 'ada.okafor', narrative: NARRATIVE })
+
+    expect(() =>
+      draftSar({ caseId: record.id, analystId: 'ada.okafor', narrative: NARRATIVE })
+    ).toThrow(SarError)
+  })
+
+  it('refuses to file against an unknown case', () => {
+    expect(() =>
+      draftSar({ caseId: 'CASE-NOPE', analystId: 'ada.okafor', narrative: NARRATIVE })
+    ).toThrow(SarError)
+  })
+})
+
+describe('updateSarStatus', () => {
+  function draft() {
+    const record = open()
+    return draftSar({ caseId: record.id, analystId: 'ada.okafor', narrative: NARRATIVE })
+  }
+
+  it('walks DRAFT → SUBMITTED → ACKNOWLEDGED', () => {
+    const sar = draft()
+
+    const submitted = updateSarStatus(sar.id, 'ada.okafor', 'SUBMITTED')
+    expect(submitted.status).toBe('SUBMITTED')
+    expect(submitted.submittedAt).toBeDefined()
+
+    const acknowledged = updateSarStatus(sar.id, 'ada.okafor', 'ACKNOWLEDGED', 'NFIU-2026-001')
+    expect(acknowledged.status).toBe('ACKNOWLEDGED')
+    expect(acknowledged.regulatorReference).toBe('NFIU-2026-001')
+  })
+
+  it('refuses to jump straight from draft to acknowledged', () => {
+    // A record that can reach ACKNOWLEDGED without ever being submitted is a
+    // record that can be falsified after the fact.
+    const sar = draft()
+    expect(() => updateSarStatus(sar.id, 'ada.okafor', 'ACKNOWLEDGED')).toThrow(SarError)
+  })
+
+  it('allows a rejected filing to be resubmitted', () => {
+    const sar = draft()
+    updateSarStatus(sar.id, 'ada.okafor', 'SUBMITTED')
+    updateSarStatus(sar.id, 'ada.okafor', 'REJECTED')
+    expect(updateSarStatus(sar.id, 'ada.okafor', 'SUBMITTED').status).toBe('SUBMITTED')
+  })
+
+  it('treats acknowledgement as final', () => {
+    const sar = draft()
+    updateSarStatus(sar.id, 'ada.okafor', 'SUBMITTED')
+    updateSarStatus(sar.id, 'ada.okafor', 'ACKNOWLEDGED')
+    expect(() => updateSarStatus(sar.id, 'ada.okafor', 'SUBMITTED')).toThrow(SarError)
+  })
+
+  it('logs the transition on the case', () => {
+    const sar = draft()
+    updateSarStatus(sar.id, 'ada.okafor', 'SUBMITTED')
+
+    const trail = getCase(sar.caseId)!.events.map((e) => e.detail).join(' ')
+    expect(trail).toContain('SUBMITTED')
+  })
+})
+
+describe('listSars', () => {
+  it('orders by soonest deadline', () => {
+    // ZA has the longest filing window of the three, so it must sort last.
+    for (const code of ['ZA', 'NG', 'KE'] as Jurisdiction[]) {
+      const record = open({ jurisdiction: code })
+      draftSar({ caseId: record.id, analystId: 'a', narrative: NARRATIVE })
+    }
+
+    const jurisdictions = listSars().map((s) => s.jurisdiction)
+    expect(jurisdictions[0]).toBe('NG')
+    expect(jurisdictions[jurisdictions.length - 1]).toBe('ZA')
+  })
+
+  it('filters to a single market', () => {
+    for (const code of ['NG', 'KE'] as Jurisdiction[]) {
+      const record = open({ jurisdiction: code })
+      draftSar({ caseId: record.id, analystId: 'a', narrative: NARRATIVE })
+    }
+
+    expect(listSars({ jurisdiction: 'NG' })).toHaveLength(1)
+  })
+})
+
+describe('retentionExpiryFor', () => {
+  it('is five years after the case was opened', () => {
+    const record = open()
+    const expiry = new Date(retentionExpiryFor(record))
+    const created = new Date(record.createdAt)
+
+    expect(expiry.getFullYear() - created.getFullYear()).toBe(RECORD_RETENTION_YEARS)
+  })
+})

--- a/lib/compliance/__tests__/case-store.test.ts
+++ b/lib/compliance/__tests__/case-store.test.ts
@@ -266,6 +266,20 @@ describe('draftSar', () => {
     expect(new Date(sar.dueAt).getTime()).toBe(expectedDue)
   })
 
+  it('refuses to draft against a market with no filing route', () => {
+    // There is no FIU to receive it.  Minting a SAR addressed to no regulator
+    // would set `sarId` and make the case read as discharged everywhere that
+    // counts filings, while the review obligation is still live.
+    const record = open({ jurisdiction: 'TZ' })
+
+    expect(() =>
+      draftSar({ caseId: record.id, analystId: 'ada.okafor', narrative: NARRATIVE })
+    ).toThrow(expect.objectContaining({ code: 'NO_FILING_ROUTE' }))
+
+    expect(getCase(record.id)?.sarId).toBeUndefined()
+    expect(getCase(record.id)?.status).toBe('OPEN')
+  })
+
   it('applies each market own filing window', () => {
     const cases: Record<string, string> = {}
     for (const code of ['NG', 'KE', 'ZA'] as Jurisdiction[]) {

--- a/lib/compliance/__tests__/markets.test.ts
+++ b/lib/compliance/__tests__/markets.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Market resolution, FX normalisation and payer identity.
+ *
+ * These are small functions guarding a large assumption: that every rule
+ * downstream is comparing like with like.  A currency that resolves to the
+ * wrong market, or an amount converted with the wrong scale, does not fail
+ * loudly — it produces a screening record that looks correct and measures the
+ * transaction against thresholds meant for somewhere else.  So the cases here
+ * are mostly about what must *not* be silently accepted.
+ */
+
+import { CURRENCY_MARKETS, JURISDICTIONS, UNLICENSED_MARKET_POLICY } from '../config'
+import { payerIdentity } from '../identity'
+import {
+  isLicensedJurisdiction,
+  policyFor,
+  resolveMarket,
+  toUsdCents,
+  UnsupportedMarketError,
+} from '../markets'
+import type { Market } from '../types'
+
+describe('resolveMarket', () => {
+  it('maps each licensed market currency to its jurisdiction', () => {
+    expect(resolveMarket('NGN')).toBe('NG')
+    expect(resolveMarket('KES')).toBe('KE')
+    expect(resolveMarket('GHS')).toBe('GH')
+    expect(resolveMarket('ZAR')).toBe('ZA')
+    expect(resolveMarket('UGX')).toBe('UG')
+  })
+
+  it('maps mobile-money currencies outside the licensed footprint', () => {
+    expect(resolveMarket('TZS')).toBe('TZ')
+    expect(resolveMarket('RWF')).toBe('RW')
+    expect(resolveMarket('ZMW')).toBe('ZM')
+  })
+
+  it('accepts lowercase and padded input', () => {
+    expect(resolveMarket('  kes ')).toBe('KE')
+  })
+
+  it('refuses an unmapped currency rather than guessing a market', () => {
+    // The alternative — defaulting to some market — would produce a case file
+    // asserting a jurisdiction the transaction never touched.
+    expect(() => resolveMarket('EUR')).toThrow(UnsupportedMarketError)
+    expect(() => resolveMarket('')).toThrow(UnsupportedMarketError)
+  })
+
+  it('carries the offending currency on the error so the route can report it', () => {
+    expect(() => resolveMarket('EUR')).toThrow(
+      expect.objectContaining({ code: 'UNSUPPORTED_MARKET', currency: 'EUR' })
+    )
+  })
+})
+
+describe('policyFor', () => {
+  it('returns the statutory policy for a licensed market', () => {
+    expect(policyFor('NG')).toBe(JURISDICTIONS.NG)
+    expect(policyFor('KE').regulator).toBe('FRC')
+  })
+
+  it('falls back to the unlicensed policy rather than throwing', () => {
+    // Rules call this mid-screening.  Throwing here would surface to the route
+    // as "engine broken", indistinguishable from a real fault, and the
+    // transaction would end up unscreened either way.
+    expect(policyFor('TZ')).toBe(UNLICENSED_MARKET_POLICY)
+    expect(policyFor('TZ').licensed).toBe(false)
+  })
+
+  it('anchors the unlicensed threshold to the lowest licensed one', () => {
+    const lowest = Math.min(
+      ...Object.values(JURISDICTIONS).map((p) => p.reportingThresholdCents)
+    )
+    expect(UNLICENSED_MARKET_POLICY.reportingThresholdCents).toBe(lowest)
+  })
+
+  it('resolves a policy for every currency the payment routes accept', () => {
+    // A currency in the table with no reachable policy would throw inside a
+    // velocity rule at screening time.
+    for (const market of Object.values(CURRENCY_MARKETS)) {
+      expect(policyFor(market).reportingThresholdCents).toBeGreaterThan(0)
+    }
+  })
+})
+
+describe('isLicensedJurisdiction', () => {
+  it('separates filing routes from screening-only markets', () => {
+    expect(isLicensedJurisdiction('ZA')).toBe(true)
+    expect(isLicensedJurisdiction('CI')).toBe(false)
+  })
+
+  it('agrees with the licensed flag on the policy', () => {
+    for (const market of Object.values(CURRENCY_MARKETS) as Market[]) {
+      expect(isLicensedJurisdiction(market)).toBe(policyFor(market).licensed)
+    }
+  })
+})
+
+describe('toUsdCents', () => {
+  it('converts local major units to USD cents', () => {
+    // 1,000,000 NGN at 0.066 cents per naira ≈ $660.
+    expect(toUsdCents(1_000_000, 'NGN')).toBe(66_000)
+    expect(toUsdCents(100, 'USD')).toBe(10_000)
+  })
+
+  it('rounds to whole cents', () => {
+    expect(Number.isInteger(toUsdCents(1234.56, 'KES'))).toBe(true)
+  })
+
+  it('is case- and whitespace-insensitive, matching resolveMarket', () => {
+    expect(toUsdCents(100, ' kes ')).toBe(toUsdCents(100, 'KES'))
+  })
+
+  it('refuses a currency it has no rate for', () => {
+    expect(() => toUsdCents(100, 'EUR')).toThrow(UnsupportedMarketError)
+  })
+
+  it('rejects non-positive and non-finite amounts', () => {
+    // Zero and NaN would sail past every threshold as an unremarkable
+    // transaction rather than being caught as bad input.
+    expect(() => toUsdCents(0, 'NGN')).toThrow(RangeError)
+    expect(() => toUsdCents(-5, 'NGN')).toThrow(RangeError)
+    expect(() => toUsdCents(Number.NaN, 'NGN')).toThrow(RangeError)
+    expect(() => toUsdCents(Number.POSITIVE_INFINITY, 'NGN')).toThrow(RangeError)
+  })
+
+  it('has a rate for every currency it will be asked to convert', () => {
+    for (const currency of Object.keys(CURRENCY_MARKETS)) {
+      expect(() => toUsdCents(1000, currency)).not.toThrow()
+    }
+  })
+})
+
+describe('payerIdentity', () => {
+  const SALT = 'test-salt'
+  let previousSalt: string | undefined
+
+  beforeAll(() => {
+    previousSalt = process.env.COMPLIANCE_HASH_SALT
+    process.env.COMPLIANCE_HASH_SALT = SALT
+  })
+
+  afterAll(() => {
+    process.env.COMPLIANCE_HASH_SALT = previousSalt
+  })
+
+  it('is stable for the same payer, so velocity rules accumulate', () => {
+    // The whole point: two payments from one handset must key to one account.
+    expect(payerIdentity('msisdn', '+254712345678')).toBe(
+      payerIdentity('msisdn', '+254712345678')
+    )
+  })
+
+  it('normalises formatting differences in a phone number', () => {
+    expect(payerIdentity('msisdn', '+254 712 345 678')).toBe(
+      payerIdentity('msisdn', '+254712345678')
+    )
+  })
+
+  it('normalises case in an email address', () => {
+    expect(payerIdentity('email', 'Ada@Example.COM ')).toBe(payerIdentity('email', 'ada@example.com'))
+  })
+
+  it('does not collide across instruments', () => {
+    expect(payerIdentity('msisdn', 'same-value')).not.toBe(payerIdentity('email', 'same-value'))
+  })
+
+  it('distinguishes different payers', () => {
+    expect(payerIdentity('msisdn', '+254712345678')).not.toBe(
+      payerIdentity('msisdn', '+254712345679')
+    )
+  })
+
+  it('does not leak the raw identifier', () => {
+    // This id lands in the ledger and on case files; a phone number in it
+    // would defeat the pseudonymisation hashCounterparty() exists to provide.
+    const id = payerIdentity('msisdn', '+254712345678')
+    expect(id).not.toContain('254712345678')
+    expect(id).toMatch(/^msisdn:[0-9a-f]{64}$/)
+  })
+
+  it('throws without a salt rather than hashing unsalted', () => {
+    delete process.env.COMPLIANCE_HASH_SALT
+    expect(() => payerIdentity('email', 'ada@example.com')).toThrow(/COMPLIANCE_HASH_SALT/)
+    process.env.COMPLIANCE_HASH_SALT = SALT
+  })
+})

--- a/lib/compliance/__tests__/matching.test.ts
+++ b/lib/compliance/__tests__/matching.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Name matching tests.
+ *
+ * These are the tests that matter most in the whole module.  A screening
+ * control is only as good as its matcher: too strict and designated people walk
+ * through under a transliteration variant, too loose and analysts drown in
+ * homonyms and start clearing everything reflexively.
+ *
+ * The cases below are grouped by the failure they guard against, and the
+ * "must not match" group is as important as the "must match" one.
+ */
+
+import {
+  bestAliasMatch,
+  jaro,
+  jaroWinkler,
+  nameSimilarity,
+  normalizeName,
+  tokenize,
+} from '../sanctions/matching'
+import { NAME_SCREENING } from '../config'
+
+const THRESHOLD = NAME_SCREENING.matchThreshold
+
+describe('normalizeName', () => {
+  it('strips diacritics so transliterations converge', () => {
+    expect(normalizeName('Séïdou Traoré')).toBe('seidou traore')
+  })
+
+  it('folds punctuation and connectors to spaces', () => {
+    expect(normalizeName('Al-Hassan')).toBe('al hassan')
+    expect(normalizeName('Al Hassan')).toBe('al hassan')
+  })
+
+  it("removes elision apostrophes rather than splitting on them", () => {
+    // d'Souza must not become two tokens "d" and "souza".
+    expect(normalizeName("D'Souza")).toBe('dsouza')
+  })
+
+  it('collapses repeated whitespace and trims', () => {
+    expect(normalizeName('  Musa   Bello  ')).toBe('musa bello')
+  })
+})
+
+describe('tokenize', () => {
+  it('drops honorifics common in Aframp markets', () => {
+    expect(tokenize('Alhaji Ibrahim Danjuma')).toEqual(['ibrahim', 'danjuma'])
+    expect(tokenize('Chief Mrs Nomvula Sithole')).toEqual(['nomvula', 'sithole'])
+  })
+
+  it('drops corporate suffixes only in entity mode', () => {
+    expect(tokenize('Zawadi Holdings Limited', { entity: true })).toEqual(['zawadi'])
+    expect(tokenize('Zawadi Holdings Limited')).toEqual(['zawadi', 'holdings', 'limited'])
+  })
+
+  it('falls back to unstripped tokens rather than returning nothing', () => {
+    // A name made entirely of noise words must still screen against something —
+    // an empty token set would match nothing at all.
+    expect(tokenize('The Group', { entity: true })).toEqual(['the', 'group'])
+  })
+
+  it('drops single-character initials', () => {
+    expect(tokenize('Ibrahim M Danjuma')).toEqual(['ibrahim', 'danjuma'])
+  })
+})
+
+describe('jaro / jaroWinkler', () => {
+  it('scores identical strings 1', () => {
+    expect(jaro('musa', 'musa')).toBe(1)
+    expect(jaroWinkler('musa', 'musa')).toBe(1)
+  })
+
+  it('scores disjoint strings 0', () => {
+    expect(jaro('abc', 'xyz')).toBe(0)
+  })
+
+  it('rewards a shared prefix, which is how transliterations differ', () => {
+    // "Abdullahi" / "Abdulahi" share nine leading characters; the ending is
+    // where transliteration diverges.
+    expect(jaroWinkler('abdullahi', 'abdulahi')).toBeGreaterThan(
+      jaro('abdullahi', 'abdulahi')
+    )
+    expect(jaroWinkler('abdullahi', 'abdulahi')).toBeGreaterThan(0.95)
+  })
+
+  it('withholds the prefix bonus from weakly-similar strings', () => {
+    // Without the 0.7 guard, unrelated names sharing a prefix get inflated.
+    const score = jaroWinkler('mohammed', 'mostafa')
+    expect(score).toBe(jaro('mohammed', 'mostafa'))
+  })
+})
+
+describe('nameSimilarity — must match', () => {
+  it('ignores name order', () => {
+    expect(nameSimilarity('Hassan Mohammed', 'Mohammed Hassan')).toBe(1)
+  })
+
+  it('matches across transliteration variants', () => {
+    expect(nameSimilarity('Ibrahim Musa Danjuma', 'Ibraheem Moussa Danjouma')).toBeGreaterThanOrEqual(
+      THRESHOLD
+    )
+  })
+
+  it('matches when the list carries an extra middle name', () => {
+    // The list routinely holds more name parts than a bank record does.  This
+    // is the single most common cause of a missed true hit.
+    expect(nameSimilarity('Musa Bello', 'Musa Ibrahim Bello')).toBeGreaterThanOrEqual(
+      THRESHOLD
+    )
+  })
+
+  it('matches through an honorific', () => {
+    expect(nameSimilarity('Alhaji Ibrahim Danjuma', 'Ibrahim Danjuma')).toBe(1)
+  })
+
+  it('matches a hyphenated name against its spaced form', () => {
+    expect(nameSimilarity('Mohammed Al-Hassan', 'Mohammed Al Hassan')).toBe(1)
+  })
+
+  it('matches corporate forms in entity mode', () => {
+    expect(
+      nameSimilarity('Zawadi Holdings Ltd', 'ZAWADI HOLDINGS LIMITED', { entity: true })
+    ).toBe(1)
+  })
+
+  it('tolerates a single-character typo', () => {
+    expect(nameSimilarity('Nomvula Sithole', 'Nomvula Sithoie')).toBeGreaterThanOrEqual(
+      THRESHOLD
+    )
+  })
+})
+
+describe('nameSimilarity — must not match', () => {
+  it('rejects unrelated names', () => {
+    expect(nameSimilarity('Musa Bello', 'Grace Achieng')).toBeLessThan(THRESHOLD)
+  })
+
+  it('rejects a shared surname alone', () => {
+    // Sharing one name part out of two is not a hit; treating it as one would
+    // flag every customer with a common surname.
+    expect(nameSimilarity('Grace Bello', 'Musa Bello')).toBeLessThan(THRESHOLD)
+  })
+
+  it('rejects a shared first name alone', () => {
+    expect(nameSimilarity('Musa Bello', 'Musa Achieng')).toBeLessThan(THRESHOLD)
+  })
+
+  it('rejects a subset that shares only a common given name', () => {
+    expect(nameSimilarity('Mohammed', 'Mohammed Hassan Ibrahim Yusuf')).toBeLessThan(
+      THRESHOLD
+    )
+  })
+
+  it('returns 0 for an empty or symbol-only name', () => {
+    expect(nameSimilarity('', 'Musa Bello')).toBe(0)
+    expect(nameSimilarity('---', 'Musa Bello')).toBe(0)
+  })
+})
+
+describe('nameSimilarity — properties', () => {
+  it('is symmetric', () => {
+    const a = 'Ibrahim Musa Danjuma'
+    const b = 'Ibraheem Moussa Danjouma'
+    expect(nameSimilarity(a, b)).toBe(nameSimilarity(b, a))
+  })
+
+  it('is deterministic across repeated calls', () => {
+    // A screening score an analyst cannot reproduce is not defensible.
+    const scores = Array.from({ length: 5 }, () =>
+      nameSimilarity('Musa Bello', 'Musa Ibrahim Bello')
+    )
+    expect(new Set(scores).size).toBe(1)
+  })
+
+  it('never exceeds 1', () => {
+    expect(nameSimilarity('Musa Bello', 'Musa Bello')).toBeLessThanOrEqual(1)
+  })
+})
+
+describe('bestAliasMatch', () => {
+  const aliases = ['Ibrahim Musa Danjuma', 'Ibrahim M. Danjuma', 'Alhaji Ibrahim Danjuma']
+
+  it('returns the strongest alias and its score', () => {
+    const { score, alias } = bestAliasMatch('Alhaji Ibrahim Danjuma', aliases)
+    expect(score).toBe(1)
+    // Several aliases here reduce to the same token set once the honorific and
+    // the "M." initial are stripped, so they tie at 1.0 and the first wins.
+    // The score is what drives the decision; which of a set of equivalent
+    // aliases is surfaced to the analyst is cosmetic.
+    expect(['Ibrahim Musa Danjuma', 'Ibrahim M. Danjuma', 'Alhaji Ibrahim Danjuma']).toContain(
+      alias
+    )
+  })
+
+  it('prefers a stronger alias over a weaker earlier one', () => {
+    const { alias } = bestAliasMatch('Grace Achieng', ['Musa Bello', 'Grace Achieng'])
+    expect(alias).toBe('Grace Achieng')
+  })
+
+  it('finds a hit through an alias the primary name would have missed', () => {
+    // The whole point of carrying aliases: subjects use them.
+    const { score } = bestAliasMatch('Ibrahim Danjuma', aliases)
+    expect(score).toBeGreaterThanOrEqual(THRESHOLD)
+  })
+
+  it('reports no alias for an empty list', () => {
+    expect(bestAliasMatch('Musa Bello', [])).toEqual({ score: 0, alias: null })
+  })
+})

--- a/lib/compliance/__tests__/monitor.test.ts
+++ b/lib/compliance/__tests__/monitor.test.ts
@@ -1,0 +1,331 @@
+/**
+ * End-to-end screening tests.
+ *
+ * These cover the behaviours that make the difference between a control and a
+ * decoration:
+ *
+ *   - a sanctions hit blocks, and blocks regardless of accumulated score
+ *   - a provider outage does NOT silently approve
+ *   - blocked attempts are still recorded, so probing behaviour stays visible
+ *   - a case is opened for everything held or blocked, exactly once
+ */
+
+import { _clearCases, getCaseByTransaction } from '../case-store'
+import { _clearLedger, _ledger } from '../ledger'
+import { screenTransaction } from '../monitor'
+import { _resetProviders } from '../providers'
+import { _resetSanctionsList, _setSanctionsEntities } from '../sanctions/list'
+import type { ScreeningSubject } from '../types'
+
+const NOW = new Date('2026-03-15T12:00:00.000Z')
+const USER = 'GTESTWALLET000000000000000000000000000000000000000000'
+const SANCTIONED_ADDRESS = 'gsanctionedaddressfortestsonly0000000000000000000000'
+
+function subject(overrides: Partial<ScreeningSubject> = {}): ScreeningSubject {
+  return {
+    transactionId: `tx_${Math.random().toString(36).slice(2)}`,
+    userId: USER,
+    kind: 'offramp',
+    amountCents: 100_00,
+    asset: 'USDC',
+    chain: 'Stellar',
+    jurisdiction: 'NG',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  _clearLedger()
+  _clearCases()
+  _resetProviders()
+  _resetSanctionsList()
+
+  // Local providers by default — no network, deterministic.
+  process.env.COMPLIANCE_WALLET_PROVIDER = 'local'
+  process.env.COMPLIANCE_NAME_PROVIDER = 'local'
+  process.env.COMPLIANCE_HASH_SALT = 'test-salt'
+
+  _setSanctionsEntities([
+    {
+      id: 'TEST-001',
+      source: 'DEV FIXTURE',
+      name: 'Ibrahim Musa Danjuma',
+      aliases: ['Ibraheem Moussa Danjouma'],
+      entityType: 'INDIVIDUAL',
+      matchTypes: ['SANCTION'],
+      countries: ['NG'],
+      cryptoAddresses: [SANCTIONED_ADDRESS],
+    },
+    {
+      id: 'TEST-002',
+      source: 'DEV FIXTURE',
+      name: 'Nomvula Precious Sithole',
+      aliases: [],
+      entityType: 'INDIVIDUAL',
+      matchTypes: ['PEP'],
+      countries: ['ZA'],
+      cryptoAddresses: [],
+    },
+  ])
+})
+
+afterAll(() => {
+  delete process.env.COMPLIANCE_WALLET_PROVIDER
+  delete process.env.COMPLIANCE_NAME_PROVIDER
+  delete process.env.COMPLIANCE_HASH_SALT
+})
+
+// ---------------------------------------------------------------------------
+
+describe('clean transactions', () => {
+  it('allows an unremarkable transaction and opens no case', async () => {
+    const result = await screenTransaction(
+      subject({ accountName: 'Grace Achieng', amountCents: 50_00 }),
+      { now: NOW }
+    )
+
+    expect(result.decision).toBe('ALLOW')
+    expect(result.riskScore).toBe(0)
+    expect(result.signals).toEqual([])
+    expect(result.caseId).toBeUndefined()
+  })
+
+  it('records allowed transactions in the monitoring ledger', async () => {
+    const input = subject({ amountCents: 50_00 })
+    await screenTransaction(input, { now: NOW })
+
+    expect(_ledger.get(USER)).toHaveLength(1)
+    expect(_ledger.get(USER)?.[0]).toMatchObject({
+      transactionId: input.transactionId,
+      decision: 'ALLOW',
+    })
+  })
+})
+
+describe('sanctions screening', () => {
+  it('blocks a designated wallet address', async () => {
+    const result = await screenTransaction(
+      subject({ walletAddress: SANCTIONED_ADDRESS, amountCents: 10_00 }),
+      { now: NOW }
+    )
+
+    expect(result.decision).toBe('BLOCK')
+    expect(result.signals.map((s) => s.code)).toContain('WALLET_SEVERE_RISK')
+  })
+
+  it('blocks a designated address on an otherwise trivial amount', async () => {
+    // A designation is a legal prohibition, so it must not be outweighed by the
+    // transaction looking harmless.
+    const result = await screenTransaction(
+      subject({ walletAddress: SANCTIONED_ADDRESS, amountCents: 1 }),
+      { now: NOW }
+    )
+    expect(result.decision).toBe('BLOCK')
+  })
+
+  it('matches a designated address case-insensitively', async () => {
+    const result = await screenTransaction(
+      subject({ walletAddress: SANCTIONED_ADDRESS.toUpperCase() }),
+      { now: NOW }
+    )
+    expect(result.decision).toBe('BLOCK')
+  })
+
+  it('blocks an exact sanctioned account name', async () => {
+    const result = await screenTransaction(
+      subject({ accountName: 'Ibrahim Musa Danjuma' }),
+      { now: NOW }
+    )
+
+    expect(result.decision).toBe('BLOCK')
+    expect(result.signals.map((s) => s.code)).toContain('SANCTIONS_MATCH')
+  })
+
+  it('catches a transliterated alias', async () => {
+    const result = await screenTransaction(
+      subject({ accountName: 'Ibraheem Moussa Danjouma' }),
+      { now: NOW }
+    )
+    expect(result.signals.map((s) => s.code)).toContain('SANCTIONS_MATCH')
+  })
+
+  it('reviews rather than blocks a PEP match', async () => {
+    // A PEP is not a criminal — the obligation is enhanced due diligence, not
+    // refusal.  Blocking here would wrongly deny service.
+    const result = await screenTransaction(
+      subject({ accountName: 'Nomvula Precious Sithole' }),
+      { now: NOW }
+    )
+
+    expect(result.signals.map((s) => s.code)).toContain('PEP_MATCH')
+    expect(result.decision).not.toBe('BLOCK')
+  })
+
+  it('lets an unrelated name through', async () => {
+    const result = await screenTransaction(
+      subject({ accountName: 'Grace Achieng', walletAddress: 'gcleanaddress0001' }),
+      { now: NOW }
+    )
+    expect(result.decision).toBe('ALLOW')
+  })
+})
+
+describe('provider failure', () => {
+  /** Forces the configured wallet provider to throw. */
+  function breakWalletProvider() {
+    process.env.COMPLIANCE_WALLET_PROVIDER = 'chainalysis'
+    process.env.CHAINALYSIS_API_KEY = 'test-key'
+    _resetProviders()
+    global.fetch = jest.fn().mockRejectedValue(new Error('network down')) as typeof fetch
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks()
+    delete process.env.CHAINALYSIS_API_KEY
+  })
+
+  it('does not silently approve when the provider is unreachable', async () => {
+    breakWalletProvider()
+
+    const result = await screenTransaction(
+      subject({ walletAddress: 'gcleanaddress0001', amountCents: 10_00 }),
+      { now: NOW }
+    )
+
+    // This is the single most important assertion in the suite: an outage at
+    // the vendor must not become an unscreened payment path.
+    expect(result.decision).toBe('REVIEW')
+    expect(result.signals.map((s) => s.code)).toContain('PROVIDER_UNAVAILABLE')
+  })
+
+  it('still catches a designated address via the local list during an outage', async () => {
+    breakWalletProvider()
+
+    const result = await screenTransaction(
+      subject({ walletAddress: SANCTIONED_ADDRESS }),
+      { now: NOW }
+    )
+
+    expect(result.decision).toBe('BLOCK')
+  })
+
+  it('attributes the failed provider in the result', async () => {
+    breakWalletProvider()
+
+    const result = await screenTransaction(
+      subject({ walletAddress: 'gcleanaddress0001' }),
+      { now: NOW }
+    )
+
+    expect(result.providers).toEqual(
+      expect.arrayContaining([expect.objectContaining({ name: 'chainalysis', ok: false })])
+    )
+  })
+})
+
+describe('case creation', () => {
+  it('opens a case for a blocked transaction', async () => {
+    const input = subject({ walletAddress: SANCTIONED_ADDRESS })
+    const result = await screenTransaction(input, { now: NOW })
+
+    expect(result.caseId).toBeDefined()
+    const record = getCaseByTransaction(input.transactionId)
+    expect(record).toMatchObject({ status: 'OPEN', decision: 'BLOCK' })
+  })
+
+  it('records why the case was opened in its audit trail', async () => {
+    const input = subject({ accountName: 'Ibrahim Musa Danjuma' })
+    await screenTransaction(input, { now: NOW })
+
+    const record = getCaseByTransaction(input.transactionId)
+    expect(record?.events[0]).toMatchObject({ actor: 'system', action: 'CREATED' })
+    expect(record?.events[0].detail).toContain('SANCTIONS_MATCH')
+  })
+
+  it('does not open a second case when a screening call is retried', async () => {
+    // Clients retry on flaky networks; duplicate cases get worked and closed
+    // inconsistently by different analysts.
+    const input = subject({ walletAddress: SANCTIONED_ADDRESS })
+
+    const first = await screenTransaction(input, { now: NOW })
+    const second = await screenTransaction(input, { now: NOW })
+
+    expect(second.caseId).toBe(first.caseId)
+  })
+
+  it('does not duplicate a ledger entry when a screening call is retried', async () => {
+    const input = subject({ amountCents: 50_00 })
+
+    await screenTransaction(input, { now: NOW })
+    await screenTransaction(input, { now: NOW })
+
+    expect(_ledger.get(USER)).toHaveLength(1)
+  })
+})
+
+describe('blocked attempts remain visible', () => {
+  it('records a blocked transaction in the ledger', async () => {
+    // An attempt that was stopped is evidence of behaviour.  Dropping it would
+    // make a probing account look quieter than a legitimate one.
+    const input = subject({ walletAddress: SANCTIONED_ADDRESS })
+    await screenTransaction(input, { now: NOW })
+
+    expect(_ledger.get(USER)).toHaveLength(1)
+    expect(_ledger.get(USER)?.[0].decision).toBe('BLOCK')
+  })
+
+  it('counts blocked attempts towards subsequent velocity rules', async () => {
+    for (let i = 0; i < 3; i++) {
+      await screenTransaction(
+        subject({ walletAddress: SANCTIONED_ADDRESS, amountCents: 3_500_00 }),
+        { now: NOW }
+      )
+    }
+
+    // Three blocked $3,500 attempts have already been recorded, so a fourth
+    // transaction breaches the daily volume ceiling on history alone.
+    const result = await screenTransaction(subject({ amountCents: 100_00 }), { now: NOW })
+    expect(result.signals.map((s) => s.code)).toContain('VELOCITY_VOLUME')
+  })
+})
+
+describe('skipLedger', () => {
+  it('re-screens without double-counting the transaction', async () => {
+    const input = subject({ amountCents: 50_00 })
+    await screenTransaction(input, { now: NOW })
+    await screenTransaction(input, { now: NOW, skipLedger: true })
+
+    expect(_ledger.get(USER)).toHaveLength(1)
+  })
+})
+
+describe('counterparty privacy', () => {
+  it('never writes a raw counterparty identifier to the ledger', async () => {
+    const accountNumber = '0123456789'
+    await screenTransaction(
+      subject({ accountNumber, counterpartyId: accountNumber, amountCents: 50_00 }),
+      { now: NOW }
+    )
+
+    const entry = _ledger.get(USER)?.[0]
+    expect(entry?.counterpartyKey).toBeDefined()
+    expect(entry?.counterpartyKey).not.toContain(accountNumber)
+    expect(JSON.stringify(entry)).not.toContain(accountNumber)
+  })
+
+  it('produces a stable key for the same counterparty', async () => {
+    // Fan-out detection depends on the same recipient hashing identically.
+    await screenTransaction(
+      subject({ counterpartyId: '0123456789', amountCents: 10_00 }),
+      { now: NOW }
+    )
+    await screenTransaction(
+      subject({ counterpartyId: '0123456789', amountCents: 10_00 }),
+      { now: NOW }
+    )
+
+    const entries = _ledger.get(USER) ?? []
+    expect(entries).toHaveLength(2)
+    expect(entries[0].counterpartyKey).toBe(entries[1].counterpartyKey)
+  })
+})

--- a/lib/compliance/__tests__/payment-routes.test.ts
+++ b/lib/compliance/__tests__/payment-routes.test.ts
@@ -1,0 +1,207 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Screening in the payment path.
+ *
+ * The engine is tested thoroughly elsewhere.  What these tests protect is
+ * cheaper to break and worse to get wrong: that the payment routes actually
+ * call it, before they move anything, and that they act on what it returns.
+ *
+ * A wiring regression here is invisible from the inside — every unit test still
+ * passes, the console still works, and money simply stops being screened.  So
+ * these exercise the exported route handlers rather than the module.
+ *
+ * They run against the local list provider (the default when no vendor is
+ * configured) and the DEV_FIXTURE_ENTITIES corpus.
+ */
+
+process.env.COMPLIANCE_HASH_SALT = 'payment-routes-test-salt'
+
+import { NextRequest } from 'next/server'
+import { POST as initiateMobileMoney } from '@/app/api/payments/mobile-money/initiate/route'
+import { POST as initiateBillPayment } from '@/app/api/bills/initiate/route'
+import { _clearCases, listCases } from '../case-store'
+import { _clearLedger } from '../ledger'
+
+const MOMO_URL = 'http://localhost/api/payments/mobile-money/initiate'
+const BILLS_URL = 'http://localhost/api/bills/initiate'
+
+/** A name on the fixture sanctions list — see DEV_FIXTURE_ENTITIES. */
+const SANCTIONED_NAME = 'Ibrahim Musa Danjuma'
+
+function post(url: string, body: unknown) {
+  return new NextRequest(new URL(url), {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function momoBody(overrides: Record<string, unknown> = {}) {
+  return {
+    provider: 'mpesa',
+    phoneNumber: '+254712345678',
+    amount: 5000,
+    currency: 'KES',
+    accountReference: 'ref',
+    transactionDesc: 'test',
+    externalId: `tx_${Math.random().toString(36).slice(2)}`,
+    ...overrides,
+  }
+}
+
+function billBody(overrides: Record<string, unknown> = {}) {
+  return {
+    billerId: 'ikeja-electric',
+    accountNumber: '12345678901',
+    amount: 5000,
+    customerEmail: 'ada@example.com',
+    ...overrides,
+  }
+}
+
+beforeEach(() => {
+  _clearCases()
+  _clearLedger()
+})
+
+// ---------------------------------------------------------------------------
+
+describe('POST /api/payments/mobile-money/initiate', () => {
+  it('blocks a sanctioned payer before the collection is initiated', async () => {
+    const response = await initiateMobileMoney(
+      post(MOMO_URL, momoBody({ accountName: SANCTIONED_NAME }))
+    )
+
+    expect(response.status).toBe(403)
+    expect((await response.json()).error).toBe('COMPLIANCE_BLOCKED')
+  })
+
+  it('opens a case an analyst can find', async () => {
+    await initiateMobileMoney(post(MOMO_URL, momoBody({ accountName: SANCTIONED_NAME })))
+
+    const { cases, total } = listCases()
+    expect(total).toBe(1)
+    expect(cases[0]).toMatchObject({ decision: 'BLOCK', jurisdiction: 'KE', kind: 'onramp' })
+  })
+
+  it('returns a reference the customer can quote to support', async () => {
+    const response = await initiateMobileMoney(
+      post(MOMO_URL, momoBody({ accountName: SANCTIONED_NAME }))
+    )
+    const body = await response.json()
+
+    expect(body.referenceId).toBe(listCases().cases[0].id)
+  })
+
+  it('does not tell the customer why', async () => {
+    // Tipping off is a criminal offence in all five markets, and the message
+    // is identical for BLOCK and REVIEW.  See app/api/withdrawals/route.ts.
+    const response = await initiateMobileMoney(
+      post(MOMO_URL, momoBody({ accountName: SANCTIONED_NAME }))
+    )
+    const body = JSON.stringify(await response.json())
+
+    expect(body).not.toMatch(/sanction/i)
+    expect(body).not.toMatch(/danjuma/i)
+  })
+
+  it('derives the market from the payment currency', async () => {
+    await initiateMobileMoney(
+      post(MOMO_URL, momoBody({ currency: 'UGX', amount: 20_000_000, accountName: SANCTIONED_NAME }))
+    )
+
+    expect(listCases().cases[0].jurisdiction).toBe('UG')
+  })
+
+  it('screens a market with no local registration rather than skipping it', async () => {
+    // Rwanda is outside the licensed five.  A designated person is designated
+    // there too, so the control must still fire — it simply cannot be filed.
+    const response = await initiateMobileMoney(
+      post(
+        MOMO_URL,
+        momoBody({
+          provider: 'mtn_momo',
+          phoneNumber: '+250781234567',
+          currency: 'RWF',
+          amount: 500_000,
+          accountName: SANCTIONED_NAME,
+        })
+      )
+    )
+
+    expect(response.status).toBe(403)
+    expect(listCases().cases[0].jurisdiction).toBe('RW')
+  })
+
+  it('refuses a currency it holds no policy for', async () => {
+    // Not an outage — there is no threshold to measure this against, so it
+    // cannot be screened and must not be collected.
+    const response = await initiateMobileMoney(post(MOMO_URL, momoBody({ currency: 'EUR' })))
+
+    expect(response.status).toBe(422)
+    expect((await response.json()).error).toBe('UNSUPPORTED_MARKET')
+  })
+
+  it('keys an anonymous payer to a hashed handset, not a raw number', async () => {
+    await initiateMobileMoney(post(MOMO_URL, momoBody({ accountName: SANCTIONED_NAME })))
+
+    const { userId } = listCases().cases[0]
+    expect(userId).toMatch(/^msisdn:[0-9a-f]{64}$/)
+    expect(userId).not.toContain('254712345678')
+  })
+
+  it('prefers the wallet key when the client sends one', async () => {
+    // So a customer's ramp and bill activity accumulate under one identity.
+    const wallet = 'GTESTWALLET000000000000000000000000000000000000000000'
+    await initiateMobileMoney(
+      post(MOMO_URL, momoBody({ accountName: SANCTIONED_NAME, userId: wallet }))
+    )
+
+    expect(listCases().cases[0].userId).toBe(wallet)
+  })
+
+  it('records the payer identity consistently across payments', async () => {
+    // The premise of every velocity rule: two payments from one handset are
+    // one account.  If this breaks, the rules silently never fire.
+    await initiateMobileMoney(post(MOMO_URL, momoBody({ accountName: SANCTIONED_NAME })))
+    await initiateMobileMoney(post(MOMO_URL, momoBody({ accountName: SANCTIONED_NAME })))
+
+    const userIds = new Set(listCases().cases.map((c) => c.userId))
+    expect(listCases().total).toBe(2)
+    expect(userIds.size).toBe(1)
+  })
+})
+
+// ---------------------------------------------------------------------------
+
+describe('POST /api/bills/initiate', () => {
+  it('refuses a currency it holds no policy for', async () => {
+    const response = await initiateBillPayment(post(BILLS_URL, billBody({ currency: 'EUR' })))
+
+    expect(response.status).toBe(422)
+    expect((await response.json()).error).toBe('UNSUPPORTED_MARKET')
+  })
+
+  it('screens before handing anything to the gateway', async () => {
+    // No gateway credentials are configured here, so reaching the gateway at
+    // all is what proves screening ran first and allowed it: a held payment
+    // would have returned 403 without ever calling out.
+    const response = await initiateBillPayment(post(BILLS_URL, billBody()))
+
+    expect(response.status).not.toBe(403)
+    expect(listCases().total).toBe(0)
+  })
+
+  it('keys an anonymous payer to a hashed email', async () => {
+    // Forced into a case via a volume the fixture ledger will flag, so the
+    // recorded identity can be inspected.
+    await initiateBillPayment(post(BILLS_URL, billBody({ amount: 500_000_000 })))
+
+    const [record] = listCases().cases
+    expect(record?.userId).toMatch(/^email:[0-9a-f]{64}$/)
+    expect(record?.userId).not.toContain('ada@example.com')
+  })
+})

--- a/lib/compliance/__tests__/risk.test.ts
+++ b/lib/compliance/__tests__/risk.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Risk aggregation tests.
+ *
+ * The scoring model gets argued about — by analysts tuning it and by examiners
+ * reviewing it — so its stated properties are pinned here rather than left as
+ * claims in a comment.
+ */
+
+import { DECISION_THRESHOLDS, SECONDARY_SIGNAL_WEIGHT } from '../config'
+import {
+  decideFromScore,
+  highestSeverity,
+  riskLevelForScore,
+  scoreSignals,
+  sortSignals,
+} from '../risk'
+import type { RiskLevel, RiskSignal, SignalCode } from '../types'
+
+function signal(score: number, severity: RiskLevel = 'MEDIUM', code = 'VELOCITY_VOLUME'): RiskSignal {
+  return { code: code as SignalCode, severity, score, description: 'test' }
+}
+
+describe('scoreSignals', () => {
+  it('scores an empty set 0', () => {
+    expect(scoreSignals([])).toBe(0)
+  })
+
+  it('returns the signal score itself when only one fired', () => {
+    expect(scoreSignals([signal(55)])).toBe(55)
+  })
+
+  it('discounts every signal after the strongest', () => {
+    // 60 + 0.35 × (40 + 20) = 81
+    const expected = Math.round(60 + SECONDARY_SIGNAL_WEIGHT * 60)
+    expect(scoreSignals([signal(40), signal(60), signal(20)])).toBe(expected)
+  })
+
+  it('is order-independent', () => {
+    const signals = [signal(40), signal(60), signal(20)]
+    const reversed = [...signals].reverse()
+    expect(scoreSignals(signals)).toBe(scoreSignals(reversed))
+  })
+
+  it('is monotone — adding a signal never lowers the score', () => {
+    // This is the property that makes the model defensible: more evidence
+    // cannot make a transaction look safer.
+    const base = [signal(50)]
+    for (const extra of [1, 25, 70, 100]) {
+      expect(scoreSignals([...base, signal(extra)])).toBeGreaterThanOrEqual(
+        scoreSignals(base)
+      )
+    }
+  })
+
+  it('ranks one severe signal above several weak ones', () => {
+    // The failure a plain sum would produce: three unremarkable signals
+    // outranking a single dangerous one, so analysts triage noise first.
+    const severe = scoreSignals([signal(100, 'SEVERE')])
+    const weak = scoreSignals([signal(30), signal(30), signal(30)])
+    expect(severe).toBeGreaterThan(weak)
+  })
+
+  it('lets corroboration escalate across a band boundary', () => {
+    // The failure taking max alone would produce: four rules firing at once
+    // scoring identically to one.
+    const alone = scoreSignals([signal(45)])
+    const corroborated = scoreSignals([signal(45), signal(45), signal(40)])
+    expect(corroborated).toBeGreaterThan(alone)
+    expect(riskLevelForScore(corroborated)).not.toBe(riskLevelForScore(alone))
+  })
+
+  it('caps at 100', () => {
+    expect(scoreSignals([signal(100), signal(100), signal(100)])).toBe(100)
+  })
+
+  it('clamps out-of-range and non-finite scores rather than propagating them', () => {
+    expect(scoreSignals([signal(150)])).toBe(100)
+    expect(scoreSignals([signal(-20)])).toBe(0)
+    expect(scoreSignals([signal(Number.NaN)])).toBe(0)
+  })
+})
+
+describe('riskLevelForScore', () => {
+  it.each([
+    [0, 'LOW'],
+    [24, 'LOW'],
+    [25, 'MEDIUM'],
+    [49, 'MEDIUM'],
+    [50, 'HIGH'],
+    [74, 'HIGH'],
+    [75, 'SEVERE'],
+    [100, 'SEVERE'],
+  ])('maps %i to %s', (score, level) => {
+    expect(riskLevelForScore(score)).toBe(level)
+  })
+
+  it('clamps scores outside 0–100', () => {
+    expect(riskLevelForScore(-5)).toBe('LOW')
+    expect(riskLevelForScore(500)).toBe('SEVERE')
+  })
+})
+
+describe('decideFromScore', () => {
+  it('allows below the review threshold', () => {
+    expect(decideFromScore(DECISION_THRESHOLDS.review - 1)).toBe('ALLOW')
+  })
+
+  it('reviews at the threshold', () => {
+    expect(decideFromScore(DECISION_THRESHOLDS.review)).toBe('REVIEW')
+  })
+
+  it('blocks at the block threshold', () => {
+    expect(decideFromScore(DECISION_THRESHOLDS.block)).toBe('BLOCK')
+  })
+
+  it('blocks on a hard block regardless of score', () => {
+    // A designation is a legal prohibition, not a risk-appetite question.
+    expect(decideFromScore(0, true)).toBe('BLOCK')
+  })
+})
+
+describe('highestSeverity', () => {
+  it('returns LOW for no signals', () => {
+    expect(highestSeverity([])).toBe('LOW')
+  })
+
+  it('returns the worst severity present regardless of score', () => {
+    expect(highestSeverity([signal(90, 'MEDIUM'), signal(10, 'SEVERE')])).toBe('SEVERE')
+  })
+})
+
+describe('sortSignals', () => {
+  it('orders by severity first, then score', () => {
+    const sorted = sortSignals([
+      signal(90, 'MEDIUM'),
+      signal(10, 'SEVERE'),
+      signal(40, 'HIGH'),
+      signal(95, 'MEDIUM'),
+    ])
+    expect(sorted.map((s) => [s.severity, s.score])).toEqual([
+      ['SEVERE', 10],
+      ['HIGH', 40],
+      ['MEDIUM', 95],
+      ['MEDIUM', 90],
+    ])
+  })
+
+  it('does not mutate its input', () => {
+    const signals = [signal(10, 'MEDIUM'), signal(90, 'SEVERE')]
+    const snapshot = [...signals]
+    sortSignals(signals)
+    expect(signals).toEqual(snapshot)
+  })
+})

--- a/lib/compliance/__tests__/velocity.test.ts
+++ b/lib/compliance/__tests__/velocity.test.ts
@@ -1,0 +1,305 @@
+/**
+ * Velocity rule tests.
+ *
+ * Each rule is tested for three things:
+ *   - it fires when it should
+ *   - it does NOT fire just below its threshold (the boundary is where tuning
+ *     arguments happen, so it is pinned)
+ *   - the evidence it records is the evidence an analyst needs
+ *
+ * `now` is injected everywhere rather than mocking the clock, so histories can
+ * be built relative to a fixed instant and the tests stay readable.
+ */
+
+import { DAY_MS, HOUR_MS, JURISDICTIONS, VELOCITY_RULES } from '../config'
+import { _clearLedger, recordTransaction } from '../ledger'
+import type { ScreeningSubject, SignalCode } from '../types'
+import { evaluateVelocityRules } from '../velocity'
+
+const NOW = new Date('2026-03-15T12:00:00.000Z')
+const USER = 'GTESTWALLET000000000000000000000000000000000000000000'
+
+let sequence = 0
+
+/** Adds a ledger entry `agoMs` before NOW. */
+function seed(
+  agoMs: number,
+  amountCents: number,
+  kind: 'onramp' | 'offramp' | 'billpay' = 'offramp',
+  counterpartyKey?: string
+) {
+  recordTransaction({
+    transactionId: `tx_${sequence++}`,
+    userId: USER,
+    kind,
+    amountCents,
+    asset: 'USDC',
+    chain: 'Stellar',
+    counterpartyKey,
+    decision: 'ALLOW',
+    riskScore: 0,
+    occurredAt: new Date(NOW.getTime() - agoMs),
+  })
+}
+
+function subject(overrides: Partial<ScreeningSubject> = {}): ScreeningSubject {
+  return {
+    transactionId: 'tx_subject',
+    userId: USER,
+    kind: 'offramp',
+    amountCents: 100_00,
+    asset: 'USDC',
+    chain: 'Stellar',
+    jurisdiction: 'NG',
+    ...overrides,
+  }
+}
+
+function codes(signals: ReturnType<typeof evaluateVelocityRules>): SignalCode[] {
+  return signals.map((s) => s.code)
+}
+
+function run(overrides: Partial<ScreeningSubject> = {}) {
+  return evaluateVelocityRules(subject(overrides), { now: NOW })
+}
+
+beforeEach(() => {
+  _clearLedger()
+  sequence = 0
+})
+
+// ---------------------------------------------------------------------------
+
+describe('VELOCITY_TX_COUNT', () => {
+  const { maxCount } = VELOCITY_RULES.txCount
+
+  it('fires once the count including the current transaction exceeds the cap', () => {
+    for (let i = 0; i < maxCount; i++) seed(HOUR_MS, 10_00)
+    expect(codes(run())).toContain('VELOCITY_TX_COUNT')
+  })
+
+  it('does not fire exactly at the cap', () => {
+    for (let i = 0; i < maxCount - 1; i++) seed(HOUR_MS, 10_00)
+    expect(codes(run())).not.toContain('VELOCITY_TX_COUNT')
+  })
+
+  it('ignores transactions outside the window', () => {
+    for (let i = 0; i < maxCount + 5; i++) seed(2 * DAY_MS, 10_00)
+    expect(codes(run())).not.toContain('VELOCITY_TX_COUNT')
+  })
+
+  it('records the observed count and threshold', () => {
+    for (let i = 0; i < maxCount; i++) seed(HOUR_MS, 10_00)
+    const signal = run().find((s) => s.code === 'VELOCITY_TX_COUNT')
+    expect(signal?.metadata).toMatchObject({
+      observedCount: maxCount + 1,
+      threshold: maxCount,
+    })
+  })
+})
+
+describe('VELOCITY_VOLUME', () => {
+  const { maxVolumeCents } = VELOCITY_RULES.volume
+
+  it('counts the transaction being screened, not just history', () => {
+    // History alone is under the ceiling; the subject pushes it over.  A rule
+    // that only looked at history would let the breaching transaction through.
+    seed(HOUR_MS, maxVolumeCents - 50_00)
+    expect(codes(run({ amountCents: 100_00 }))).toContain('VELOCITY_VOLUME')
+  })
+
+  it('does not fire when the total lands exactly on the ceiling', () => {
+    seed(HOUR_MS, maxVolumeCents - 100_00)
+    expect(codes(run({ amountCents: 100_00 }))).not.toContain('VELOCITY_VOLUME')
+  })
+})
+
+describe('VELOCITY_SPIKE', () => {
+  it('fires when today far exceeds the account trailing average', () => {
+    // 30 days of ~$20/day, then a $2,000 day.
+    for (let day = 2; day <= 30; day++) seed(day * DAY_MS, 20_00)
+    expect(codes(run({ amountCents: 2_000_00 }))).toContain('VELOCITY_SPIKE')
+  })
+
+  it('stays silent on a new account with no baseline', () => {
+    // The rule must not fire on a first real transaction — every new user would
+    // trivially clear any multiple of ~zero.
+    seed(HOUR_MS, 10_00)
+    expect(codes(run({ amountCents: 5_000_00 }))).not.toContain('VELOCITY_SPIKE')
+  })
+
+  it('stays silent when the trailing baseline is negligible', () => {
+    // Long history, but almost no value in it — a $2 baseline should not make
+    // a $100 transaction a "50× spike".
+    for (let day = 2; day <= 30; day++) seed(day * DAY_MS, 1)
+    expect(codes(run({ amountCents: 100_00 }))).not.toContain('VELOCITY_SPIKE')
+  })
+
+  it('does not compare the spike against itself', () => {
+    // Today's own volume is excluded from the baseline; if it were included,
+    // a large day would inflate its own mean and hide the ratio.
+    for (let day = 2; day <= 30; day++) seed(day * DAY_MS, 20_00)
+    seed(HOUR_MS, 1_500_00) // earlier today
+    const signal = run({ amountCents: 500_00 }).find((s) => s.code === 'VELOCITY_SPIKE')
+    expect(signal).toBeDefined()
+    expect(signal?.metadata?.todayCents).toBe(2_000_00)
+  })
+})
+
+describe('STRUCTURING', () => {
+  const threshold = JURISDICTIONS.NG.reportingThresholdCents
+  const inBand = Math.round(threshold * 0.9) // comfortably inside the 20% band
+
+  it('fires on repeated sub-threshold transactions that sum past the threshold', () => {
+    seed(DAY_MS, inBand)
+    seed(2 * DAY_MS, inBand)
+    expect(codes(run({ amountCents: inBand }))).toContain('STRUCTURING')
+  })
+
+  it('does not fire when the current transaction is not in the band', () => {
+    seed(DAY_MS, inBand)
+    seed(2 * DAY_MS, inBand)
+    // Well below the band — this is not a structured piece.
+    expect(codes(run({ amountCents: 10_00 }))).not.toContain('STRUCTURING')
+  })
+
+  it('does not fire below the minimum count', () => {
+    seed(DAY_MS, inBand)
+    expect(codes(run({ amountCents: inBand }))).not.toContain('STRUCTURING')
+  })
+
+  it('is jurisdiction-aware', () => {
+    // The same amounts against a market with a higher threshold are no longer
+    // "just below" anything.
+    seed(DAY_MS, inBand)
+    seed(2 * DAY_MS, inBand)
+    expect(codes(run({ amountCents: inBand, jurisdiction: 'KE' }))).not.toContain(
+      'STRUCTURING'
+    )
+  })
+
+  it('records the threshold it measured against', () => {
+    seed(DAY_MS, inBand)
+    seed(2 * DAY_MS, inBand)
+    const signal = run({ amountCents: inBand }).find((s) => s.code === 'STRUCTURING')
+    expect(signal?.metadata).toMatchObject({
+      bandedCount: 3,
+      reportingThresholdCents: threshold,
+      jurisdiction: 'NG',
+    })
+  })
+})
+
+describe('RAPID_RAMP_REVERSAL', () => {
+  it('fires when an offramp reverses a recent onramp of similar size', () => {
+    seed(2 * HOUR_MS, 1_000_00, 'onramp')
+    expect(codes(run({ kind: 'offramp', amountCents: 1_000_00 }))).toContain(
+      'RAPID_RAMP_REVERSAL'
+    )
+  })
+
+  it('ignores a counterpart of materially different value', () => {
+    seed(2 * HOUR_MS, 1_000_00, 'onramp')
+    expect(codes(run({ kind: 'offramp', amountCents: 5_000_00 }))).not.toContain(
+      'RAPID_RAMP_REVERSAL'
+    )
+  })
+
+  it('ignores a counterpart outside the window', () => {
+    seed(2 * DAY_MS, 1_000_00, 'onramp')
+    expect(codes(run({ kind: 'offramp', amountCents: 1_000_00 }))).not.toContain(
+      'RAPID_RAMP_REVERSAL'
+    )
+  })
+
+  it('ignores same-direction transactions', () => {
+    seed(2 * HOUR_MS, 1_000_00, 'offramp')
+    expect(codes(run({ kind: 'offramp', amountCents: 1_000_00 }))).not.toContain(
+      'RAPID_RAMP_REVERSAL'
+    )
+  })
+
+  it('ignores small round-trips, which are usually genuine mistakes', () => {
+    seed(HOUR_MS, 50_00, 'onramp')
+    expect(codes(run({ kind: 'offramp', amountCents: 50_00 }))).not.toContain(
+      'RAPID_RAMP_REVERSAL'
+    )
+  })
+})
+
+describe('COUNTERPARTY_FANOUT', () => {
+  const { maxCounterparties } = VELOCITY_RULES.counterpartyFanout
+
+  it('fires past the distinct-recipient cap', () => {
+    for (let i = 0; i <= maxCounterparties; i++) {
+      seed(HOUR_MS, 10_00, 'offramp', `cp_${i}`)
+    }
+    expect(codes(run())).toContain('COUNTERPARTY_FANOUT')
+  })
+
+  it('counts distinct recipients, not transaction volume', () => {
+    // Many transactions to one recipient is not fan-out.
+    for (let i = 0; i < maxCounterparties * 3; i++) {
+      seed(HOUR_MS, 10_00, 'offramp', 'cp_same')
+    }
+    expect(codes(run())).not.toContain('COUNTERPARTY_FANOUT')
+  })
+})
+
+describe('NEW_ACCOUNT_HIGH_VALUE', () => {
+  it('fires on a large first transaction', () => {
+    expect(codes(run({ amountCents: 5_000_00 }))).toContain('NEW_ACCOUNT_HIGH_VALUE')
+  })
+
+  it('does not fire on a small first transaction', () => {
+    expect(codes(run({ amountCents: 10_00 }))).not.toContain('NEW_ACCOUNT_HIGH_VALUE')
+  })
+
+  it('does not fire on an established account', () => {
+    expect(
+      codes(
+        run({
+          amountCents: 5_000_00,
+          accountCreatedAt: new Date(NOW.getTime() - 60 * DAY_MS),
+        })
+      )
+    ).not.toContain('NEW_ACCOUNT_HIGH_VALUE')
+  })
+})
+
+describe('DORMANT_REACTIVATION', () => {
+  it('fires on a large transaction after a long silence', () => {
+    seed(120 * DAY_MS, 50_00)
+    expect(codes(run({ amountCents: 2_000_00 }))).toContain('DORMANT_REACTIVATION')
+  })
+
+  it('does not fire on a recently active account', () => {
+    seed(2 * DAY_MS, 50_00)
+    expect(codes(run({ amountCents: 2_000_00 }))).not.toContain('DORMANT_REACTIVATION')
+  })
+
+  it('does not fire on an account with no history — that is newness, not dormancy', () => {
+    expect(codes(run({ amountCents: 2_000_00 }))).not.toContain('DORMANT_REACTIVATION')
+  })
+})
+
+describe('evaluateVelocityRules', () => {
+  it('returns nothing for an unremarkable transaction', () => {
+    seed(2 * DAY_MS, 100_00)
+    seed(3 * DAY_MS, 120_00)
+    expect(run({ amountCents: 110_00 })).toEqual([])
+  })
+
+  it('accumulates independent signals', () => {
+    // A large first transaction that also round-trips a recent onramp.
+    seed(HOUR_MS, 3_000_00, 'onramp')
+    const fired = codes(run({ kind: 'offramp', amountCents: 3_000_00 }))
+    expect(fired).toContain('RAPID_RAMP_REVERSAL')
+    expect(fired).toContain('NEW_ACCOUNT_HIGH_VALUE')
+  })
+
+  it('does not read another account history', () => {
+    for (let i = 0; i < 50; i++) seed(HOUR_MS, 100_00)
+    expect(run({ userId: 'GOTHERWALLET', amountCents: 100_00 })).toEqual([])
+  })
+})

--- a/lib/compliance/__tests__/velocity.test.ts
+++ b/lib/compliance/__tests__/velocity.test.ts
@@ -11,7 +11,7 @@
  * be built relative to a fixed instant and the tests stay readable.
  */
 
-import { DAY_MS, HOUR_MS, JURISDICTIONS, VELOCITY_RULES } from '../config'
+import { DAY_MS, HOUR_MS, JURISDICTIONS, UNLICENSED_MARKET_POLICY, VELOCITY_RULES } from '../config'
 import { _clearLedger, recordTransaction } from '../ledger'
 import type { ScreeningSubject, SignalCode } from '../types'
 import { evaluateVelocityRules } from '../velocity'
@@ -186,6 +186,26 @@ describe('STRUCTURING', () => {
       bandedCount: 3,
       reportingThresholdCents: threshold,
       jurisdiction: 'NG',
+    })
+  })
+
+  it('still runs in a market with no local AML registration', () => {
+    // Structuring detection must not switch off just because there is nowhere
+    // to file the result — the transaction is still held and reviewed.
+    const unlicensedBand = Math.round(
+      UNLICENSED_MARKET_POLICY.reportingThresholdCents * 0.9
+    )
+    seed(DAY_MS, unlicensedBand)
+    seed(2 * DAY_MS, unlicensedBand)
+
+    const signal = run({ amountCents: unlicensedBand, jurisdiction: 'TZ' }).find(
+      (s) => s.code === 'STRUCTURING'
+    )
+
+    expect(signal).toBeDefined()
+    expect(signal?.metadata).toMatchObject({
+      jurisdiction: 'TZ',
+      reportingThresholdCents: UNLICENSED_MARKET_POLICY.reportingThresholdCents,
     })
   })
 })

--- a/lib/compliance/admin-auth.ts
+++ b/lib/compliance/admin-auth.ts
@@ -1,0 +1,106 @@
+/**
+ * Admin authentication for the compliance console.
+ *
+ * ⚠️  This is a deliberately minimal guard, and it is **not** sufficient on its
+ *     own for production.
+ *
+ *     Aframp has no user authentication system today — identity everywhere else
+ *     in the app is a wallet address, which is a claim, not a credential.  The
+ *     compliance console cannot wait for that: it exposes customer names,
+ *     account identifiers and sanctions determinations, so shipping it with no
+ *     gate at all would be worse than shipping nothing.
+ *
+ *     So this implements shared-secret bearer tokens with per-analyst identity,
+ *     which is enough to (a) keep the console off the public internet and
+ *     (b) attribute every case decision to a named human, which is the part the
+ *     audit trail genuinely depends on.
+ *
+ *     Before this console handles real customer data it needs, at minimum:
+ *       - real per-user accounts with individually revocable credentials
+ *       - mandatory MFA (an AML console is a high-value target)
+ *       - session expiry and idle timeout
+ *       - alerting on bulk case reads, which is how insider misuse presents
+ *     Tracked in docs/AML_COMPLIANCE.md § Known gaps.
+ *
+ * Token format in COMPLIANCE_ADMIN_TOKENS:  analystId:token,analystId:token
+ * e.g.  ada.okafor:s3cr3t-1,ben.mwangi:s3cr3t-2
+ */
+
+import { timingSafeEqual } from 'node:crypto'
+import type { NextRequest } from 'next/server'
+
+export interface AdminIdentity {
+  /** Analyst id recorded as the actor on every case event. */
+  analystId: string
+}
+
+export type AuthResult =
+  | { ok: true; identity: AdminIdentity }
+  | { ok: false; status: 401 | 403; error: string }
+
+/**
+ * Authenticates an admin request from its `Authorization: Bearer` header.
+ *
+ * Returns a result rather than throwing so route handlers keep their error
+ * shape consistent with the rest of the API.
+ */
+export function authenticateAdmin(request: NextRequest): AuthResult {
+  const configured = parseTokens(process.env.COMPLIANCE_ADMIN_TOKENS)
+
+  // No tokens configured means the console is not provisioned.  Denying is the
+  // only safe reading: an empty allowlist that admits everyone is how staging
+  // configuration becomes a production breach.
+  if (configured.size === 0) {
+    return {
+      ok: false,
+      status: 403,
+      error: 'Compliance console is not provisioned (COMPLIANCE_ADMIN_TOKENS unset)',
+    }
+  }
+
+  const header = request.headers.get('authorization') ?? ''
+  const [scheme, token] = header.split(' ')
+
+  if (scheme?.toLowerCase() !== 'bearer' || !token) {
+    return { ok: false, status: 401, error: 'Missing bearer token' }
+  }
+
+  for (const [analystId, expected] of configured) {
+    if (constantTimeEquals(token, expected)) {
+      return { ok: true, identity: { analystId } }
+    }
+  }
+
+  return { ok: false, status: 401, error: 'Invalid token' }
+}
+
+function parseTokens(raw: string | undefined): Map<string, string> {
+  const tokens = new Map<string, string>()
+  if (!raw) return tokens
+
+  for (const pair of raw.split(',')) {
+    const trimmed = pair.trim()
+    if (!trimmed) continue
+    const separator = trimmed.indexOf(':')
+    // Reject malformed entries rather than guessing an id — an analyst id that
+    // silently defaults would attribute decisions to the wrong person.
+    if (separator <= 0 || separator === trimmed.length - 1) continue
+    tokens.set(trimmed.slice(0, separator), trimmed.slice(separator + 1))
+  }
+
+  return tokens
+}
+
+/**
+ * Compares two secrets without leaking their contents through timing.
+ *
+ * Length is compared first and returns early, which does leak length — that is
+ * accepted, and is why the tokens are expected to be long random strings rather
+ * than anything guessable from their size.
+ */
+function constantTimeEquals(a: string, b: string): boolean {
+  const bufferA = Buffer.from(a, 'utf8')
+  const bufferB = Buffer.from(b, 'utf8')
+  if (bufferA.length !== bufferB.length) return false
+  return timingSafeEqual(bufferA, bufferB)
+}

--- a/lib/compliance/admin-client.ts
+++ b/lib/compliance/admin-client.ts
@@ -1,0 +1,246 @@
+/**
+ * Browser client for the compliance admin API.
+ *
+ * Server-only modules (stores, providers, node:crypto) must never be pulled
+ * into this bundle, so this file imports types only — same discipline as
+ * lib/orders/order-client.ts.
+ *
+ * Token handling:
+ *   The analyst's bearer token is held in sessionStorage, not localStorage, so
+ *   it dies with the tab rather than persisting on a shared machine.  This is a
+ *   stopgap, not a design — a token readable by any script on the origin is one
+ *   XSS away from exposure.  It exists because Aframp has no session
+ *   infrastructure yet; the destination is an httpOnly session cookie issued by
+ *   a real login.  See the header of lib/compliance/admin-auth.ts.
+ */
+
+import type {
+  ComplianceCase,
+  Jurisdiction,
+  SarRecord,
+  CaseStatus,
+  SarStatus,
+} from './types'
+import type { JurisdictionPolicy } from './config'
+
+const TOKEN_KEY = 'aframp.compliance.token'
+
+// ---------------------------------------------------------------------------
+// Token
+// ---------------------------------------------------------------------------
+//
+// sessionStorage is an external store, so it is exposed as one —
+// subscribe/getSnapshot, consumed with useSyncExternalStore.  Mirroring it into
+// component state via an effect would mean rendering once with the wrong value
+// and correcting it, which is both a cascading render and a visible flash of
+// the sign-in form for an analyst who is already signed in.
+
+const listeners = new Set<() => void>()
+
+/** Subscribes to token changes.  Returns an unsubscribe function. */
+export function subscribeToToken(listener: () => void): () => void {
+  listeners.add(listener)
+  return () => {
+    listeners.delete(listener)
+  }
+}
+
+function emitTokenChange(): void {
+  for (const listener of listeners) listener()
+}
+
+/**
+ * Current token, or null.
+ *
+ * Returns a primitive rather than an object so useSyncExternalStore can compare
+ * snapshots by identity without an infinite re-render loop.
+ */
+export function getStoredToken(): string | null {
+  if (typeof window === 'undefined') return null
+  return window.sessionStorage.getItem(TOKEN_KEY)
+}
+
+/** Server snapshot — there is no session storage during SSR. */
+export function getServerTokenSnapshot(): string | null {
+  return null
+}
+
+export function setStoredToken(token: string): void {
+  window.sessionStorage.setItem(TOKEN_KEY, token)
+  emitTokenChange()
+}
+
+export function clearStoredToken(): void {
+  window.sessionStorage.removeItem(TOKEN_KEY)
+  emitTokenChange()
+}
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class AdminApiError extends Error {
+  readonly status: number
+
+  constructor(status: number, message: string) {
+    super(message)
+    this.name = 'AdminApiError'
+    this.status = status
+  }
+
+  /** True when the token was missing, wrong, or the console is unprovisioned. */
+  get isAuthError(): boolean {
+    return this.status === 401 || this.status === 403
+  }
+}
+
+async function request<T>(path: string, init: RequestInit = {}): Promise<T> {
+  const token = getStoredToken()
+  if (!token) throw new AdminApiError(401, 'Not signed in')
+
+  const response = await fetch(path, {
+    ...init,
+    headers: {
+      ...init.headers,
+      Authorization: `Bearer ${token}`,
+      ...(init.body ? { 'Content-Type': 'application/json' } : {}),
+    },
+    cache: 'no-store',
+  })
+
+  if (!response.ok) {
+    let message = `Request failed with ${response.status}`
+    try {
+      const body = await response.json()
+      message = body.message ?? body.error ?? message
+    } catch {
+      // Non-JSON error body — keep the status-derived message.
+    }
+    throw new AdminApiError(response.status, message)
+  }
+
+  return (await response.json()) as T
+}
+
+// ---------------------------------------------------------------------------
+// Cases
+// ---------------------------------------------------------------------------
+
+export interface CaseStats {
+  byStatus: Record<CaseStatus, number>
+  total: number
+  overdueFilings: number
+}
+
+export interface ListCasesResponse {
+  cases: ComplianceCase[]
+  total: number
+  stats: CaseStats
+}
+
+export interface CaseFilters {
+  status?: CaseStatus
+  jurisdiction?: Jurisdiction
+  assignedTo?: string
+  userId?: string
+  minRiskScore?: number
+  limit?: number
+  offset?: number
+}
+
+export function listCases(filters: CaseFilters = {}): Promise<ListCasesResponse> {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(filters)) {
+    if (value !== undefined && value !== '') params.set(key, String(value))
+  }
+  return request<ListCasesResponse>(`/api/admin/compliance/cases?${params}`)
+}
+
+export function getCase(
+  caseId: string
+): Promise<{ case: ComplianceCase; retentionExpiresAt: string }> {
+  return request(`/api/admin/compliance/cases/${encodeURIComponent(caseId)}`)
+}
+
+export type CaseAction =
+  | { action: 'assign' }
+  | { action: 'note'; note: string }
+  | {
+      action: 'decide'
+      status: 'CLEARED' | 'CONFIRMED_SUSPICIOUS' | 'ESCALATED'
+      disposition?: 'FALSE_POSITIVE' | 'TRUE_POSITIVE' | 'INCONCLUSIVE'
+      rationale: string
+    }
+  | { action: 'reopen'; reason: string }
+
+export function actOnCase(
+  caseId: string,
+  action: CaseAction
+): Promise<{ case: ComplianceCase }> {
+  return request(`/api/admin/compliance/cases/${encodeURIComponent(caseId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify(action),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// SARs
+// ---------------------------------------------------------------------------
+
+export interface ListSarsResponse {
+  sars: SarRecord[]
+  jurisdictions: Record<Jurisdiction, JurisdictionPolicy>
+}
+
+export function listSars(
+  filters: { status?: SarStatus; jurisdiction?: Jurisdiction; overdueOnly?: boolean } = {}
+): Promise<ListSarsResponse> {
+  const params = new URLSearchParams()
+  for (const [key, value] of Object.entries(filters)) {
+    if (value !== undefined && value !== '') params.set(key, String(value))
+  }
+  return request<ListSarsResponse>(`/api/admin/compliance/sars?${params}`)
+}
+
+export function draftSar(caseId: string, narrative: string): Promise<{ sar: SarRecord }> {
+  return request('/api/admin/compliance/sars', {
+    method: 'POST',
+    body: JSON.stringify({ action: 'draft', caseId, narrative }),
+  })
+}
+
+export function advanceSar(
+  sarId: string,
+  status: Exclude<SarStatus, 'DRAFT'>,
+  regulatorReference?: string
+): Promise<{ sar: SarRecord }> {
+  return request('/api/admin/compliance/sars', {
+    method: 'POST',
+    body: JSON.stringify({ action: 'advance', sarId, status, regulatorReference }),
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
+export interface HealthResponse {
+  status: 'OK' | 'DEGRADED' | 'CRITICAL'
+  checks: {
+    sanctionsList: {
+      loaded: boolean
+      generatedAt: string | null
+      ageDays: number | null
+      entityCount: number
+      addressCount: number
+      stale: boolean
+    }
+    providers: { wallet: string; name: string; localOnly: boolean }
+    policy: { failClosed: boolean; hashSaltConfigured: boolean }
+    queue: { openCases: number; overdueFilings: number }
+  }
+}
+
+export function getHealth(): Promise<HealthResponse> {
+  return request<HealthResponse>('/api/admin/compliance/health')
+}

--- a/lib/compliance/case-store.ts
+++ b/lib/compliance/case-store.ts
@@ -1,0 +1,510 @@
+/**
+ * Case store and SAR workflow.
+ *
+ * A flagged transaction is not a case file on its own — the regulatory
+ * artefact is the *record of what a human did about it*.  Every mutation here
+ * appends to an immutable event trail rather than only updating state, because
+ * "who cleared this, when, and on what basis" is the first question asked in an
+ * examination and the last thing anyone remembers a year later.
+ *
+ * Storage layer:
+ *   In-memory maps mirroring db/migrations/003_create_compliance.sql, matching
+ *   the convention in lib/orders/order-store.ts and lib/kyc/withdrawalLimitService.ts.
+ *   Each function quotes its SQL equivalent.
+ *
+ * Deletion:
+ *   There is deliberately no deleteCase().  AML records carry a five-year
+ *   retention obligation (RECORD_RETENTION_YEARS) in all five markets, and a
+ *   case that can be deleted through the application is a case that can be
+ *   deleted by whoever compromises it.  Cases close; they do not disappear.
+ */
+
+import { JURISDICTIONS, RECORD_RETENTION_YEARS } from './config'
+import type {
+  CaseDisposition,
+  CaseEvent,
+  CaseStatus,
+  ComplianceCase,
+  Jurisdiction,
+  SarRecord,
+  SarStatus,
+  ScreeningResult,
+  ScreeningSubject,
+  SignalCode,
+} from './types'
+
+// ---------------------------------------------------------------------------
+// In-memory stores (replace with DB queries in production)
+// ---------------------------------------------------------------------------
+
+/** Map<caseId, ComplianceCase> — the `compliance_cases` table. */
+export const _caseStore = new Map<string, ComplianceCase>()
+
+/** Map<sarId, SarRecord> — the `compliance_sars` table. */
+export const _sarStore = new Map<string, SarRecord>()
+
+/** Map<transactionId, caseId> — stands in for a unique index. */
+const _byTransaction = new Map<string, string>()
+
+// ---------------------------------------------------------------------------
+// Case creation
+// ---------------------------------------------------------------------------
+
+/**
+ * Opens a case for a screening result, or returns the existing one.
+ *
+ *   INSERT INTO compliance_cases (…) VALUES (…)
+ *   ON CONFLICT (transaction_id) DO NOTHING
+ *   RETURNING *;
+ *
+ * Idempotent on transactionId: the screening endpoint is retried by clients,
+ * and duplicate cases for one transaction inflate the queue and get closed
+ * inconsistently.
+ */
+export function openCase(
+  subject: ScreeningSubject,
+  result: Omit<ScreeningResult, 'caseId'>
+): ComplianceCase {
+  const existingId = _byTransaction.get(subject.transactionId)
+  if (existingId) {
+    const existing = _caseStore.get(existingId)
+    if (existing) return existing
+  }
+
+  const now = new Date().toISOString()
+  const id = generateId('CASE')
+
+  const record: ComplianceCase = {
+    id,
+    transactionId: subject.transactionId,
+    userId: subject.userId,
+    kind: subject.kind,
+    jurisdiction: subject.jurisdiction,
+    amountCents: subject.amountCents,
+    asset: subject.asset,
+    status: 'OPEN',
+    riskScore: result.riskScore,
+    riskLevel: result.riskLevel,
+    decision: result.decision,
+    signals: result.signals,
+    events: [
+      {
+        at: now,
+        actor: 'system',
+        action: 'CREATED',
+        detail: `${result.decision} at risk ${result.riskScore} — ${result.signals
+          .map((s) => s.code)
+          .join(', ')}`,
+      },
+    ],
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  _caseStore.set(id, record)
+  _byTransaction.set(subject.transactionId, id)
+
+  return record
+}
+
+// ---------------------------------------------------------------------------
+// Case reads
+// ---------------------------------------------------------------------------
+
+export function getCase(caseId: string): ComplianceCase | null {
+  return _caseStore.get(caseId) ?? null
+}
+
+export function getCaseByTransaction(transactionId: string): ComplianceCase | null {
+  const id = _byTransaction.get(transactionId)
+  return id ? (_caseStore.get(id) ?? null) : null
+}
+
+export interface ListCasesOptions {
+  status?: CaseStatus
+  jurisdiction?: Jurisdiction
+  assignedTo?: string
+  userId?: string
+  /** Only cases at or above this aggregate score. */
+  minRiskScore?: number
+  limit?: number
+  offset?: number
+}
+
+export interface ListCasesResult {
+  cases: ComplianceCase[]
+  /** Total matching the filter, before paging — drives the queue counter. */
+  total: number
+}
+
+/**
+ * Lists cases newest-first, filtered and paged.
+ *
+ *   SELECT * FROM compliance_cases
+ *   WHERE  ($1::TEXT IS NULL OR status = $1)
+ *     AND  ($2::TEXT IS NULL OR jurisdiction = $2)
+ *     AND  ($3::TEXT IS NULL OR assigned_to = $3)
+ *     AND  ($4::TEXT IS NULL OR user_id = $4)
+ *     AND  ($5::INT  IS NULL OR risk_score >= $5)
+ *   ORDER  BY created_at DESC
+ *   LIMIT  $6 OFFSET $7;
+ *
+ * Newest-first rather than riskiest-first is intentional: filing deadlines run
+ * from when suspicion was formed, so the oldest unworked case is the one that
+ * breaches first, and analysts work the queue from the far end. The admin UI
+ * offers risk sorting on top of this for triage.
+ */
+export function listCases({
+  status,
+  jurisdiction,
+  assignedTo,
+  userId,
+  minRiskScore,
+  limit = 25,
+  offset = 0,
+}: ListCasesOptions = {}): ListCasesResult {
+  const matching = [..._caseStore.values()]
+    .filter((c) => (status ? c.status === status : true))
+    .filter((c) => (jurisdiction ? c.jurisdiction === jurisdiction : true))
+    .filter((c) => (assignedTo ? c.assignedTo === assignedTo : true))
+    .filter((c) => (userId ? c.userId === userId : true))
+    .filter((c) => (minRiskScore != null ? c.riskScore >= minRiskScore : true))
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+
+  return {
+    cases: matching.slice(offset, offset + limit),
+    total: matching.length,
+  }
+}
+
+/** Open-case counts by status — the admin dashboard's summary row. */
+export function getCaseStats(): {
+  byStatus: Record<CaseStatus, number>
+  total: number
+  /** Cases with an unfiled SAR past their jurisdiction's deadline. */
+  overdueFilings: number
+} {
+  const byStatus: Record<CaseStatus, number> = {
+    OPEN: 0,
+    IN_REVIEW: 0,
+    ESCALATED: 0,
+    CLEARED: 0,
+    CONFIRMED_SUSPICIOUS: 0,
+  }
+
+  for (const record of _caseStore.values()) {
+    byStatus[record.status]++
+  }
+
+  const now = Date.now()
+  const overdueFilings = [..._sarStore.values()].filter(
+    (sar) => sar.status === 'DRAFT' && new Date(sar.dueAt).getTime() < now
+  ).length
+
+  return {
+    byStatus,
+    total: _caseStore.size,
+    overdueFilings,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Case mutations
+// ---------------------------------------------------------------------------
+
+/**
+ * Applies a change and appends the matching audit event.
+ *
+ * The single mutation path exists so no caller can change a case without
+ * leaving a trace — an "update case" helper that took arbitrary fields would
+ * make the trail optional, and an optional audit trail is not an audit trail.
+ */
+function mutate(
+  caseId: string,
+  actor: string,
+  action: CaseEvent['action'],
+  detail: string | undefined,
+  apply: (record: ComplianceCase) => Partial<ComplianceCase>
+): ComplianceCase | null {
+  const existing = _caseStore.get(caseId)
+  if (!existing) return null
+
+  const now = new Date().toISOString()
+  const updated: ComplianceCase = {
+    ...existing,
+    ...apply(existing),
+    events: [...existing.events, { at: now, actor, action, detail }],
+    updatedAt: now,
+  }
+
+  _caseStore.set(caseId, updated)
+  return updated
+}
+
+/**
+ * Assigns a case to an analyst and moves it to IN_REVIEW.
+ *
+ *   UPDATE compliance_cases SET assigned_to = $2, status = 'IN_REVIEW' WHERE id = $1;
+ */
+export function assignCase(caseId: string, analystId: string): ComplianceCase | null {
+  return mutate(caseId, analystId, 'ASSIGNED', `Assigned to ${analystId}`, (record) => ({
+    assignedTo: analystId,
+    // Don't drag a closed case back into the queue by assigning it.
+    status: isClosed(record.status) ? record.status : 'IN_REVIEW',
+  }))
+}
+
+export interface DecideCaseInput {
+  caseId: string
+  analystId: string
+  status: Extract<CaseStatus, 'CLEARED' | 'CONFIRMED_SUSPICIOUS' | 'ESCALATED'>
+  disposition?: CaseDisposition
+  /** Analyst's reasoning.  Required — a decision without a rationale is not one. */
+  rationale: string
+}
+
+/**
+ * Records an analyst's decision on a case.
+ *
+ * `rationale` is mandatory by signature rather than by convention.  The most
+ * common examination finding against a monitoring programme is alerts closed
+ * with no recorded reason, and the cheapest way to prevent that is to make the
+ * reason impossible to omit.
+ */
+export function decideCase({
+  caseId,
+  analystId,
+  status,
+  disposition,
+  rationale,
+}: DecideCaseInput): ComplianceCase | null {
+  return mutate(
+    caseId,
+    analystId,
+    'STATUS_CHANGED',
+    `${status}${disposition ? ` (${disposition})` : ''}: ${rationale}`,
+    () => ({ status, disposition })
+  )
+}
+
+/** Appends a free-text note without changing state. */
+export function addCaseNote(
+  caseId: string,
+  analystId: string,
+  note: string
+): ComplianceCase | null {
+  return mutate(caseId, analystId, 'NOTE_ADDED', note, () => ({}))
+}
+
+/**
+ * Reopens a closed case — new information, or a quality-assurance review.
+ *
+ *   UPDATE compliance_cases SET status = 'IN_REVIEW', disposition = NULL WHERE id = $1;
+ *
+ * The prior disposition is cleared but its history stays in `events`, so a
+ * reopened case still shows what was originally concluded and by whom.
+ */
+export function reopenCase(
+  caseId: string,
+  analystId: string,
+  reason: string
+): ComplianceCase | null {
+  return mutate(caseId, analystId, 'REOPENED', reason, () => ({
+    status: 'IN_REVIEW',
+    disposition: undefined,
+  }))
+}
+
+function isClosed(status: CaseStatus): boolean {
+  return status === 'CLEARED' || status === 'CONFIRMED_SUSPICIOUS'
+}
+
+// ---------------------------------------------------------------------------
+// SAR / STR workflow
+// ---------------------------------------------------------------------------
+
+export interface DraftSarInput {
+  caseId: string
+  analystId: string
+  /** The narrative filed with the FIU — who, what, when, why it is suspicious. */
+  narrative: string
+}
+
+export class SarError extends Error {
+  readonly code: 'CASE_NOT_FOUND' | 'ALREADY_FILED' | 'SAR_NOT_FOUND' | 'INVALID_TRANSITION'
+
+  constructor(code: SarError['code'], message: string) {
+    super(message)
+    this.name = 'SarError'
+    this.code = code
+  }
+}
+
+/**
+ * Drafts a SAR/STR against a case.
+ *
+ * The filing deadline runs from the case's creation — the moment the system
+ * formed suspicion — not from when the analyst got round to drafting.  Dating
+ * the clock from draft time would let a backlog quietly extinguish every
+ * deadline, which is the exact failure the deadline exists to prevent.
+ *
+ * Drafting also moves the case to CONFIRMED_SUSPICIOUS: you do not report a
+ * transaction you consider clean.
+ */
+export function draftSar({ caseId, analystId, narrative }: DraftSarInput): SarRecord {
+  const record = _caseStore.get(caseId)
+  if (!record) throw new SarError('CASE_NOT_FOUND', `No case ${caseId}`)
+  if (record.sarId) {
+    throw new SarError('ALREADY_FILED', `Case ${caseId} already has SAR ${record.sarId}`)
+  }
+
+  const policy = JURISDICTIONS[record.jurisdiction]
+  const suspicionFormedAt = record.createdAt
+  const dueAt = new Date(
+    new Date(suspicionFormedAt).getTime() + policy.filingDeadlineHours * 3_600_000
+  ).toISOString()
+
+  const now = new Date().toISOString()
+  const sar: SarRecord = {
+    id: generateId('SAR'),
+    caseId,
+    userId: record.userId,
+    jurisdiction: record.jurisdiction,
+    regulator: policy.regulator,
+    status: 'DRAFT',
+    narrative,
+    groundsForSuspicion: record.signals.map((s) => s.code) as SignalCode[],
+    amountCents: record.amountCents,
+    filedBy: analystId,
+    suspicionFormedAt,
+    dueAt,
+    createdAt: now,
+    updatedAt: now,
+  }
+
+  _sarStore.set(sar.id, sar)
+
+  mutate(
+    caseId,
+    analystId,
+    'SAR_FILED',
+    `${policy.filingName} ${sar.id} drafted for ${policy.regulator}, due ${dueAt}`,
+    () => ({ sarId: sar.id, status: 'CONFIRMED_SUSPICIOUS' as CaseStatus })
+  )
+
+  return sar
+}
+
+/**
+ * Advances a SAR through submission and acknowledgement.
+ *
+ * Transitions are constrained (DRAFT → SUBMITTED → ACKNOWLEDGED | REJECTED)
+ * because a filing record that can jump straight to ACKNOWLEDGED without ever
+ * being submitted is a record that can be falsified after the fact.
+ */
+export function updateSarStatus(
+  sarId: string,
+  analystId: string,
+  status: SarStatus,
+  regulatorReference?: string
+): SarRecord {
+  const sar = _sarStore.get(sarId)
+  if (!sar) throw new SarError('SAR_NOT_FOUND', `No SAR ${sarId}`)
+
+  const allowed: Record<SarStatus, SarStatus[]> = {
+    DRAFT: ['SUBMITTED'],
+    SUBMITTED: ['ACKNOWLEDGED', 'REJECTED'],
+    // A rejected filing is corrected and resubmitted; an acknowledged one is final.
+    REJECTED: ['SUBMITTED'],
+    ACKNOWLEDGED: [],
+  }
+
+  if (!allowed[sar.status].includes(status)) {
+    throw new SarError(
+      'INVALID_TRANSITION',
+      `Cannot move SAR ${sarId} from ${sar.status} to ${status}`
+    )
+  }
+
+  const now = new Date().toISOString()
+  const updated: SarRecord = {
+    ...sar,
+    status,
+    regulatorReference: regulatorReference ?? sar.regulatorReference,
+    submittedAt: status === 'SUBMITTED' ? now : sar.submittedAt,
+    updatedAt: now,
+  }
+
+  _sarStore.set(sarId, updated)
+  addCaseNote(sar.caseId, analystId, `SAR ${sarId} → ${status}`)
+
+  return updated
+}
+
+export function getSar(sarId: string): SarRecord | null {
+  return _sarStore.get(sarId) ?? null
+}
+
+export interface ListSarsOptions {
+  status?: SarStatus
+  jurisdiction?: Jurisdiction
+  /** Only drafts past their filing deadline. */
+  overdueOnly?: boolean
+  limit?: number
+}
+
+/**
+ * Lists SARs, soonest deadline first.
+ *
+ *   SELECT * FROM compliance_sars
+ *   WHERE  ($1::TEXT IS NULL OR status = $1)
+ *     AND  ($2::TEXT IS NULL OR jurisdiction = $2)
+ *   ORDER  BY due_at
+ *   LIMIT  $3;
+ */
+export function listSars({
+  status,
+  jurisdiction,
+  overdueOnly = false,
+  limit = 50,
+}: ListSarsOptions = {}): SarRecord[] {
+  const now = Date.now()
+
+  return [..._sarStore.values()]
+    .filter((s) => (status ? s.status === status : true))
+    .filter((s) => (jurisdiction ? s.jurisdiction === jurisdiction : true))
+    .filter((s) =>
+      overdueOnly ? s.status === 'DRAFT' && new Date(s.dueAt).getTime() < now : true
+    )
+    .sort((a, b) => a.dueAt.localeCompare(b.dueAt))
+    .slice(0, limit)
+}
+
+/** ISO date after which a case may lawfully be purged. */
+export function retentionExpiryFor(record: ComplianceCase): string {
+  const expiry = new Date(record.createdAt)
+  expiry.setFullYear(expiry.getFullYear() + RECORD_RETENTION_YEARS)
+  return expiry.toISOString()
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function generateId(prefix: string): string {
+  return `${prefix}-${Date.now().toString(36).toUpperCase()}-${Math.random()
+    .toString(36)
+    .slice(2, 8)
+    .toUpperCase()}`
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Empties both stores.  Test helper only. */
+export function _clearCases(): void {
+  _caseStore.clear()
+  _sarStore.clear()
+  _byTransaction.clear()
+}

--- a/lib/compliance/case-store.ts
+++ b/lib/compliance/case-store.ts
@@ -19,13 +19,15 @@
  *   deleted by whoever compromises it.  Cases close; they do not disappear.
  */
 
-import { JURISDICTIONS, RECORD_RETENTION_YEARS } from './config'
+import { RECORD_RETENTION_YEARS } from './config'
+import { isLicensedJurisdiction, policyFor } from './markets'
 import type {
   CaseDisposition,
   CaseEvent,
   CaseStatus,
   ComplianceCase,
   Jurisdiction,
+  Market,
   SarRecord,
   SarStatus,
   ScreeningResult,
@@ -122,7 +124,7 @@ export function getCaseByTransaction(transactionId: string): ComplianceCase | nu
 
 export interface ListCasesOptions {
   status?: CaseStatus
-  jurisdiction?: Jurisdiction
+  jurisdiction?: Market
   assignedTo?: string
   userId?: string
   /** Only cases at or above this aggregate score. */
@@ -331,7 +333,12 @@ export interface DraftSarInput {
 }
 
 export class SarError extends Error {
-  readonly code: 'CASE_NOT_FOUND' | 'ALREADY_FILED' | 'SAR_NOT_FOUND' | 'INVALID_TRANSITION'
+  readonly code:
+    | 'CASE_NOT_FOUND'
+    | 'ALREADY_FILED'
+    | 'SAR_NOT_FOUND'
+    | 'INVALID_TRANSITION'
+    | 'NO_FILING_ROUTE'
 
   constructor(code: SarError['code'], message: string) {
     super(message)
@@ -350,6 +357,11 @@ export class SarError extends Error {
  *
  * Drafting also moves the case to CONFIRMED_SUSPICIOUS: you do not report a
  * transaction you consider clean.
+ *
+ * Refuses on cases from unlicensed markets.  There is no FIU to receive the
+ * filing, and minting a SAR addressed to no regulator would leave the case
+ * looking discharged in every queue and count that reads `sarId` — the review
+ * obligation is still live and must stay visibly so.
  */
 export function draftSar({ caseId, analystId, narrative }: DraftSarInput): SarRecord {
   const record = _caseStore.get(caseId)
@@ -357,8 +369,15 @@ export function draftSar({ caseId, analystId, narrative }: DraftSarInput): SarRe
   if (record.sarId) {
     throw new SarError('ALREADY_FILED', `Case ${caseId} already has SAR ${record.sarId}`)
   }
+  if (!isLicensedJurisdiction(record.jurisdiction)) {
+    throw new SarError(
+      'NO_FILING_ROUTE',
+      `Case ${caseId} originates in ${record.jurisdiction}, where Aframp holds no AML registration. ` +
+        `Disposition it internally and escalate to the MLRO — there is no FIU to file with.`
+    )
+  }
 
-  const policy = JURISDICTIONS[record.jurisdiction]
+  const policy = policyFor(record.jurisdiction)
   const suspicionFormedAt = record.createdAt
   const dueAt = new Date(
     new Date(suspicionFormedAt).getTime() + policy.filingDeadlineHours * 3_600_000

--- a/lib/compliance/config.ts
+++ b/lib/compliance/config.ts
@@ -14,7 +14,7 @@
  *     a scheduled basis.  They are configuration, not fact.
  */
 
-import type { Jurisdiction, RiskLevel } from './types'
+import type { Jurisdiction, Market, RiskLevel } from './types'
 
 // ---------------------------------------------------------------------------
 // Risk bands
@@ -184,6 +184,13 @@ export const VELOCITY_RULES = {
 // ---------------------------------------------------------------------------
 
 export interface JurisdictionPolicy {
+  /**
+   * Whether Aframp holds an AML registration in this market.
+   *
+   * `false` means there is no FIU to file with — the screening controls still
+   * run, but a SAR cannot be raised.  See UNLICENSED_MARKET_POLICY.
+   */
+  licensed: boolean
   /** Receiving financial intelligence unit. */
   regulator: string
   regulatorName: string
@@ -207,6 +214,7 @@ export interface JurisdictionPolicy {
 
 export const JURISDICTIONS: Record<Jurisdiction, JurisdictionPolicy> = {
   NG: {
+    licensed: true,
     regulator: 'NFIU',
     regulatorName: 'Nigerian Financial Intelligence Unit',
     filingName: 'Suspicious Transaction Report (STR)',
@@ -215,6 +223,7 @@ export const JURISDICTIONS: Record<Jurisdiction, JurisdictionPolicy> = {
     localThresholdNote: '≈ ₦5,000,000 individual threshold (MLPPA 2022)',
   },
   KE: {
+    licensed: true,
     regulator: 'FRC',
     regulatorName: 'Financial Reporting Centre',
     filingName: 'Suspicious Transaction Report (STR)',
@@ -223,6 +232,7 @@ export const JURISDICTIONS: Record<Jurisdiction, JurisdictionPolicy> = {
     localThresholdNote: '≈ KES 1,000,000 threshold (POCAMLA)',
   },
   GH: {
+    licensed: true,
     regulator: 'FIC',
     regulatorName: 'Financial Intelligence Centre',
     filingName: 'Suspicious Transaction Report (STR)',
@@ -231,6 +241,7 @@ export const JURISDICTIONS: Record<Jurisdiction, JurisdictionPolicy> = {
     localThresholdNote: '≈ GHS 50,000 threshold (AMLA 2020)',
   },
   ZA: {
+    licensed: true,
     regulator: 'FIC',
     regulatorName: 'Financial Intelligence Centre',
     filingName: 'Suspicious Transaction Report (STR), FICA s29',
@@ -239,6 +250,7 @@ export const JURISDICTIONS: Record<Jurisdiction, JurisdictionPolicy> = {
     localThresholdNote: '≈ R49,999.99 cash threshold (FICA)',
   },
   UG: {
+    licensed: true,
     regulator: 'FIA',
     regulatorName: 'Financial Intelligence Authority',
     filingName: 'Suspicious Transaction Report (STR)',
@@ -246,6 +258,99 @@ export const JURISDICTIONS: Record<Jurisdiction, JurisdictionPolicy> = {
     reportingThresholdCents: 5_400_00,
     localThresholdNote: '≈ UGX 20,000,000 threshold (AMLA 2013)',
   },
+}
+
+/**
+ * Policy applied to markets Aframp accepts payments from but is not registered
+ * in — see UnlicensedMarket in ./types.ts.
+ *
+ * This is a stopgap, not a licence.  Screening still runs in full: sanctions,
+ * wallet risk and every velocity rule behave identically, because a designated
+ * person is designated everywhere and the FATF recommendations do not stop at
+ * our licensing footprint.  What is missing is the part that requires a
+ * regulator: there is no FIU to file with, so `draftSar()` refuses on these
+ * cases and an analyst can only disposition them internally.
+ *
+ * The threshold is deliberately the lowest of the five licensed markets rather
+ * than an average.  Structuring detection anchors to it, and a threshold set
+ * too high simply fails to detect — under-detecting in a market with no filing
+ * route is the worse error.
+ *
+ * Onboarding one of these markets properly means adding it to JURISDICTIONS
+ * with figures from local counsel, at which point it stops resolving here.
+ */
+export const UNLICENSED_MARKET_POLICY: JurisdictionPolicy = {
+  licensed: false,
+  regulator: 'NONE',
+  regulatorName: 'No AML registration held in this market',
+  filingName: 'Not filable — no registration',
+  // Only used to age the internal review queue; nothing is filed against it.
+  filingDeadlineHours: 24,
+  reportingThresholdCents: Math.min(
+    ...Object.values(JURISDICTIONS).map((p) => p.reportingThresholdCents)
+  ),
+  localThresholdNote:
+    'No local statutory threshold — defaults to the lowest licensed-market threshold',
+}
+
+/**
+ * Which market a payment currency belongs to.
+ *
+ * Currency is the only market signal the mobile-money and bill-payment routes
+ * carry, and it is the one the payment provider itself settles on, so it is a
+ * better source than a client-supplied country code.  Currencies absent here
+ * cannot be screened under any policy — the payment route must refuse rather
+ * than guess (see resolveMarket() in ./markets.ts).
+ */
+export const CURRENCY_MARKETS: Record<string, Market> = {
+  // Licensed markets
+  NGN: 'NG',
+  KES: 'KE',
+  GHS: 'GH',
+  ZAR: 'ZA',
+  UGX: 'UG',
+  // Mobile-money markets without a local AML registration
+  TZS: 'TZ',
+  XAF: 'CM',
+  XOF: 'CI',
+  RWF: 'RW',
+  ZMW: 'ZM',
+}
+
+/**
+ * Reference FX rates: USD cents per one major unit of local currency.
+ *
+ * ⚠️  Configuration, not a price feed, and deliberately so.  Every threshold in
+ *     this module is in USD cents, so a local-currency payment has to be
+ *     converted before any rule can see it.  Two things that must not happen:
+ *
+ *     1. Screening must not depend on a third-party rate API.  That would put a
+ *        network call with its own outage profile in the payment path, and
+ *        under FAIL_CLOSED every rate outage becomes a payments outage.
+ *     2. Thresholds must not move minute to minute.  A structuring band that
+ *        drifts with spot makes "was this transaction in the band?" unanswerable
+ *        after the fact, and an audit trail that cannot be reproduced is not
+ *        one.
+ *
+ *     The cost is drift: these are stale the moment they are committed. Review
+ *     on the same schedule as the reportingThresholdCents figures they interact
+ *     with, and re-derive both together — a rate revision that leaves the
+ *     thresholds untouched silently retunes every rule.
+ *
+ *     Rates below are approximate mid-market as of 2026-07.
+ */
+export const FX_USD_CENTS_PER_UNIT: Record<string, number> = {
+  USD: 100,
+  NGN: 0.066,
+  KES: 0.77,
+  GHS: 8.0,
+  ZAR: 5.4,
+  UGX: 0.027,
+  TZS: 0.038,
+  XAF: 0.17,
+  XOF: 0.17,
+  RWF: 0.072,
+  ZMW: 3.8,
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/compliance/config.ts
+++ b/lib/compliance/config.ts
@@ -1,0 +1,293 @@
+/**
+ * Tunable AML policy — every threshold the engine reads lives here.
+ *
+ * Nothing in lib/compliance/ may hard-code a limit, a window, or a score.  A
+ * compliance officer changing risk appetite should only ever have to touch this
+ * file, and the diff should be reviewable by someone who does not read
+ * TypeScript.  This mirrors the rule lib/kyc/tiers.ts sets for KYC limits.
+ *
+ * ⚠️  The jurisdictional figures below (reporting thresholds, filing windows)
+ *     are starting values drawn from the headline requirements of each market's
+ *     AML statute.  They are NOT a substitute for local legal advice, and the
+ *     exact figures move with statutory instruments and FX.  Confirm each one
+ *     with counsel and with the relevant FIU before go-live, and re-confirm on
+ *     a scheduled basis.  They are configuration, not fact.
+ */
+
+import type { Jurisdiction, RiskLevel } from './types'
+
+// ---------------------------------------------------------------------------
+// Risk bands
+// ---------------------------------------------------------------------------
+
+/**
+ * Aggregate-score → risk level.  Bands are lower-inclusive: a score of exactly
+ * 50 is HIGH.
+ */
+export const RISK_BANDS: Array<{ min: number; level: RiskLevel }> = [
+  { min: 75, level: 'SEVERE' },
+  { min: 50, level: 'HIGH' },
+  { min: 25, level: 'MEDIUM' },
+  { min: 0, level: 'LOW' },
+]
+
+/**
+ * Decision thresholds against the aggregate score.
+ *
+ * A sanctions hit bypasses these entirely and blocks — see screenTransaction().
+ * These only decide what to do with an accumulation of softer signals.
+ */
+export const DECISION_THRESHOLDS = {
+  /** At or above this, hold the transaction and open a case. */
+  review: 50,
+  /** At or above this, reject. */
+  block: 90,
+} as const
+
+/**
+ * Weight applied to every signal after the highest-scoring one when
+ * aggregating.  See scoreSignals() for why the aggregate is not a plain sum.
+ */
+export const SECONDARY_SIGNAL_WEIGHT = 0.35
+
+// ---------------------------------------------------------------------------
+// Name screening
+// ---------------------------------------------------------------------------
+
+export const NAME_SCREENING = {
+  /**
+   * Similarity at or above which a candidate is returned as a match.  0.85 is
+   * the conventional starting point for Jaro-Winkler on transliterated names;
+   * lowering it trades analyst time for recall.  Regulators expect this number
+   * to be justified and periodically tested — do not change it casually.
+   */
+  matchThreshold: 0.85,
+  /**
+   * Above this, treat the hit as strong enough to block rather than review.
+   * Between the two thresholds a human decides.
+   */
+  strongMatchThreshold: 0.95,
+  /** Cap on matches carried into a case file, highest-scoring first. */
+  maxMatches: 25,
+} as const
+
+// ---------------------------------------------------------------------------
+// Velocity rules
+// ---------------------------------------------------------------------------
+
+export const HOUR_MS = 3_600_000
+export const DAY_MS = 86_400_000
+
+/**
+ * Velocity thresholds.  All windows in ms, all amounts in integer USD cents.
+ *
+ * Each rule is independently switchable so a market can run a subset while its
+ * baseline data matures — a rule with no history behind it generates noise, not
+ * intelligence.
+ */
+export const VELOCITY_RULES = {
+  /** More than `maxCount` transactions inside `windowMs`. */
+  txCount: {
+    enabled: true,
+    windowMs: DAY_MS,
+    maxCount: 15,
+    score: 45,
+  },
+
+  /** Aggregate throughput inside `windowMs` exceeds `maxVolumeCents`. */
+  volume: {
+    enabled: true,
+    windowMs: DAY_MS,
+    maxVolumeCents: 10_000_00, // $10,000
+    score: 55,
+  },
+
+  /**
+   * 24 h volume exceeds `multiplier` × the account's own trailing daily mean.
+   *
+   * Requires `minHistoryDays` of history and `minBaselineCents` of trailing
+   * volume before it fires: without both, a first real transaction on a quiet
+   * account trivially clears any multiple of ~zero and every new user gets
+   * flagged.
+   */
+  spike: {
+    enabled: true,
+    windowMs: DAY_MS,
+    baselineMs: 30 * DAY_MS,
+    multiplier: 5,
+    minHistoryDays: 7,
+    minBaselineCents: 100_00, // $100
+    score: 50,
+  },
+
+  /**
+   * Structuring / smurfing: `minCount` or more transactions inside
+   * `windowMs`, each landing within `bandPct` *below* the jurisdiction's
+   * reporting threshold, and summing to at least that threshold.
+   *
+   * The "sums to at least the threshold" leg is what separates deliberate
+   * structuring from a merchant who simply transacts in similar amounts.
+   */
+  structuring: {
+    enabled: true,
+    windowMs: 7 * DAY_MS,
+    minCount: 3,
+    bandPct: 0.2,
+    score: 70,
+  },
+
+  /**
+   * Layering: an onramp followed by an offramp (or the reverse) of comparable
+   * value inside `windowMs`.  Buying and immediately selling forfeits the
+   * spread, so it is rarely done for economic reasons.
+   */
+  rapidReversal: {
+    enabled: true,
+    windowMs: 6 * HOUR_MS,
+    /** Counterpart must be within ±this fraction of the current amount. */
+    valueTolerance: 0.15,
+    /** Ignore below this — small round-trips are usually genuine mistakes. */
+    minAmountCents: 500_00, // $500
+    score: 60,
+  },
+
+  /** Payouts fanned across more than `maxCounterparties` distinct recipients. */
+  counterpartyFanout: {
+    enabled: true,
+    windowMs: DAY_MS,
+    maxCounterparties: 8,
+    score: 45,
+  },
+
+  /** A large transaction inside the account's first `windowMs`. */
+  newAccountHighValue: {
+    enabled: true,
+    windowMs: 7 * DAY_MS,
+    minAmountCents: 2_000_00, // $2,000
+    score: 40,
+  },
+
+  /**
+   * A large transaction after `dormancyMs` of silence — a classic mule-account
+   * reactivation pattern.
+   */
+  dormantReactivation: {
+    enabled: true,
+    dormancyMs: 90 * DAY_MS,
+    minAmountCents: 1_000_00, // $1,000
+    score: 40,
+  },
+} as const
+
+// ---------------------------------------------------------------------------
+// Jurisdictions
+// ---------------------------------------------------------------------------
+
+export interface JurisdictionPolicy {
+  /** Receiving financial intelligence unit. */
+  regulator: string
+  regulatorName: string
+  /** What the FIU calls the filing locally. */
+  filingName: string
+  /**
+   * Hours from suspicion being formed to the filing being due.
+   * ⚠️  Confirm against current local statute — see the file header.
+   */
+  filingDeadlineHours: number
+  /**
+   * Cash/transaction reporting threshold, converted to USD cents.
+   *
+   * Used only to anchor structuring detection (transactions clustering just
+   * below it).  It is an FX-sensitive approximation of the local-currency
+   * figure noted alongside, and must be re-derived when rates move materially.
+   */
+  reportingThresholdCents: number
+  localThresholdNote: string
+}
+
+export const JURISDICTIONS: Record<Jurisdiction, JurisdictionPolicy> = {
+  NG: {
+    regulator: 'NFIU',
+    regulatorName: 'Nigerian Financial Intelligence Unit',
+    filingName: 'Suspicious Transaction Report (STR)',
+    filingDeadlineHours: 24,
+    reportingThresholdCents: 3_300_00,
+    localThresholdNote: '≈ ₦5,000,000 individual threshold (MLPPA 2022)',
+  },
+  KE: {
+    regulator: 'FRC',
+    regulatorName: 'Financial Reporting Centre',
+    filingName: 'Suspicious Transaction Report (STR)',
+    filingDeadlineHours: 168, // 7 days
+    reportingThresholdCents: 7_700_00,
+    localThresholdNote: '≈ KES 1,000,000 threshold (POCAMLA)',
+  },
+  GH: {
+    regulator: 'FIC',
+    regulatorName: 'Financial Intelligence Centre',
+    filingName: 'Suspicious Transaction Report (STR)',
+    filingDeadlineHours: 24,
+    reportingThresholdCents: 4_000_00,
+    localThresholdNote: '≈ GHS 50,000 threshold (AMLA 2020)',
+  },
+  ZA: {
+    regulator: 'FIC',
+    regulatorName: 'Financial Intelligence Centre',
+    filingName: 'Suspicious Transaction Report (STR), FICA s29',
+    filingDeadlineHours: 360, // 15 days
+    reportingThresholdCents: 2_700_00,
+    localThresholdNote: '≈ R49,999.99 cash threshold (FICA)',
+  },
+  UG: {
+    regulator: 'FIA',
+    regulatorName: 'Financial Intelligence Authority',
+    filingName: 'Suspicious Transaction Report (STR)',
+    filingDeadlineHours: 48,
+    reportingThresholdCents: 5_400_00,
+    localThresholdNote: '≈ UGX 20,000,000 threshold (AMLA 2013)',
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Retention
+// ---------------------------------------------------------------------------
+
+/**
+ * All five markets require AML records to be retained for at least five years
+ * after the relationship or transaction ends.  The in-memory stores obviously
+ * cannot honour that — this constant exists so the SQL retention job and any
+ * future archival code read the same number.
+ */
+export const RECORD_RETENTION_YEARS = 5
+
+/**
+ * Ledger entries held per account in the in-memory store.  Bounds heap growth
+ * the way MAX_ORDERS_PER_WALLET does for orders.  The SQL table has no such
+ * cap — retention there is RECORD_RETENTION_YEARS.
+ */
+export const MAX_LEDGER_ENTRIES_PER_USER = 500
+
+// ---------------------------------------------------------------------------
+// Provider selection
+// ---------------------------------------------------------------------------
+
+/**
+ * How long to wait on a provider before falling back to the local list.
+ *
+ * A screening call sits in the critical path of a payment, so this is short by
+ * design.  A timeout is not a pass: it raises PROVIDER_UNAVAILABLE and the
+ * transaction is routed to review rather than allowed through unscreened
+ * (see FAIL_CLOSED).
+ */
+export const PROVIDER_TIMEOUT_MS = 4_000
+
+/**
+ * When a provider is unreachable, fail closed — hold the transaction for human
+ * review instead of letting it through unscreened.
+ *
+ * Turning this off makes an outage at the provider a hole in the control, which
+ * is exactly the failure mode examiners look for.  It exists only so a market
+ * can be brought up before its provider contract is signed, and it should be
+ * `true` in every production environment.
+ */
+export const FAIL_CLOSED = true

--- a/lib/compliance/identity.ts
+++ b/lib/compliance/identity.ts
@@ -1,0 +1,42 @@
+/**
+ * Payer identity for screening.
+ *
+ * Every velocity rule keys off `ScreeningSubject.userId`.  The offramp path has
+ * a wallet public key to use; the mobile-money and bill-payment paths often do
+ * not — a customer can pay a bill by card without ever connecting a wallet.
+ * Screening those transactions under a per-request id would key each one to a
+ * fresh account, and every rule that counts behaviour over time — structuring,
+ * fan-out, dormancy — would silently never fire.  That is a worse failure than
+ * not screening at all, because the queue looks healthy while it happens.
+ *
+ * So an anonymous payer gets a stable identity derived from the instrument they
+ * paid with.  It is imperfect: one person with two phone numbers is two
+ * accounts here, and a shared handset is one account for two people.  Both are
+ * accepted limitations of instrument-derived identity, and both resolve once
+ * the payer connects a wallet — which is why callers pass the wallet key when
+ * they have one and only fall back to this.
+ */
+
+import { hashCounterparty } from './ledger'
+
+/** Instrument a payer identity can be derived from. */
+export type PayerInstrument = 'msisdn' | 'email'
+
+/**
+ * Derives a stable pseudonymous account id from a payment instrument.
+ *
+ * Salted and hashed via the ledger's own function, so a payer's identity and
+ * their counterparty key are protected identically and by the same secret —
+ * these are phone numbers and email addresses, and the ledger is not a place to
+ * accumulate raw contact details.  Missing COMPLIANCE_HASH_SALT throws; see the
+ * note on hashCounterparty().
+ *
+ * The instrument is part of the hashed input, so the same string arriving as a
+ * phone number and as an email cannot collide into one account.  The prefix on
+ * the returned id keeps it legible to an analyst reading a case file, who needs
+ * to know they are looking at a derived identity rather than a wallet key.
+ */
+export function payerIdentity(instrument: PayerInstrument, value: string): string {
+  const normalised = instrument === 'email' ? value.trim().toLowerCase() : value.replace(/\s+/g, '')
+  return `${instrument}:${hashCounterparty(`${instrument}:${normalised}`)}`
+}

--- a/lib/compliance/ledger.ts
+++ b/lib/compliance/ledger.ts
@@ -1,0 +1,236 @@
+/**
+ * Transaction ledger — the monitoring record every velocity rule reads from.
+ *
+ * Storage layer:
+ *   Same shape as lib/kyc/withdrawalLimitService.ts and lib/orders/order-store.ts
+ *   — an in-memory map deliberately mirroring the SQL table in
+ *   db/migrations/003_create_compliance.sql, so the swap to a real database is
+ *   a one-file change.  Each exported function maps to a single statement and
+ *   quotes the equivalent SQL.
+ *
+ *   The distinction from the withdrawals store matters: that one exists to
+ *   enforce a *limit* and only records offramps.  This one exists to establish
+ *   a *behavioural baseline* and records every direction of flow, including
+ *   transactions that were ultimately blocked — an attempt that was stopped is
+ *   evidence, and dropping it would make the account look cleaner than it is.
+ *
+ * PII:
+ *   No account numbers or holder names are stored here.  Counterparties are
+ *   recorded as an opaque `counterpartyKey` (see hashCounterparty) so fan-out
+ *   and reuse can be detected without the ledger becoming a second copy of
+ *   customers' banking details.  Names live only on cases, where access is
+ *   gated and audited.
+ */
+
+import { createHash } from 'node:crypto'
+import { MAX_LEDGER_ENTRIES_PER_USER } from './config'
+import type { ScreeningDecision, TransactionKind } from './types'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** A row of the `compliance_transactions` table. */
+export interface LedgerEntry {
+  transactionId: string
+  userId: string
+  kind: TransactionKind
+  /** Integer USD cents. */
+  amountCents: number
+  asset: string
+  chain: string
+  /** Salted hash of the counterparty identifier — never the raw value. */
+  counterpartyKey?: string
+  /** What screening decided.  Blocked attempts are retained deliberately. */
+  decision: ScreeningDecision
+  riskScore: number
+  occurredAt: Date
+}
+
+export interface RecordEntryInput extends Omit<LedgerEntry, 'occurredAt'> {
+  /** Defaults to now.  Injectable so tests can build histories. */
+  occurredAt?: Date
+}
+
+export interface WindowQuery {
+  /** Rolling window length in ms, measured back from `now`. */
+  windowMs: number
+  /** Window end.  Injectable so rules are testable without faking the clock. */
+  now?: Date
+}
+
+// ---------------------------------------------------------------------------
+// In-memory store (replace with DB queries in production)
+// ---------------------------------------------------------------------------
+
+/**
+ * Map<userId, LedgerEntry[]> — the `compliance_transactions` table, kept in
+ * ascending occurredAt order.  Exported so tests can inspect state directly.
+ */
+export const _ledger = new Map<string, LedgerEntry[]>()
+
+// ---------------------------------------------------------------------------
+// Writes
+// ---------------------------------------------------------------------------
+
+/**
+ * Appends an entry, keeping each user's list ordered by occurredAt.
+ *
+ *   INSERT INTO compliance_transactions
+ *     (transaction_id, user_id, kind, amount_cents, asset, chain,
+ *      counterparty_key, decision, risk_score, occurred_at)
+ *   VALUES ($1, …, $10)
+ *   ON CONFLICT (transaction_id) DO NOTHING;
+ *
+ * Re-recording the same transaction id is ignored rather than duplicated: the
+ * screening endpoint is retried by clients on flaky networks, and a duplicate
+ * would inflate every velocity count that reads this table.
+ */
+export function recordTransaction(input: RecordEntryInput): LedgerEntry {
+  const entries = _ledger.get(input.userId) ?? []
+
+  const existing = entries.find((e) => e.transactionId === input.transactionId)
+  if (existing) return existing
+
+  const entry: LedgerEntry = { ...input, occurredAt: input.occurredAt ?? new Date() }
+
+  // Almost every insert is the newest entry, so scan from the end — seeded
+  // back-dated history is the exception, not the hot path.
+  let i = entries.length
+  while (i > 0 && entries[i - 1].occurredAt > entry.occurredAt) i--
+  entries.splice(i, 0, entry)
+
+  // Bound heap growth per user, oldest first.  In SQL this is a retention job
+  // running on RECORD_RETENTION_YEARS instead.
+  if (entries.length > MAX_LEDGER_ENTRIES_PER_USER) {
+    entries.splice(0, entries.length - MAX_LEDGER_ENTRIES_PER_USER)
+  }
+
+  _ledger.set(input.userId, entries)
+  return entry
+}
+
+// ---------------------------------------------------------------------------
+// Reads
+// ---------------------------------------------------------------------------
+
+/**
+ * Entries for a user inside a rolling window, oldest first.
+ *
+ *   SELECT * FROM compliance_transactions
+ *   WHERE  user_id = $1 AND occurred_at >= $2 AND occurred_at <= $3
+ *   ORDER  BY occurred_at;
+ *
+ * The upper bound is not redundant: back-dated seeds and clock skew can put an
+ * entry ahead of `now`, and a future-dated row silently inflating a velocity
+ * count is the kind of bug that only surfaces in an audit.
+ */
+export function getEntriesInWindow(
+  userId: string,
+  { windowMs, now = new Date() }: WindowQuery
+): LedgerEntry[] {
+  const cutoff = new Date(now.getTime() - windowMs)
+  const entries = _ledger.get(userId) ?? []
+  return entries.filter((e) => e.occurredAt >= cutoff && e.occurredAt <= now)
+}
+
+/**
+ * Count and summed value inside a window.
+ *
+ *   SELECT COUNT(*), COALESCE(SUM(amount_cents), 0)
+ *   FROM   compliance_transactions
+ *   WHERE  user_id = $1 AND occurred_at >= $2;
+ */
+export function getWindowTotals(
+  userId: string,
+  query: WindowQuery
+): { count: number; volumeCents: number } {
+  const entries = getEntriesInWindow(userId, query)
+  return {
+    count: entries.length,
+    volumeCents: entries.reduce((sum, e) => sum + e.amountCents, 0),
+  }
+}
+
+/**
+ * Distinct counterparties transacted with inside a window.
+ *
+ *   SELECT COUNT(DISTINCT counterparty_key) FROM compliance_transactions
+ *   WHERE user_id = $1 AND occurred_at >= $2 AND counterparty_key IS NOT NULL;
+ */
+export function getDistinctCounterparties(
+  userId: string,
+  query: WindowQuery
+): Set<string> {
+  const keys = new Set<string>()
+  for (const entry of getEntriesInWindow(userId, query)) {
+    if (entry.counterpartyKey) keys.add(entry.counterpartyKey)
+  }
+  return keys
+}
+
+/**
+ * The user's most recent entry before `before`, or null.
+ *
+ *   SELECT * FROM compliance_transactions
+ *   WHERE user_id = $1 AND occurred_at < $2
+ *   ORDER BY occurred_at DESC LIMIT 1;
+ *
+ * Drives dormancy detection.
+ */
+export function getLastEntryBefore(userId: string, before: Date): LedgerEntry | null {
+  const entries = _ledger.get(userId) ?? []
+  for (let i = entries.length - 1; i >= 0; i--) {
+    if (entries[i].occurredAt < before) return entries[i]
+  }
+  return null
+}
+
+/** The user's earliest recorded activity, or null.  Approximates account age. */
+export function getFirstEntry(userId: string): LedgerEntry | null {
+  return _ledger.get(userId)?.[0] ?? null
+}
+
+// ---------------------------------------------------------------------------
+// Counterparty hashing
+// ---------------------------------------------------------------------------
+
+/**
+ * One-way key for a counterparty identifier (bank account, wallet address).
+ *
+ * Salted with COMPLIANCE_HASH_SALT: an unsalted hash of a 10-digit NUBAN or a
+ * phone number is trivially reversible by brute force, so it would not be
+ * pseudonymisation in any meaningful sense — and would not be treated as such
+ * under NDPA 2023 (NG) or POPIA (ZA).
+ *
+ * The salt must be stable for the lifetime of the data: rotating it re-keys
+ * every counterparty and silently resets fan-out detection, so treat it as a
+ * long-lived secret rather than a rotating one.  Missing salt throws rather
+ * than falling back to unsalted — a weak hash that looks like protection is
+ * worse than an obvious failure.
+ */
+export function hashCounterparty(identifier: string): string {
+  const salt = process.env.COMPLIANCE_HASH_SALT
+  if (!salt) {
+    throw new Error(
+      'COMPLIANCE_HASH_SALT is required to hash counterparty identifiers for the compliance ledger'
+    )
+  }
+  return createHash('sha256')
+    .update(`${salt}:${identifier.trim().toLowerCase()}`)
+    .digest('hex')
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Clears one user's ledger.  Test helper only. */
+export function _clearUserLedger(userId: string): void {
+  _ledger.delete(userId)
+}
+
+/** Empties the ledger.  Test helper only. */
+export function _clearLedger(): void {
+  _ledger.clear()
+}

--- a/lib/compliance/markets.ts
+++ b/lib/compliance/markets.ts
@@ -1,0 +1,91 @@
+/**
+ * Market resolution and currency normalisation.
+ *
+ * Payment routes speak in local currency and provider-specific country codes;
+ * every rule in this module speaks in USD cents and a market policy.  This file
+ * is the only place that translation happens, so a route cannot quietly invent
+ * its own conversion — the same reason screenTransaction() is the only entry
+ * point for risk.
+ *
+ * The tables it reads (CURRENCY_MARKETS, FX_USD_CENTS_PER_UNIT,
+ * UNLICENSED_MARKET_POLICY) live in ./config.ts with everything else a
+ * compliance officer tunes.  Logic here, figures there.
+ */
+
+import {
+  CURRENCY_MARKETS,
+  FX_USD_CENTS_PER_UNIT,
+  JURISDICTIONS,
+  UNLICENSED_MARKET_POLICY,
+  type JurisdictionPolicy,
+} from './config'
+import type { Jurisdiction, Market } from './types'
+
+/**
+ * Raised when a payment cannot be mapped onto any screening policy.
+ *
+ * Callers must treat this as a refusal, not a warning.  An unmappable currency
+ * means the engine has no threshold to measure the transaction against, and a
+ * transaction that cannot be measured has not been screened.
+ */
+export class UnsupportedMarketError extends Error {
+  readonly code = 'UNSUPPORTED_MARKET'
+  readonly currency: string
+
+  constructor(currency: string) {
+    super(`No screening policy for currency ${currency}`)
+    this.name = 'UnsupportedMarketError'
+    this.currency = currency
+  }
+}
+
+/** Whether `market` is one Aframp holds an AML registration in. */
+export function isLicensedJurisdiction(market: Market): market is Jurisdiction {
+  return market in JURISDICTIONS
+}
+
+/**
+ * The policy governing a market.
+ *
+ * Falls back to UNLICENSED_MARKET_POLICY rather than throwing: by the time a
+ * transaction reaches a rule it has already been accepted for screening, and a
+ * rule that throws mid-screening would fail *open* — the caller's catch block
+ * cannot distinguish "engine broken" from "market unknown", and the transaction
+ * ends up unscreened either way.  Refusal belongs at the edge, in
+ * resolveMarket(), before any of this runs.
+ */
+export function policyFor(market: Market): JurisdictionPolicy {
+  return JURISDICTIONS[market as Jurisdiction] ?? UNLICENSED_MARKET_POLICY
+}
+
+/**
+ * Maps an ISO 4217 currency onto the market whose policy governs it.
+ *
+ * Throws UnsupportedMarketError for anything unmapped.  Guessing — defaulting
+ * to the strictest market, say — would produce a screening record that claims a
+ * jurisdiction the transaction never touched, which is worse than a refusal:
+ * it looks like a control operating correctly.
+ */
+export function resolveMarket(currency: string): Market {
+  const market = CURRENCY_MARKETS[currency.trim().toUpperCase()]
+  if (!market) throw new UnsupportedMarketError(currency)
+  return market
+}
+
+/**
+ * Converts a local-currency major-unit amount to integer USD cents.
+ *
+ * Rounds half-up.  Sub-cent precision is meaningless against thresholds in the
+ * thousands of dollars, and rounding *up* keeps a transaction from landing just
+ * under a band edge through arithmetic alone.
+ */
+export function toUsdCents(amount: number, currency: string): number {
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new RangeError(`Amount must be a positive finite number, got ${amount}`)
+  }
+
+  const rate = FX_USD_CENTS_PER_UNIT[currency.trim().toUpperCase()]
+  if (rate === undefined) throw new UnsupportedMarketError(currency)
+
+  return Math.round(amount * rate)
+}

--- a/lib/compliance/monitor.ts
+++ b/lib/compliance/monitor.ts
@@ -1,0 +1,427 @@
+/**
+ * Screening orchestrator — the single entry point for transaction monitoring.
+ *
+ * Callers hand it a transaction and get back a decision.  Everything else —
+ * which vendor answered, how signals were scored, whether a case was opened,
+ * what got written to the ledger — is this module's business.  Payment routes
+ * must never assemble their own view of risk; a control implemented twice is a
+ * control implemented differently.
+ *
+ * Order of operations, and why:
+ *
+ *   1. Sanctions and wallet screening run **concurrently**.  They are
+ *      independent network calls and this sits in a payment path.
+ *   2. Velocity rules run against the ledger, which does not yet contain the
+ *      subject transaction.
+ *   3. Signals are scored into one decision (lib/compliance/risk.ts).
+ *   4. A case is opened for anything not ALLOW.
+ *   5. The transaction is recorded in the ledger **including when blocked** —
+ *      a blocked attempt is evidence of behaviour, and omitting it would make
+ *      a probing account look quieter than it is.
+ *
+ * Failure behaviour:
+ *   A provider that errors or times out never produces a clean result.  It
+ *   raises PROVIDER_UNAVAILABLE, the local list is still consulted so
+ *   designations are caught during an outage, and under FAIL_CLOSED the
+ *   transaction is held for review rather than allowed through unscreened.
+ */
+
+import { FAIL_CLOSED, NAME_SCREENING } from './config'
+import { openCase } from './case-store'
+import { hashCounterparty, recordTransaction } from './ledger'
+import {
+  getNameScreeningProvider,
+  getWalletRiskProvider,
+  localNameProvider,
+  localWalletProvider,
+} from './providers'
+import { decideFromScore, riskLevelForScore, scoreSignals, sortSignals } from './risk'
+import type {
+  NameMatch,
+  ProviderAttribution,
+  RiskSignal,
+  ScreeningResult,
+  ScreeningSubject,
+  WalletRiskResult,
+} from './types'
+import { evaluateVelocityRules } from './velocity'
+
+export interface ScreenOptions {
+  /** Evaluation time.  Injectable so tests need no clock control. */
+  now?: Date
+  /**
+   * Skip the ledger write.  For re-screening an existing transaction (a
+   * periodic re-check against updated lists) where a second entry would
+   * double-count it in every velocity rule.
+   */
+  skipLedger?: boolean
+}
+
+/**
+ * Screens a transaction and returns the decision.
+ *
+ * Never throws for compliance reasons — a BLOCK is a return value, not an
+ * exception, so the caller decides how to surface it to the user.  It can
+ * still throw on programmer error (missing COMPLIANCE_HASH_SALT, an
+ * unconfigured provider), which are startup faults rather than screening
+ * outcomes.
+ */
+export async function screenTransaction(
+  subject: ScreeningSubject,
+  { now = new Date(), skipLedger = false }: ScreenOptions = {}
+): Promise<ScreeningResult> {
+  const signals: RiskSignal[] = []
+  const providers: ProviderAttribution[] = []
+
+  // -- 1. External screening, concurrently -----------------------------------
+  const [walletOutcome, nameOutcome] = await Promise.all([
+    subject.walletAddress
+      ? screenWallet(subject.walletAddress, subject.chain, providers)
+      : Promise.resolve(null),
+    subject.accountName
+      ? screenName(subject.accountName, subject.jurisdiction, providers)
+      : Promise.resolve(null),
+  ])
+
+  if (walletOutcome) signals.push(...walletSignals(walletOutcome))
+  if (nameOutcome) signals.push(...nameSignals(nameOutcome))
+
+  // -- 2. Velocity -----------------------------------------------------------
+  signals.push(...evaluateVelocityRules(subject, { now }))
+
+  // -- 3. Score and decide ---------------------------------------------------
+  const sorted = sortSignals(signals)
+  const riskScore = scoreSignals(sorted)
+  const riskLevel = riskLevelForScore(riskScore)
+
+  // A designation is a legal prohibition, not a risk appetite question, so it
+  // bypasses the score thresholds entirely.
+  const hardBlock = sorted.some(
+    (s) =>
+      (s.code === 'SANCTIONS_MATCH' && s.severity === 'SEVERE') ||
+      (s.code === 'WALLET_SEVERE_RISK' && s.metadata?.sanctioned === true)
+  )
+
+  let decision = decideFromScore(riskScore, hardBlock)
+
+  // Fail closed: an unscreened transaction is not an approved one.
+  const providerFailed = sorted.some((s) => s.code === 'PROVIDER_UNAVAILABLE')
+  if (FAIL_CLOSED && providerFailed && decision === 'ALLOW') {
+    decision = 'REVIEW'
+  }
+
+  const result: Omit<ScreeningResult, 'caseId'> = {
+    transactionId: subject.transactionId,
+    userId: subject.userId,
+    decision,
+    riskScore,
+    riskLevel,
+    signals: sorted,
+    providers,
+    screenedAt: now.toISOString(),
+  }
+
+  // -- 4. Open a case for anything held or blocked ---------------------------
+  const caseId = decision === 'ALLOW' ? undefined : openCase(subject, result).id
+
+  // -- 5. Record the attempt, whatever the outcome ---------------------------
+  if (!skipLedger) {
+    recordTransaction({
+      transactionId: subject.transactionId,
+      userId: subject.userId,
+      kind: subject.kind,
+      amountCents: subject.amountCents,
+      asset: subject.asset,
+      chain: subject.chain,
+      counterpartyKey: subject.counterpartyId
+        ? hashCounterparty(subject.counterpartyId)
+        : undefined,
+      decision,
+      riskScore,
+      occurredAt: now,
+    })
+  }
+
+  return { ...result, caseId }
+}
+
+// ---------------------------------------------------------------------------
+// Wallet screening
+// ---------------------------------------------------------------------------
+
+interface WalletOutcome {
+  result: WalletRiskResult | null
+  failed: boolean
+  error?: string
+}
+
+/**
+ * Screens an address with the configured vendor, falling back to the local
+ * list.
+ *
+ * The fallback is not a substitute — see the note in providers/local.ts.  When
+ * the vendor fails, `failed` stays true even if the local list came back
+ * clean, so PROVIDER_UNAVAILABLE is raised and the transaction is held.
+ */
+async function screenWallet(
+  address: string,
+  chain: string,
+  providers: ProviderAttribution[]
+): Promise<WalletOutcome> {
+  const provider = getWalletRiskProvider()
+  const startedAt = Date.now()
+
+  try {
+    const result = await provider.screenWallet(address, chain)
+    providers.push({
+      name: provider.name,
+      kind: 'wallet',
+      ok: true,
+      latencyMs: Date.now() - startedAt,
+      reference: result.reference,
+    })
+    return { result, failed: false }
+  } catch (error) {
+    providers.push({
+      name: provider.name,
+      kind: 'wallet',
+      ok: false,
+      latencyMs: Date.now() - startedAt,
+    })
+
+    // Still consult the local list — a designated address must be caught even
+    // while the vendor is down.
+    let fallback: WalletRiskResult | null = null
+    try {
+      fallback = await localWalletProvider.screenWallet(address, chain)
+      providers.push({
+        name: localWalletProvider.name,
+        kind: 'wallet',
+        ok: true,
+        latencyMs: Date.now() - startedAt,
+      })
+    } catch {
+      // The local list is in-process; a failure here means the corpus itself is
+      // broken, which the health endpoint surfaces separately.
+    }
+
+    return {
+      result: fallback,
+      failed: true,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+function walletSignals(outcome: WalletOutcome): RiskSignal[] {
+  const signals: RiskSignal[] = []
+
+  if (outcome.failed) {
+    signals.push({
+      code: 'PROVIDER_UNAVAILABLE',
+      severity: 'MEDIUM',
+      // Scored just under DECISION_THRESHOLDS.review: an outage alone should
+      // hold the transaction (via FAIL_CLOSED) without also inflating the risk
+      // score of an otherwise unremarkable account, which would distort the
+      // queue ordering analysts triage by.
+      score: 45,
+      description: `Wallet risk provider unavailable — ${outcome.error ?? 'unknown error'}`,
+      metadata: { failedCheck: 'wallet', error: outcome.error },
+    })
+  }
+
+  const result = outcome.result
+  if (!result) return signals
+
+  if (result.sanctioned) {
+    signals.push({
+      code: 'WALLET_SEVERE_RISK',
+      severity: 'SEVERE',
+      score: 100,
+      description: `Counterparty address is on a sanctions list`,
+      metadata: {
+        sanctioned: true,
+        address: result.address,
+        categories: result.categories,
+        reference: result.reference,
+      },
+    })
+    return signals
+  }
+
+  if (result.riskLevel === 'SEVERE' || result.riskLevel === 'HIGH') {
+    signals.push({
+      code: result.riskLevel === 'SEVERE' ? 'WALLET_SEVERE_RISK' : 'WALLET_HIGH_RISK',
+      severity: result.riskLevel,
+      score: result.riskScore,
+      description: `Address rated ${result.riskLevel} — ${result.categories.join(', ') || 'no categories returned'}`,
+      metadata: {
+        sanctioned: false,
+        address: result.address,
+        providerScore: result.riskScore,
+        categories: result.categories,
+        reference: result.reference,
+      },
+    })
+  } else if (result.riskLevel === 'MEDIUM') {
+    signals.push({
+      code: 'WALLET_MEDIUM_RISK',
+      severity: 'MEDIUM',
+      score: result.riskScore,
+      description: `Address rated MEDIUM — ${result.categories.join(', ') || 'no categories returned'}`,
+      metadata: {
+        address: result.address,
+        providerScore: result.riskScore,
+        categories: result.categories,
+      },
+    })
+  }
+
+  return signals
+}
+
+// ---------------------------------------------------------------------------
+// Name screening
+// ---------------------------------------------------------------------------
+
+interface NameOutcome {
+  matches: NameMatch[]
+  failed: boolean
+  error?: string
+  reference?: string
+}
+
+async function screenName(
+  name: string,
+  jurisdiction: string,
+  providers: ProviderAttribution[]
+): Promise<NameOutcome> {
+  const provider = getNameScreeningProvider()
+  const startedAt = Date.now()
+
+  try {
+    const result = await provider.screenName(name, { country: jurisdiction })
+    providers.push({
+      name: provider.name,
+      kind: 'name',
+      ok: true,
+      latencyMs: Date.now() - startedAt,
+      reference: result.reference,
+    })
+    return { matches: result.matches, failed: false, reference: result.reference }
+  } catch (error) {
+    providers.push({
+      name: provider.name,
+      kind: 'name',
+      ok: false,
+      latencyMs: Date.now() - startedAt,
+    })
+
+    let fallbackMatches: NameMatch[] = []
+    try {
+      const fallback = await localNameProvider.screenName(name)
+      fallbackMatches = fallback.matches
+      providers.push({
+        name: localNameProvider.name,
+        kind: 'name',
+        ok: true,
+        latencyMs: Date.now() - startedAt,
+      })
+    } catch {
+      // See the equivalent note in screenWallet().
+    }
+
+    return {
+      matches: fallbackMatches,
+      failed: true,
+      error: error instanceof Error ? error.message : String(error),
+    }
+  }
+}
+
+/**
+ * Turns name hits into signals.
+ *
+ * Only the strongest hit of each class becomes a signal.  A common name can
+ * return dozens of list entries, and emitting one signal each would let match
+ * *quantity* dominate the aggregate score over match *quality* — five weak
+ * homonyms would outrank one near-exact designation. Every hit is still
+ * carried in metadata for the analyst.
+ */
+function nameSignals(outcome: NameOutcome): RiskSignal[] {
+  const signals: RiskSignal[] = []
+
+  if (outcome.failed) {
+    signals.push({
+      code: 'PROVIDER_UNAVAILABLE',
+      severity: 'MEDIUM',
+      score: 45,
+      description: `Name screening provider unavailable — ${outcome.error ?? 'unknown error'}`,
+      metadata: { failedCheck: 'name', error: outcome.error },
+    })
+  }
+
+  const strongest = (type: NameMatch['matchTypes'][number]) =>
+    outcome.matches
+      .filter((m) => m.matchTypes.includes(type))
+      .sort((a, b) => b.matchScore - a.matchScore)[0]
+
+  const sanction = strongest('SANCTION')
+  if (sanction) {
+    // Above strongMatchThreshold the hit is near-exact and blocks; between the
+    // two thresholds a human decides, so it scores into REVIEW rather than
+    // BLOCK. Auto-blocking every fuzzy homonym would strand legitimate
+    // customers who share a name with a designated person — a real and
+    // frequent occurrence, not a hypothetical.
+    const strong = sanction.matchScore >= NAME_SCREENING.strongMatchThreshold
+    signals.push({
+      code: 'SANCTIONS_MATCH',
+      severity: strong ? 'SEVERE' : 'HIGH',
+      score: strong ? 100 : 70,
+      description: `Account name matches "${sanction.name}" on ${sanction.listName} at ${(sanction.matchScore * 100).toFixed(0)}% confidence`,
+      metadata: {
+        matchScore: sanction.matchScore,
+        entityId: sanction.entityId,
+        listName: sanction.listName,
+        strongMatch: strong,
+        allMatches: outcome.matches,
+        providerReference: outcome.reference,
+      },
+    })
+  }
+
+  const pep = strongest('PEP')
+  if (pep) {
+    signals.push({
+      code: 'PEP_MATCH',
+      severity: 'MEDIUM',
+      // A PEP is not a criminal — the obligation is enhanced due diligence, not
+      // refusal — so this scores to review, never to block.
+      score: 40,
+      description: `Account name matches politically exposed person "${pep.name}" at ${(pep.matchScore * 100).toFixed(0)}% confidence`,
+      metadata: {
+        matchScore: pep.matchScore,
+        entityId: pep.entityId,
+        listName: pep.listName,
+        countries: pep.countries,
+      },
+    })
+  }
+
+  const media = strongest('ADVERSE_MEDIA')
+  if (media) {
+    signals.push({
+      code: 'ADVERSE_MEDIA',
+      severity: 'MEDIUM',
+      score: 30,
+      description: `Adverse media match on "${media.name}" at ${(media.matchScore * 100).toFixed(0)}% confidence`,
+      metadata: {
+        matchScore: media.matchScore,
+        entityId: media.entityId,
+        listName: media.listName,
+      },
+    })
+  }
+
+  return signals
+}

--- a/lib/compliance/providers/chainalysis.ts
+++ b/lib/compliance/providers/chainalysis.ts
@@ -1,0 +1,165 @@
+/**
+ * Chainalysis adapter — wallet risk.
+ *
+ * Targets the Address Screening API (`/api/risk/v2/entities`), which returns a
+ * categorical risk verdict plus the exposure reasoning behind it.  KYT, the
+ * other Chainalysis product, is a transfer-registration API with a different
+ * lifecycle (register, then poll for alerts) that does not fit a synchronous
+ * pre-transaction check; if Aframp later adopts KYT it belongs in its own
+ * adapter rather than bent into this one.
+ *
+ * ⚠️  Request/response shapes follow the vendor's published v2 contract at time
+ *     of writing.  Verify against current Chainalysis documentation and their
+ *     sandbox before enabling in production — vendors revise these, and a
+ *     silently-changed field here degrades to "no risk found", which is the
+ *     failure direction that matters.  parseRisk() below is deliberately strict
+ *     about the enum so an unrecognised verdict raises instead of scoring 0.
+ */
+
+import { PROVIDER_TIMEOUT_MS } from '../config'
+import type { RiskLevel, WalletRiskResult } from '../types'
+import { ProviderError, withTimeout, type WalletRiskProvider } from './types'
+
+const DEFAULT_BASE_URL = 'https://api.chainalysis.com'
+
+/** Chainalysis returns a four-level enum; it maps 1:1 onto our RiskLevel. */
+const RISK_MAP: Record<string, RiskLevel> = {
+  Low: 'LOW',
+  Medium: 'MEDIUM',
+  High: 'HIGH',
+  Severe: 'SEVERE',
+}
+
+/**
+ * Representative numeric score per band, since this API is categorical.
+ *
+ * The engine works in numbers so that vendor verdicts compose with velocity
+ * signals.  Values sit at the midpoint of each RISK_BANDS range, except SEVERE
+ * which is pinned to 100 — a severe verdict should reach the block threshold on
+ * its own, without needing a second corroborating signal.
+ */
+const RISK_SCORES: Record<RiskLevel, number> = {
+  LOW: 5,
+  MEDIUM: 35,
+  HIGH: 65,
+  SEVERE: 100,
+}
+
+interface ChainalysisEntityResponse {
+  risk?: string
+  riskReason?: string | null
+  cluster?: { name?: string; category?: string } | null
+  addressIdentifications?: Array<{ category?: string; name?: string }>
+  exposures?: Array<{ category?: string; value?: number }>
+}
+
+export class ChainalysisProvider implements WalletRiskProvider {
+  readonly name = 'chainalysis'
+
+  private readonly apiKey: string
+  private readonly baseUrl: string
+
+  constructor(apiKey: string, baseUrl: string = DEFAULT_BASE_URL) {
+    if (!apiKey) throw new Error('ChainalysisProvider requires an API key')
+    this.apiKey = apiKey
+    this.baseUrl = baseUrl.replace(/\/$/, '')
+  }
+
+  /**
+   * `chain` is unused: this endpoint resolves an address to a cluster without
+   * needing the chain named, unlike Elliptic.  It stays in the signature
+   * because WalletRiskProvider requires it and adapters must stay swappable.
+   */
+  async screenWallet(address: string, _chain: string): Promise<WalletRiskResult> {
+    const url = `${this.baseUrl}/api/risk/v2/entities/${encodeURIComponent(address)}`
+
+    const response = await withTimeout(
+      fetch(url, {
+        method: 'GET',
+        headers: {
+          Token: this.apiKey,
+          Accept: 'application/json',
+        },
+        // Screening results are per-address and change over time; never serve
+        // one from an HTTP cache.
+        cache: 'no-store',
+      }),
+      PROVIDER_TIMEOUT_MS,
+      this.name
+    )
+
+    // 404 means the address is unknown to Chainalysis, which is a legitimate
+    // low-risk answer for a fresh address — not an error.
+    if (response.status === 404) {
+      return {
+        address,
+        riskScore: RISK_SCORES.LOW,
+        riskLevel: 'LOW',
+        categories: [],
+        sanctioned: false,
+      }
+    }
+
+    if (!response.ok) {
+      throw new ProviderError(
+        this.name,
+        `Address screening failed with HTTP ${response.status}`
+      )
+    }
+
+    let body: ChainalysisEntityResponse
+    try {
+      body = (await response.json()) as ChainalysisEntityResponse
+    } catch (error) {
+      throw new ProviderError(this.name, 'Malformed JSON in response', error)
+    }
+
+    const riskLevel = parseRisk(body.risk, this.name)
+    const categories = collectCategories(body)
+
+    return {
+      address,
+      riskScore: RISK_SCORES[riskLevel],
+      riskLevel,
+      categories,
+      // Chainalysis signals designation through the `sanctions` category rather
+      // than a dedicated boolean, so we look for it explicitly instead of
+      // inferring it from the severity — a SEVERE verdict can also come from
+      // heavy darknet exposure, which is a risk call, not a legal prohibition.
+      sanctioned: categories.some((c) => c.toLowerCase().includes('sanction')),
+      reference: body.cluster?.name ?? undefined,
+    }
+  }
+}
+
+/**
+ * Maps the vendor's risk enum, raising on anything unrecognised.
+ *
+ * Defaulting an unknown verdict to LOW would turn a vendor-side rename into a
+ * silent screening bypass.  Raising routes the transaction to review instead,
+ * which is the correct direction to fail.
+ */
+function parseRisk(risk: string | undefined, provider: string): RiskLevel {
+  if (!risk) throw new ProviderError(provider, 'Response contained no risk verdict')
+  const level = RISK_MAP[risk]
+  if (!level) throw new ProviderError(provider, `Unrecognised risk verdict "${risk}"`)
+  return level
+}
+
+/** Flattens identification, cluster and exposure categories into one list. */
+function collectCategories(body: ChainalysisEntityResponse): string[] {
+  const categories = new Set<string>()
+
+  for (const id of body.addressIdentifications ?? []) {
+    if (id.category) categories.add(id.category)
+  }
+  if (body.cluster?.category) categories.add(body.cluster.category)
+  for (const exposure of body.exposures ?? []) {
+    // Only exposures with actual value attached — a zero-value exposure row is
+    // noise in the case file.
+    if (exposure.category && (exposure.value ?? 0) > 0) categories.add(exposure.category)
+  }
+  if (body.riskReason) categories.add(body.riskReason)
+
+  return [...categories]
+}

--- a/lib/compliance/providers/comply-advantage.ts
+++ b/lib/compliance/providers/comply-advantage.ts
@@ -1,0 +1,207 @@
+/**
+ * ComplyAdvantage adapter — name screening (sanctions, PEP, adverse media).
+ *
+ * This is the half of the control that covers bank account holder names and
+ * mobile-money subscriber names, which blockchain analytics cannot see.  For an
+ * offramp it is the more important half: the fiat leg is where a designated
+ * person actually receives value.
+ *
+ * ⚠️  Verify endpoint, parameters and response shape against current
+ *     ComplyAdvantage documentation before enabling in production.
+ *
+ * Cost note: ComplyAdvantage bills per search.  Screening every transaction
+ * re-bills for the same counterparty repeatedly.  The intended production
+ * shape is to screen a counterparty once on first use, persist the result, and
+ * re-screen on list update or after a staleness window — see the caching
+ * discussion in docs/AML_COMPLIANCE.md.  This adapter deliberately does no
+ * caching of its own: caching a *screening decision* is a compliance policy
+ * choice, not a transport detail, and hiding it inside an HTTP client is how
+ * teams end up unable to answer "when was this person last screened?".
+ */
+
+import { NAME_SCREENING, PROVIDER_TIMEOUT_MS } from '../config'
+import type { NameMatch, NameScreeningResult } from '../types'
+import {
+  ProviderError,
+  withTimeout,
+  type NameScreeningOptions,
+  type NameScreeningProvider,
+} from './types'
+
+const DEFAULT_BASE_URL = 'https://api.complyadvantage.com'
+
+/**
+ * ComplyAdvantage `fuzziness` is 0–1 and is *not* the same quantity as our
+ * match threshold: theirs widens the candidate net server-side, ours decides
+ * what counts as a hit.  Searching narrower than we filter would mean the
+ * provider silently discards candidates we would have wanted to see, so this
+ * sits deliberately below NAME_SCREENING.matchThreshold.
+ */
+const SEARCH_FUZZINESS = 0.6
+
+/** Their match-type vocabulary → ours. */
+const MATCH_TYPE_MAP: Record<string, NameMatch['matchTypes'][number]> = {
+  sanction: 'SANCTION',
+  'warning': 'WATCHLIST',
+  'fitness-probity': 'WATCHLIST',
+  pep: 'PEP',
+  'pep-class-1': 'PEP',
+  'pep-class-2': 'PEP',
+  'pep-class-3': 'PEP',
+  'pep-class-4': 'PEP',
+  'adverse-media': 'ADVERSE_MEDIA',
+  'adverse-media-financial-crime': 'ADVERSE_MEDIA',
+  'adverse-media-violent-crime': 'ADVERSE_MEDIA',
+  'adverse-media-sexual-crime': 'ADVERSE_MEDIA',
+  'adverse-media-terrorism': 'ADVERSE_MEDIA',
+  'adverse-media-fraud': 'ADVERSE_MEDIA',
+}
+
+interface ComplyAdvantageField {
+  name?: string
+  value?: string
+  source?: string
+}
+
+interface ComplyAdvantageHit {
+  doc?: {
+    id?: string
+    name?: string
+    entity_type?: string
+    aka?: Array<{ name?: string }>
+    types?: string[]
+    fields?: ComplyAdvantageField[]
+    sources?: string[]
+  }
+  match_types?: string[]
+  score?: number
+}
+
+interface ComplyAdvantageResponse {
+  content?: {
+    data?: {
+      id?: number
+      ref?: string
+      hits?: ComplyAdvantageHit[]
+    }
+  }
+}
+
+export class ComplyAdvantageProvider implements NameScreeningProvider {
+  readonly name = 'complyadvantage'
+
+  private readonly apiKey: string
+  private readonly baseUrl: string
+
+  constructor(apiKey: string, baseUrl: string = DEFAULT_BASE_URL) {
+    if (!apiKey) throw new Error('ComplyAdvantageProvider requires an API key')
+    this.apiKey = apiKey
+    this.baseUrl = baseUrl.replace(/\/$/, '')
+  }
+
+  async screenName(
+    name: string,
+    { country, entity = false, clientRef }: NameScreeningOptions = {}
+  ): Promise<NameScreeningResult> {
+    const body = JSON.stringify({
+      search_term: name,
+      client_ref: clientRef,
+      fuzziness: SEARCH_FUZZINESS,
+      // `share_url` returns a link into their case manager, which is what an
+      // analyst actually wants in the case file.
+      share_url: 1,
+      filters: {
+        entity_type: entity ? 'company' : 'person',
+        types: ['sanction', 'warning', 'fitness-probity', 'pep', 'adverse-media'],
+        ...(country ? { country_codes: [country] } : {}),
+      },
+    })
+
+    const response = await withTimeout(
+      fetch(`${this.baseUrl}/searches`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Token ${this.apiKey}`,
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body,
+        cache: 'no-store',
+      }),
+      PROVIDER_TIMEOUT_MS,
+      this.name
+    )
+
+    if (!response.ok) {
+      throw new ProviderError(
+        this.name,
+        `Name screening failed with HTTP ${response.status}`
+      )
+    }
+
+    let parsed: ComplyAdvantageResponse
+    try {
+      parsed = (await response.json()) as ComplyAdvantageResponse
+    } catch (error) {
+      throw new ProviderError(this.name, 'Malformed JSON in response', error)
+    }
+
+    const data = parsed.content?.data
+    const hits = data?.hits ?? []
+
+    const matches = hits
+      .map((hit) => toNameMatch(hit))
+      .filter((match): match is NameMatch => match !== null)
+      .filter((match) => match.matchScore >= NAME_SCREENING.matchThreshold)
+      .sort((a, b) => b.matchScore - a.matchScore)
+      .slice(0, NAME_SCREENING.maxMatches)
+
+    return {
+      matches,
+      // Persisted on the case so the search can be re-opened in their console
+      // during an audit or a regulator query.
+      reference: data?.ref ?? (data?.id != null ? String(data.id) : undefined),
+    }
+  }
+}
+
+function toNameMatch(hit: ComplyAdvantageHit): NameMatch | null {
+  const doc = hit.doc
+  if (!doc?.id || !doc.name) return null
+
+  const matchTypes = new Set<NameMatch['matchTypes'][number]>()
+  // `match_types` describes *how* the name matched; `types` describes what the
+  // subject is listed for.  Both feed our classification — a hit that arrives
+  // with neither is still a hit, so it falls back to WATCHLIST rather than
+  // being dropped.
+  for (const type of [...(hit.match_types ?? []), ...(doc.types ?? [])]) {
+    const mapped = MATCH_TYPE_MAP[type]
+    if (mapped) matchTypes.add(mapped)
+  }
+  if (matchTypes.size === 0) matchTypes.add('WATCHLIST')
+
+  return {
+    entityId: doc.id,
+    name: doc.name,
+    // ComplyAdvantage scores can exceed 1 on strong multi-field matches; clamp
+    // so downstream threshold comparisons stay on a 0–1 scale.
+    matchScore: Math.min(1, hit.score ?? 0),
+    listName: doc.sources?.[0] ?? 'ComplyAdvantage',
+    matchTypes: [...matchTypes],
+    countries: extractCountries(doc.fields),
+    aliases: (doc.aka ?? [])
+      .map((a) => a.name)
+      .filter((n): n is string => Boolean(n))
+      .slice(0, 10),
+  }
+}
+
+function extractCountries(fields: ComplyAdvantageField[] | undefined): string[] {
+  const countries = new Set<string>()
+  for (const field of fields ?? []) {
+    if (field.name?.toLowerCase().includes('country') && field.value) {
+      countries.add(field.value)
+    }
+  }
+  return [...countries]
+}

--- a/lib/compliance/providers/elliptic.ts
+++ b/lib/compliance/providers/elliptic.ts
@@ -1,0 +1,205 @@
+/**
+ * Elliptic adapter — wallet risk.
+ *
+ * Targets Elliptic's synchronous wallet screening endpoint.  Two things make
+ * this adapter more involved than the Chainalysis one:
+ *
+ *   1. **HMAC request signing.**  Elliptic authenticates each call with an
+ *      HMAC-SHA256 signature over `{timestamp}{METHOD}{path}{body}`, keyed on
+ *      the base64-decoded API secret.  The signature is timestamp-bound, so
+ *      clock skew on the server shows up as 401s rather than as a code bug —
+ *      worth knowing before debugging this at 3am.
+ *   2. **A 0–10 risk score**, not a category, which is rescaled to our 0–100.
+ *
+ * ⚠️  As with the Chainalysis adapter: verify the endpoint, the signing payload
+ *     and the response shape against current Elliptic documentation before
+ *     enabling in production.
+ */
+
+import { createHmac } from 'node:crypto'
+import { PROVIDER_TIMEOUT_MS } from '../config'
+import type { RiskLevel, WalletRiskResult } from '../types'
+import { ProviderError, withTimeout, type WalletRiskProvider } from './types'
+
+const DEFAULT_BASE_URL = 'https://aml-api.elliptic.co'
+const SCREEN_PATH = '/v2/wallet/synchronous'
+
+/**
+ * Elliptic scores 0–10.  Multiplying by 10 lands on our 0–100 scale directly,
+ * and the band boundaries line up with how Elliptic documents its own
+ * thresholds (≥7 high, ≥9 severe), so no bespoke mapping table is needed.
+ */
+const ELLIPTIC_SCORE_MAX = 10
+
+interface EllipticResponse {
+  /** 0–10, or null when Elliptic has no opinion on the address. */
+  risk_score?: number | null
+  evaluation_detail?: {
+    source?: string
+    destination?: string
+  }
+  triggered_rules?: Array<{
+    rule?: { name?: string }
+    matched_elements?: Array<{ contributions?: Array<{ entities?: Array<{ category?: string; name?: string }> }> }>
+  }>
+  cluster?: { category?: string; name?: string }
+  id?: string
+}
+
+export class EllipticProvider implements WalletRiskProvider {
+  readonly name = 'elliptic'
+
+  private readonly apiKey: string
+  private readonly apiSecret: string
+  private readonly baseUrl: string
+
+  constructor(apiKey: string, apiSecret: string, baseUrl: string = DEFAULT_BASE_URL) {
+    if (!apiKey || !apiSecret) {
+      throw new Error('EllipticProvider requires both an API key and secret')
+    }
+    this.apiKey = apiKey
+    this.apiSecret = apiSecret
+    this.baseUrl = baseUrl.replace(/\/$/, '')
+  }
+
+  async screenWallet(address: string, chain: string): Promise<WalletRiskResult> {
+    const payload = JSON.stringify({
+      subject: {
+        asset: mapChainToAsset(chain),
+        blockchain: mapChainToBlockchain(chain),
+        type: 'address',
+        hash: address,
+      },
+      type: 'wallet_exposure',
+      customer_reference: 'aframp',
+    })
+
+    const timestamp = Date.now()
+    const signature = this.sign(timestamp, 'POST', SCREEN_PATH, payload)
+
+    const response = await withTimeout(
+      fetch(`${this.baseUrl}${SCREEN_PATH}`, {
+        method: 'POST',
+        headers: {
+          'x-access-key': this.apiKey,
+          'x-access-sign': signature,
+          'x-access-timestamp': String(timestamp),
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        body: payload,
+        cache: 'no-store',
+      }),
+      PROVIDER_TIMEOUT_MS,
+      this.name
+    )
+
+    if (!response.ok) {
+      throw new ProviderError(
+        this.name,
+        `Wallet screening failed with HTTP ${response.status}`
+      )
+    }
+
+    let body: EllipticResponse
+    try {
+      body = (await response.json()) as EllipticResponse
+    } catch (error) {
+      throw new ProviderError(this.name, 'Malformed JSON in response', error)
+    }
+
+    // A null score means "no exposure found", which is genuinely low risk —
+    // distinct from a failed call, which throws above.
+    const rawScore = body.risk_score ?? 0
+    if (typeof rawScore !== 'number' || Number.isNaN(rawScore)) {
+      throw new ProviderError(this.name, 'Response contained a non-numeric risk score')
+    }
+
+    const riskScore = Math.round(
+      (Math.min(Math.max(rawScore, 0), ELLIPTIC_SCORE_MAX) / ELLIPTIC_SCORE_MAX) * 100
+    )
+    const categories = collectCategories(body)
+
+    return {
+      address,
+      riskScore,
+      riskLevel: levelFromScore(riskScore),
+      categories,
+      sanctioned: categories.some((c) => c.toLowerCase().includes('sanction')),
+      reference: body.id,
+    }
+  }
+
+  /**
+   * HMAC-SHA256 over `{timestamp}{METHOD}{path}{body}`, keyed on the
+   * base64-decoded secret, emitted base64.
+   *
+   * The secret is base64 at rest, so it must be decoded to bytes before use —
+   * signing with the base64 *text* produces a well-formed signature that the
+   * API rejects, which is an easy hour to lose.
+   */
+  private sign(timestamp: number, method: string, path: string, body: string): string {
+    const message = `${timestamp}${method.toUpperCase()}${path}${body}`
+    return createHmac('sha256', Buffer.from(this.apiSecret, 'base64'))
+      .update(message, 'utf8')
+      .digest('base64')
+  }
+}
+
+/** Mirrors the band boundaries in config.ts RISK_BANDS. */
+function levelFromScore(score: number): RiskLevel {
+  if (score >= 75) return 'SEVERE'
+  if (score >= 50) return 'HIGH'
+  if (score >= 25) return 'MEDIUM'
+  return 'LOW'
+}
+
+/**
+ * Chain name → Elliptic asset code.
+ *
+ * Aframp settles on Stellar today; the rest are here so adding a chain does not
+ * require touching the adapter.  Unknown chains fall through to the raw string
+ * so Elliptic rejects it loudly rather than being silently screened as the
+ * wrong asset.
+ */
+function mapChainToAsset(chain: string): string {
+  const map: Record<string, string> = {
+    stellar: 'XLM',
+    ethereum: 'ETH',
+    bitcoin: 'BTC',
+    polygon: 'MATIC',
+    tron: 'TRX',
+  }
+  return map[chain.toLowerCase()] ?? chain.toUpperCase()
+}
+
+function mapChainToBlockchain(chain: string): string {
+  const map: Record<string, string> = {
+    stellar: 'stellar',
+    ethereum: 'ethereum',
+    bitcoin: 'bitcoin',
+    polygon: 'polygon',
+    tron: 'tron',
+  }
+  return map[chain.toLowerCase()] ?? chain.toLowerCase()
+}
+
+/** Pulls rule names and attributed entity categories into a flat list. */
+function collectCategories(body: EllipticResponse): string[] {
+  const categories = new Set<string>()
+
+  if (body.cluster?.category) categories.add(body.cluster.category)
+
+  for (const rule of body.triggered_rules ?? []) {
+    if (rule.rule?.name) categories.add(rule.rule.name)
+    for (const element of rule.matched_elements ?? []) {
+      for (const contribution of element.contributions ?? []) {
+        for (const entity of contribution.entities ?? []) {
+          if (entity.category) categories.add(entity.category)
+        }
+      }
+    }
+  }
+
+  return [...categories]
+}

--- a/lib/compliance/providers/index.ts
+++ b/lib/compliance/providers/index.ts
@@ -1,0 +1,117 @@
+/**
+ * Provider selection and failover.
+ *
+ * Which vendor is active is an environment decision, not a code one — a market
+ * can run Chainalysis while another runs Elliptic, and CI runs neither.
+ * Construction is lazy and memoised: a missing key must fail when screening is
+ * first attempted, not at module import, or a misconfigured secret takes down
+ * the whole app rather than degrading one control.
+ *
+ * Environment:
+ *   COMPLIANCE_WALLET_PROVIDER   chainalysis | elliptic | local   (default: local)
+ *   COMPLIANCE_NAME_PROVIDER     complyadvantage | local          (default: local)
+ *   CHAINALYSIS_API_KEY
+ *   ELLIPTIC_API_KEY / ELLIPTIC_API_SECRET
+ *   COMPLYADVANTAGE_API_KEY
+ *
+ * Defaulting to `local` is chosen so a developer without vendor keys still runs
+ * the full code path.  Production must set these explicitly — the admin health
+ * endpoint reports the active provider so "we forgot to configure it" is
+ * visible rather than assumed.
+ */
+
+import { ChainalysisProvider } from './chainalysis'
+import { ComplyAdvantageProvider } from './comply-advantage'
+import { EllipticProvider } from './elliptic'
+import { LocalListNameProvider, LocalListWalletProvider } from './local'
+import type { NameScreeningProvider, WalletRiskProvider } from './types'
+
+let _walletProvider: WalletRiskProvider | null = null
+let _nameProvider: NameScreeningProvider | null = null
+
+/** The blockchain-analytics provider named by the environment. */
+export function getWalletRiskProvider(): WalletRiskProvider {
+  if (_walletProvider) return _walletProvider
+
+  const choice = (process.env.COMPLIANCE_WALLET_PROVIDER ?? 'local').toLowerCase()
+
+  switch (choice) {
+    case 'chainalysis':
+      _walletProvider = new ChainalysisProvider(
+        requireEnv('CHAINALYSIS_API_KEY'),
+        process.env.CHAINALYSIS_BASE_URL
+      )
+      break
+    case 'elliptic':
+      _walletProvider = new EllipticProvider(
+        requireEnv('ELLIPTIC_API_KEY'),
+        requireEnv('ELLIPTIC_API_SECRET'),
+        process.env.ELLIPTIC_BASE_URL
+      )
+      break
+    case 'local':
+      _walletProvider = new LocalListWalletProvider()
+      break
+    default:
+      throw new Error(
+        `Unknown COMPLIANCE_WALLET_PROVIDER "${choice}" — expected chainalysis, elliptic or local`
+      )
+  }
+
+  return _walletProvider
+}
+
+/** The entity-screening provider named by the environment. */
+export function getNameScreeningProvider(): NameScreeningProvider {
+  if (_nameProvider) return _nameProvider
+
+  const choice = (process.env.COMPLIANCE_NAME_PROVIDER ?? 'local').toLowerCase()
+
+  switch (choice) {
+    case 'complyadvantage':
+      _nameProvider = new ComplyAdvantageProvider(
+        requireEnv('COMPLYADVANTAGE_API_KEY'),
+        process.env.COMPLYADVANTAGE_BASE_URL
+      )
+      break
+    case 'local':
+      _nameProvider = new LocalListNameProvider()
+      break
+    default:
+      throw new Error(
+        `Unknown COMPLIANCE_NAME_PROVIDER "${choice}" — expected complyadvantage or local`
+      )
+  }
+
+  return _nameProvider
+}
+
+/** Local providers, used as the failover leg when a vendor call fails. */
+export const localWalletProvider = new LocalListWalletProvider()
+export const localNameProvider = new LocalListNameProvider()
+
+/** True when either half of screening is running without a paid provider. */
+export function isRunningOnLocalOnly(): boolean {
+  const wallet = (process.env.COMPLIANCE_WALLET_PROVIDER ?? 'local').toLowerCase()
+  const name = (process.env.COMPLIANCE_NAME_PROVIDER ?? 'local').toLowerCase()
+  return wallet === 'local' || name === 'local'
+}
+
+function requireEnv(key: string): string {
+  const value = process.env[key]
+  if (!value) {
+    throw new Error(
+      `${key} is required by the configured compliance provider but is not set`
+    )
+  }
+  return value
+}
+
+/** Drops memoised providers so a test can re-read the environment. */
+export function _resetProviders(): void {
+  _walletProvider = null
+  _nameProvider = null
+}
+
+export { ProviderError } from './types'
+export type { NameScreeningProvider, WalletRiskProvider } from './types'

--- a/lib/compliance/providers/local.ts
+++ b/lib/compliance/providers/local.ts
@@ -1,0 +1,64 @@
+/**
+ * Local providers — screening against the bundled list, no network call.
+ *
+ * These are not a stub.  They are the failover path: when the paid provider
+ * times out or errors, the orchestrator still runs these so a designated name
+ * or a designated address is caught even during a vendor outage.  A local hit
+ * blocks exactly as a vendor hit does.
+ *
+ * What they cannot do is the part vendors are paid for — attributing an address
+ * to a darknet market, spotting adverse media, resolving a PEP's family
+ * members.  So a clean local result is never treated as a clean screening when
+ * the vendor failed; the orchestrator still raises PROVIDER_UNAVAILABLE and,
+ * under FAIL_CLOSED, holds for review.  Silence here means "nothing on the
+ * list", not "no risk".
+ */
+
+import type { NameScreeningResult, WalletRiskResult } from '../types'
+import { screenAddressAgainstLists, screenNameAgainstLists } from '../sanctions/list'
+import type {
+  NameScreeningOptions,
+  NameScreeningProvider,
+  WalletRiskProvider,
+} from './types'
+
+export class LocalListNameProvider implements NameScreeningProvider {
+  readonly name = 'local-list'
+
+  // Synchronous under the hood — the corpus is in process memory.  The Promise
+  // is there because the interface is shared with providers that make network
+  // calls, and callers must not be able to tell them apart.
+  screenName(
+    name: string,
+    { entity = false }: NameScreeningOptions = {}
+  ): Promise<NameScreeningResult> {
+    return Promise.resolve({ matches: screenNameAgainstLists(name, { entity }) })
+  }
+}
+
+export class LocalListWalletProvider implements WalletRiskProvider {
+  readonly name = 'local-list'
+
+  screenWallet(address: string, _chain: string): Promise<WalletRiskResult> {
+    const hit = screenAddressAgainstLists(address)
+
+    if (!hit) {
+      return Promise.resolve({
+        address,
+        riskScore: 0,
+        riskLevel: 'LOW',
+        categories: [],
+        sanctioned: false,
+      })
+    }
+
+    return Promise.resolve({
+      address,
+      riskScore: 100,
+      riskLevel: 'SEVERE',
+      categories: ['sanctioned_address'],
+      sanctioned: true,
+      reference: hit.id,
+    })
+  }
+}

--- a/lib/compliance/providers/types.ts
+++ b/lib/compliance/providers/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Provider abstraction.
+ *
+ * The requirement named three candidate vendors — Elliptic, Chainalysis and
+ * ComplyAdvantage — so the code commits to none of them.  They are not
+ * interchangeable in the first place: Elliptic and Chainalysis do blockchain
+ * analytics (is *this address* risky), ComplyAdvantage does entity screening
+ * (is *this person* listed).  A ramp needs both halves, which is why the
+ * interface is split in two rather than being one `ComplianceProvider`.
+ *
+ * Adapters normalise each vendor's scoring onto a common 0–100 scale so the
+ * risk engine never learns vendor-specific vocabulary.  Swapping vendor, or
+ * running one per market, is then a config change.
+ */
+
+import type { NameScreeningResult, WalletRiskResult } from '../types'
+
+/** Blockchain analytics: Chainalysis, Elliptic, TRM, … */
+export interface WalletRiskProvider {
+  readonly name: string
+  /**
+   * @param address Counterparty address, as the chain formats it.
+   * @param chain   Chain identifier, e.g. "Stellar", "Ethereum".
+   */
+  screenWallet(address: string, chain: string): Promise<WalletRiskResult>
+}
+
+/** Entity screening: ComplyAdvantage, Dow Jones, Refinitiv, … */
+export interface NameScreeningProvider {
+  readonly name: string
+  screenName(name: string, options?: NameScreeningOptions): Promise<NameScreeningResult>
+}
+
+export interface NameScreeningOptions {
+  /** Country hint (ISO 3166-1 alpha-2) — narrows false positives. */
+  country?: string
+  /** True when the name belongs to a business rather than a person. */
+  entity?: boolean
+  /** Correlation id echoed into provider logs for audit. */
+  clientRef?: string
+}
+
+/**
+ * Raised when a provider cannot answer — network failure, timeout, auth error,
+ * malformed response.
+ *
+ * Never swallowed into a clean result.  A screening call that failed must be
+ * distinguishable from one that returned "no hits", or an outage silently
+ * becomes an approval.  Callers translate this into PROVIDER_UNAVAILABLE and,
+ * under FAIL_CLOSED, a review hold.
+ */
+export class ProviderError extends Error {
+  readonly provider: string
+  readonly cause?: unknown
+
+  constructor(provider: string, message: string, cause?: unknown) {
+    super(`[${provider}] ${message}`)
+    this.name = 'ProviderError'
+    this.provider = provider
+    this.cause = cause
+  }
+}
+
+/**
+ * Rejects with ProviderError if `promise` has not settled within `timeoutMs`.
+ *
+ * A screening call blocks a payment, so an unbounded wait on a vendor is a
+ * self-inflicted outage.  Note this abandons rather than cancels the in-flight
+ * request — vendors are billed per call, so a timed-out call still costs.
+ */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  provider: string
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new ProviderError(provider, `Timed out after ${timeoutMs}ms`)),
+          timeoutMs
+        )
+      }),
+    ])
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}

--- a/lib/compliance/risk.ts
+++ b/lib/compliance/risk.ts
@@ -1,0 +1,88 @@
+/**
+ * Risk aggregation — turns a bag of signals into one score, level and decision.
+ *
+ * Isolated from the orchestrator so the scoring model can be unit-tested and
+ * reasoned about on its own.  Examiners ask how a score is produced; the answer
+ * needs to fit on one page, which is this file.
+ */
+
+import { DECISION_THRESHOLDS, RISK_BANDS, SECONDARY_SIGNAL_WEIGHT } from './config'
+import {
+  RISK_LEVEL_RANK,
+  type RiskLevel,
+  type RiskSignal,
+  type ScreeningDecision,
+} from './types'
+
+/**
+ * Aggregates signal scores into a single 0–100 figure.
+ *
+ * The model is "strongest signal, plus a discounted contribution from the
+ * rest", capped at 100:
+ *
+ *   score = max(s) + SECONDARY_SIGNAL_WEIGHT × Σ(remaining s)
+ *
+ * A plain sum was rejected because three unremarkable MEDIUM signals would
+ * outrank one sanctions-adjacent HIGH one, and analysts end up triaging noise
+ * ahead of danger.  Taking the max alone was also rejected: corroboration is
+ * genuinely evidence, and an account tripping four rules at once deserves to
+ * outrank one tripping a single rule of the same severity.  The discounted sum
+ * keeps the ordering dominated by the worst thing observed while still letting
+ * corroboration escalate a case across a band boundary.
+ *
+ * The function is order-independent and monotone — adding a signal can never
+ * lower the score, which is the property that makes the model defensible.
+ */
+export function scoreSignals(signals: RiskSignal[]): number {
+  if (signals.length === 0) return 0
+
+  const scores = signals.map((s) => clamp(s.score, 0, 100)).sort((a, b) => b - a)
+  const [highest, ...rest] = scores
+  const secondary = rest.reduce((sum, s) => sum + s, 0) * SECONDARY_SIGNAL_WEIGHT
+
+  return Math.min(100, Math.round(highest + secondary))
+}
+
+/** Maps an aggregate score onto its band.  Bands are lower-inclusive. */
+export function riskLevelForScore(score: number): RiskLevel {
+  const clamped = clamp(score, 0, 100)
+  // RISK_BANDS is ordered highest-first, so the first match is the tightest.
+  const band = RISK_BANDS.find((b) => clamped >= b.min)
+  return band?.level ?? 'LOW'
+}
+
+/**
+ * Chooses ALLOW / REVIEW / BLOCK.
+ *
+ * `hardBlock` is set by the caller for conditions that are not a matter of
+ * accumulated score — a confirmed sanctions match, or a provider verdict that
+ * the counterparty address is itself sanctioned.  Those are legal
+ * prohibitions rather than risk appetite, so they bypass the thresholds.
+ */
+export function decideFromScore(score: number, hardBlock = false): ScreeningDecision {
+  if (hardBlock) return 'BLOCK'
+  if (score >= DECISION_THRESHOLDS.block) return 'BLOCK'
+  if (score >= DECISION_THRESHOLDS.review) return 'REVIEW'
+  return 'ALLOW'
+}
+
+/** The most severe level present, or LOW for an empty set. */
+export function highestSeverity(signals: RiskSignal[]): RiskLevel {
+  return signals.reduce<RiskLevel>(
+    (worst, s) => (RISK_LEVEL_RANK[s.severity] > RISK_LEVEL_RANK[worst] ? s.severity : worst),
+    'LOW'
+  )
+}
+
+/** Sorts most-severe-first, then by score — the order analysts read them in. */
+export function sortSignals(signals: RiskSignal[]): RiskSignal[] {
+  return [...signals].sort((a, b) => {
+    const bySeverity = RISK_LEVEL_RANK[b.severity] - RISK_LEVEL_RANK[a.severity]
+    return bySeverity !== 0 ? bySeverity : b.score - a.score
+  })
+}
+
+function clamp(n: number, min: number, max: number): number {
+  if (!Number.isFinite(n)) return min
+  return Math.min(max, Math.max(min, n))
+}

--- a/lib/compliance/sanctions/list.ts
+++ b/lib/compliance/sanctions/list.ts
@@ -1,0 +1,266 @@
+/**
+ * Sanctions list registry — the local screening corpus.
+ *
+ * Why a local list exists at all when we pay for a screening provider:
+ *
+ *   1. **Failover.**  ComplyAdvantage/Chainalysis going down must not become an
+ *      unscreened payment path.  With FAIL_CLOSED the transaction is held for
+ *      review, but a local hit lets us block outright rather than queue.
+ *   2. **Wallet addresses.**  OFAC publishes designated crypto addresses
+ *      directly in the SDN file.  Matching those is exact-string work that does
+ *      not need a paid API call on every transaction.
+ *   3. **Determinism in tests and CI**, which cannot reach a live provider.
+ *
+ * Where the data comes from:
+ *
+ *   `scripts/refresh-sanctions-lists.mjs` fetches the OFAC SDN and UN
+ *   Consolidated files, normalises them into the SanctionsEntity shape below,
+ *   and writes a snapshot JSON.  The snapshot is loaded at boot via
+ *   loadSanctionsSnapshot().  It is intentionally NOT committed: it is large,
+ *   it changes several times a week, and a stale committed copy is worse than
+ *   no copy because it looks current.
+ *
+ *   With no snapshot loaded the registry holds only DEV_FIXTURE_ENTITIES —
+ *   synthetic entries that exist so the code path is exercised in development
+ *   and tests.  isSnapshotLoaded() reports which state we are in, and
+ *   /api/admin/compliance/health surfaces it, because silently screening
+ *   against a fixture list in production would be a control failure of the
+ *   worst kind.
+ */
+
+import { NAME_SCREENING } from '../config'
+import type { NameMatch } from '../types'
+import { bestAliasMatch, normalizeName } from './matching'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ListSource =
+  | 'OFAC SDN'
+  | 'OFAC Consolidated'
+  | 'UN Consolidated'
+  | 'EU CFSP'
+  | 'UK HMT'
+  | 'DEV FIXTURE'
+
+export interface SanctionsEntity {
+  /** List-native id (OFAC uid, UN dataid, …), prefixed by source. */
+  id: string
+  source: ListSource
+  /** Primary listed name. */
+  name: string
+  /** Every a.k.a. / f.k.a. the list carries.  Primary name excluded. */
+  aliases: string[]
+  entityType: 'INDIVIDUAL' | 'ENTITY' | 'VESSEL' | 'AIRCRAFT'
+  matchTypes: Array<'SANCTION' | 'PEP' | 'ADVERSE_MEDIA' | 'WATCHLIST'>
+  countries: string[]
+  /** Designated crypto addresses, normalised to lowercase. */
+  cryptoAddresses: string[]
+  /** ISO date the entry was published/last amended, when the list gives one. */
+  listedAt?: string
+}
+
+export interface SanctionsSnapshot {
+  /** ISO timestamp the snapshot was generated. */
+  generatedAt: string
+  sources: ListSource[]
+  entities: SanctionsEntity[]
+}
+
+// ---------------------------------------------------------------------------
+// Development fixture
+// ---------------------------------------------------------------------------
+
+/**
+ * Synthetic entries — **not** real designations.
+ *
+ * Deliberately invented so no real person or organisation is represented as
+ * sanctioned anywhere in this repository.  They exercise the shapes that make
+ * matching hard: transliteration variants, reordered name parts, honorifics,
+ * a corporate suffix, and an entity carrying a crypto address.
+ */
+export const DEV_FIXTURE_ENTITIES: SanctionsEntity[] = [
+  {
+    id: 'FIXTURE-001',
+    source: 'DEV FIXTURE',
+    name: 'Ibrahim Musa Danjuma',
+    aliases: ['Ibrahim M. Danjuma', 'Alhaji Ibrahim Danjuma', 'Ibraheem Moussa Danjouma'],
+    entityType: 'INDIVIDUAL',
+    matchTypes: ['SANCTION'],
+    countries: ['NG'],
+    cryptoAddresses: [],
+    listedAt: '2021-03-14',
+  },
+  {
+    id: 'FIXTURE-002',
+    source: 'DEV FIXTURE',
+    name: 'Zawadi Holdings Limited',
+    aliases: ['Zawadi Holdings Ltd', 'Zawadi Group'],
+    entityType: 'ENTITY',
+    matchTypes: ['SANCTION', 'ADVERSE_MEDIA'],
+    countries: ['KE'],
+    cryptoAddresses: ['gd7fixtureaddressfortestingonlyaaaaaaaaaaaaaaaaaaaaaaaa'],
+    listedAt: '2022-11-02',
+  },
+  {
+    id: 'FIXTURE-003',
+    source: 'DEV FIXTURE',
+    name: 'Nomvula Precious Sithole',
+    aliases: ['Nomvula P. Sithole', 'N. Sithole'],
+    entityType: 'INDIVIDUAL',
+    matchTypes: ['PEP'],
+    countries: ['ZA'],
+    cryptoAddresses: [],
+    listedAt: '2023-06-21',
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Registry
+// ---------------------------------------------------------------------------
+
+let _entities: SanctionsEntity[] = DEV_FIXTURE_ENTITIES
+let _snapshotLoaded = false
+let _generatedAt: string | null = null
+
+/**
+ * Exact-match index over designated crypto addresses.
+ *
+ * Screening a wallet address is the one part of this module that must be exact:
+ * a fuzzy match on an address is meaningless, and a linear scan of every
+ * entity's addresses on every transaction is not something a payment path can
+ * afford once the SDN list is loaded in full.
+ */
+let _addressIndex = new Map<string, SanctionsEntity>()
+
+function rebuildAddressIndex(): void {
+  const index = new Map<string, SanctionsEntity>()
+  for (const entity of _entities) {
+    for (const address of entity.cryptoAddresses) {
+      index.set(address.toLowerCase(), entity)
+    }
+  }
+  _addressIndex = index
+}
+
+rebuildAddressIndex()
+
+/**
+ * Replaces the in-memory corpus with a refreshed snapshot.
+ *
+ * Called at boot from the snapshot file and by the refresh job.  Swapping the
+ * array wholesale (rather than mutating) means an in-flight screening call
+ * always sees one consistent version of the list.
+ */
+export function loadSanctionsSnapshot(snapshot: SanctionsSnapshot): void {
+  _entities = snapshot.entities
+  _snapshotLoaded = true
+  _generatedAt = snapshot.generatedAt
+  rebuildAddressIndex()
+}
+
+export interface SnapshotStatus {
+  loaded: boolean
+  generatedAt: string | null
+  entityCount: number
+  addressCount: number
+  /** Whole days since generation, or null when no snapshot is loaded. */
+  ageDays: number | null
+}
+
+/**
+ * Reports what the registry is currently screening against.
+ *
+ * Surfaced on the admin health endpoint.  `loaded: false` in production means
+ * screening is running on fixture data and must be treated as an incident.
+ */
+export function getSnapshotStatus(): SnapshotStatus {
+  return {
+    loaded: _snapshotLoaded,
+    generatedAt: _generatedAt,
+    entityCount: _entities.length,
+    addressCount: _addressIndex.size,
+    ageDays: _generatedAt
+      ? Math.floor((Date.now() - new Date(_generatedAt).getTime()) / 86_400_000)
+      : null,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Screening
+// ---------------------------------------------------------------------------
+
+/**
+ * Fuzzy-matches `name` against every listed name and alias.
+ *
+ * Returns matches at or above NAME_SCREENING.matchThreshold, highest first,
+ * capped at maxMatches so one generic name cannot produce a case file with
+ * thousands of hits in it.
+ *
+ * `entity: true` additionally folds away corporate suffixes — pass it when the
+ * name came from a business account.
+ */
+export function screenNameAgainstLists(
+  name: string,
+  { entity = false }: { entity?: boolean } = {}
+): NameMatch[] {
+  if (normalizeName(name).length === 0) return []
+
+  const matches: NameMatch[] = []
+
+  for (const candidate of _entities) {
+    const isEntity = entity || candidate.entityType === 'ENTITY'
+    const { score, alias } = bestAliasMatch(
+      name,
+      [candidate.name, ...candidate.aliases],
+      { entity: isEntity }
+    )
+
+    if (score < NAME_SCREENING.matchThreshold) continue
+
+    matches.push({
+      entityId: candidate.id,
+      name: candidate.name,
+      matchScore: score,
+      listName: candidate.source,
+      matchTypes: candidate.matchTypes,
+      countries: candidate.countries,
+      // Surface the alias that actually matched — an analyst clearing a hit
+      // needs to see *what* matched, not just that something did.
+      aliases: alias && alias !== candidate.name ? [alias] : undefined,
+    })
+  }
+
+  return matches
+    .sort((a, b) => b.matchScore - a.matchScore)
+    .slice(0, NAME_SCREENING.maxMatches)
+}
+
+/**
+ * Exact lookup of a crypto address against designated addresses.
+ *
+ * Case-insensitive because the lists publish EVM addresses in mixed
+ * (checksummed) case while wallets hand us lowercase, and vice versa.
+ */
+export function screenAddressAgainstLists(address: string): SanctionsEntity | null {
+  return _addressIndex.get(address.trim().toLowerCase()) ?? null
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/** Restores the fixture corpus.  Test helper only. */
+export function _resetSanctionsList(): void {
+  _entities = DEV_FIXTURE_ENTITIES
+  _snapshotLoaded = false
+  _generatedAt = null
+  rebuildAddressIndex()
+}
+
+/** Swaps in an arbitrary corpus without marking a snapshot loaded.  Tests only. */
+export function _setSanctionsEntities(entities: SanctionsEntity[]): void {
+  _entities = entities
+  rebuildAddressIndex()
+}

--- a/lib/compliance/sanctions/matching.ts
+++ b/lib/compliance/sanctions/matching.ts
@@ -1,0 +1,274 @@
+/**
+ * Name matching for sanctions screening.
+ *
+ * Screening a bank account holder name against a watchlist is a fuzzy-match
+ * problem, not a string-equality one.  The same person appears across lists as
+ * "Mohammed Al-Hassan", "Muhammad al Hassan", "HASSAN, Mohamed" and
+ * "Alhaji Mohammed Hassan".  Exact matching catches none of those, and a bank
+ * that only exact-matches has no screening control at all.
+ *
+ * The approach here is the industry-standard one:
+ *
+ *   1. Normalise aggressively — case, diacritics, punctuation, honorifics.
+ *   2. Compare as *token sets*, so name order and inserted middle names do not
+ *      break the match.
+ *   3. Compare individual tokens with Jaro-Winkler, which is tuned for short
+ *      strings with shared prefixes — exactly how transliteration variants
+ *      differ ("Yusuf"/"Yousef", "Abdulahi"/"Abdullahi").
+ *
+ * Everything is deterministic and dependency-free so the same input always
+ * produces the same score.  A screening decision an analyst cannot reproduce is
+ * not defensible to a regulator.
+ */
+
+// ---------------------------------------------------------------------------
+// Normalisation
+// ---------------------------------------------------------------------------
+
+/**
+ * Honorifics, titles and generational suffixes stripped before comparison.
+ *
+ * These carry no identifying information but do inflate token counts, which
+ * drags a real match below threshold ("Alhaji Musa Bello" vs "Musa Bello"
+ * would otherwise lose a third of its coverage).  The list is weighted towards
+ * titles common in Aframp's markets alongside the usual English ones.
+ */
+const HONORIFICS = new Set([
+  'mr', 'mrs', 'ms', 'miss', 'mx', 'dr', 'prof', 'professor', 'rev', 'reverend',
+  'sir', 'madam', 'mallam', 'malam', 'alhaji', 'alhaja', 'hajia', 'hajj', 'hajji',
+  'chief', 'oba', 'eze', 'igwe', 'otunba', 'engr', 'engineer', 'barr', 'barrister',
+  'arc', 'architect', 'hon', 'honourable', 'honorable', 'pastor', 'bishop', 'imam',
+  'sheikh', 'sheik', 'elder', 'capt', 'captain', 'col', 'colonel', 'gen', 'general',
+  'jnr', 'jr', 'snr', 'sr', 'ii', 'iii', 'iv',
+])
+
+/**
+ * Corporate suffixes folded away when screening entity (rather than person)
+ * names, so "Acme Trading Ltd" matches the listed "ACME TRADING LIMITED".
+ */
+const CORPORATE_SUFFIXES = new Set([
+  'ltd', 'limited', 'plc', 'inc', 'incorporated', 'llc', 'llp', 'lp', 'gmbh',
+  'sa', 'sarl', 'bv', 'nv', 'ag', 'pty', 'co', 'company', 'corp', 'corporation',
+  'holdings', 'holding', 'group', 'intl', 'international', 'enterprises',
+  'enterprise', 'ventures', 'trading', 'and', 'the',
+])
+
+/**
+ * Strips diacritics, punctuation and case, and collapses whitespace.
+ *
+ * Arabic/French transliterations reach us with accents that the lists drop
+ * ("Séïdou" vs "Seidou"), and connectors are written inconsistently
+ * ("Al-Hassan", "Al Hassan", "AlHassan").  Hyphens and apostrophes become
+ * spaces rather than being deleted, so "Al-Hassan" tokenises to two tokens the
+ * same way "Al Hassan" does.
+ */
+export function normalizeName(raw: string): string {
+  return raw
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '') // combining diacritical marks
+    .toLowerCase()
+    .replace(/[\u2018\u2019'\u0060\u00b4]/g, '') // elision apostrophes: d'Souza -> dsouza
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ')
+}
+
+export interface TokenizeOptions {
+  /** Also drop corporate suffixes.  Use when screening business names. */
+  entity?: boolean
+}
+
+/**
+ * Normalises then splits into comparison tokens, dropping noise words.
+ *
+ * If stripping leaves nothing (a name made entirely of words we consider
+ * noise, e.g. a company literally called "The Group"), the un-stripped tokens
+ * are returned instead — screening something is always better than screening
+ * an empty set, which would match everything or nothing depending on the
+ * caller.
+ */
+export function tokenize(raw: string, { entity = false }: TokenizeOptions = {}): string[] {
+  const all = normalizeName(raw).split(' ').filter(Boolean)
+
+  const kept = all.filter((t) => {
+    if (HONORIFICS.has(t)) return false
+    if (entity && CORPORATE_SUFFIXES.has(t)) return false
+    // Single letters are initials — they carry too little signal to compare
+    // but shouldn't count against coverage either.
+    return t.length > 1
+  })
+
+  return kept.length > 0 ? kept : all
+}
+
+// ---------------------------------------------------------------------------
+// Jaro-Winkler
+// ---------------------------------------------------------------------------
+
+/**
+ * Jaro similarity — 0 (nothing in common) to 1 (identical).
+ *
+ * Counts characters common to both strings within a sliding window of
+ * ⌊max(len)/2⌋ − 1, then discounts for how many of those are transposed.
+ */
+export function jaro(a: string, b: string): number {
+  if (a === b) return 1
+  if (a.length === 0 || b.length === 0) return 0
+
+  const matchWindow = Math.max(0, Math.floor(Math.max(a.length, b.length) / 2) - 1)
+  const aMatched = new Array<boolean>(a.length).fill(false)
+  const bMatched = new Array<boolean>(b.length).fill(false)
+
+  let matches = 0
+  for (let i = 0; i < a.length; i++) {
+    const start = Math.max(0, i - matchWindow)
+    const end = Math.min(i + matchWindow + 1, b.length)
+    for (let j = start; j < end; j++) {
+      if (bMatched[j] || a[i] !== b[j]) continue
+      aMatched[i] = true
+      bMatched[j] = true
+      matches++
+      break
+    }
+  }
+
+  if (matches === 0) return 0
+
+  // Transpositions: matched characters that appear in a different relative
+  // order in the two strings, counted in pairs.
+  let transpositions = 0
+  let k = 0
+  for (let i = 0; i < a.length; i++) {
+    if (!aMatched[i]) continue
+    while (!bMatched[k]) k++
+    if (a[i] !== b[k]) transpositions++
+    k++
+  }
+  transpositions /= 2
+
+  return (matches / a.length + matches / b.length + (matches - transpositions) / matches) / 3
+}
+
+/**
+ * Jaro-Winkler — Jaro with a bonus for a shared prefix (up to 4 characters).
+ *
+ * The prefix bonus is what makes this the right metric for names: people
+ * misspell and transliterate endings far more often than beginnings, so
+ * "Abdullahi"/"Abdulahi" should score higher than raw Jaro gives it.
+ */
+export function jaroWinkler(a: string, b: string, scalingFactor = 0.1): number {
+  const j = jaro(a, b)
+  // The standard boost only applies to already-similar strings; without this
+  // guard, unrelated names that happen to share a prefix get inflated.
+  if (j < 0.7) return j
+
+  let prefix = 0
+  const maxPrefix = Math.min(4, a.length, b.length)
+  while (prefix < maxPrefix && a[prefix] === b[prefix]) prefix++
+
+  return j + prefix * scalingFactor * (1 - j)
+}
+
+// ---------------------------------------------------------------------------
+// Token-set similarity
+// ---------------------------------------------------------------------------
+
+/** Below this, two tokens are treated as unrelated rather than weakly matched. */
+const TOKEN_MATCH_FLOOR = 0.8
+
+/**
+ * Fraction of the score lost per surplus token in the longer name.
+ *
+ * Deliberately gentle.  Lists routinely hold more name parts than a bank
+ * record does ("Musa Ibrahim Bello" listed, "Musa Bello" on the account), and
+ * a harsh penalty there is precisely how real hits get missed.  The asymmetry
+ * is intentional: false positives cost analyst minutes, false negatives cost a
+ * licence.
+ */
+const SURPLUS_PENALTY = 0.3
+
+/**
+ * Similarity between two names as token sets — 0 to 1.
+ *
+ * Each token of the shorter name is greedily paired with its best unused
+ * partner in the longer one, so word order does not matter: "Hassan Mohammed"
+ * and "Mohammed Hassan" score 1.0.  The mean pair similarity is then discounted
+ * by how many tokens went unpaired.
+ *
+ * Greedy pairing rather than optimal (Hungarian) assignment is a deliberate
+ * trade: on the 2–4 token inputs real names produce, the two agree almost
+ * always, and greedy runs in the microseconds a payment path can afford.
+ */
+export function nameSimilarity(
+  a: string,
+  b: string,
+  options: TokenizeOptions = {}
+): number {
+  const tokensA = tokenize(a, options)
+  const tokensB = tokenize(b, options)
+
+  if (tokensA.length === 0 || tokensB.length === 0) return 0
+
+  const [shorter, longer] =
+    tokensA.length <= tokensB.length ? [tokensA, tokensB] : [tokensB, tokensA]
+
+  const used = new Set<number>()
+  let total = 0
+
+  for (const token of shorter) {
+    let best = 0
+    let bestIndex = -1
+
+    for (let i = 0; i < longer.length; i++) {
+      if (used.has(i)) continue
+      const score = jaroWinkler(token, longer[i])
+      if (score > best) {
+        best = score
+        bestIndex = i
+      }
+    }
+
+    if (bestIndex >= 0 && best >= TOKEN_MATCH_FLOOR) {
+      used.add(bestIndex)
+      total += best
+    }
+    // Below the floor the token contributes 0 but still counts in the mean —
+    // an unmatched name part must drag the overall score down.
+  }
+
+  const mean = total / shorter.length
+  const surplus = longer.length - shorter.length
+  const penalty = 1 - SURPLUS_PENALTY * (surplus / longer.length)
+
+  return round4(mean * penalty)
+}
+
+/**
+ * Best similarity between `name` and any of an entity's aliases (its primary
+ * name included), plus which alias produced it.
+ *
+ * Lists carry aliases precisely because subjects use them; screening only the
+ * primary name discards most of the list's value.
+ */
+export function bestAliasMatch(
+  name: string,
+  aliases: string[],
+  options: TokenizeOptions = {}
+): { score: number; alias: string | null } {
+  let best = 0
+  let bestAlias: string | null = null
+
+  for (const alias of aliases) {
+    const score = nameSimilarity(name, alias, options)
+    if (score > best) {
+      best = score
+      bestAlias = alias
+    }
+  }
+
+  return { score: best, alias: bestAlias }
+}
+
+function round4(n: number): number {
+  return Math.round(n * 10_000) / 10_000
+}

--- a/lib/compliance/types.ts
+++ b/lib/compliance/types.ts
@@ -1,0 +1,269 @@
+/**
+ * Shared AML/CFT types.
+ *
+ * Kept free of server-only imports so the admin UI and the browser client can
+ * import these shapes without pulling in the stores or provider adapters —
+ * same split as lib/orders/types.ts.
+ *
+ * Terminology note: the code says "SAR" (Suspicious Activity Report) throughout
+ * because that is the term used in the requirement.  Every regulator Aframp
+ * files with in-market — NFIU (NG), FRC (KE), FIC (GH), FIC (ZA), FIA (UG) —
+ * calls the same artefact a Suspicious Transaction Report (STR).  They are the
+ * same filing; see JURISDICTIONS in ./config.ts.
+ */
+
+// ---------------------------------------------------------------------------
+// Risk
+// ---------------------------------------------------------------------------
+
+/** Ordered least → most severe.  Comparisons must use RISK_LEVEL_RANK. */
+export type RiskLevel = 'LOW' | 'MEDIUM' | 'HIGH' | 'SEVERE'
+
+export const RISK_LEVEL_RANK: Record<RiskLevel, number> = {
+  LOW: 0,
+  MEDIUM: 1,
+  HIGH: 2,
+  SEVERE: 3,
+}
+
+/**
+ * What the screening engine decided the transaction should do next.
+ *
+ *   ALLOW  — proceed; the screening result is still written to the ledger.
+ *   REVIEW — hold the transaction and open a case for a human analyst.
+ *   BLOCK  — reject outright.  Only sanctions hits and severe provider
+ *            verdicts reach this; a blocked transaction always opens a case
+ *            too, because a block is itself a reportable event.
+ */
+export type ScreeningDecision = 'ALLOW' | 'REVIEW' | 'BLOCK'
+
+/**
+ * Every distinct reason a transaction can be flagged.  These strings are
+ * persisted on cases and surfaced in the admin UI, so treat them as a stable
+ * wire contract — rename via migration, not in place.
+ */
+export type SignalCode =
+  // --- sanctions / provider screening -------------------------------------
+  | 'SANCTIONS_MATCH'
+  | 'PEP_MATCH'
+  | 'ADVERSE_MEDIA'
+  | 'WALLET_SEVERE_RISK'
+  | 'WALLET_HIGH_RISK'
+  | 'WALLET_MEDIUM_RISK'
+  | 'PROVIDER_UNAVAILABLE'
+  // --- velocity ------------------------------------------------------------
+  | 'VELOCITY_TX_COUNT'
+  | 'VELOCITY_VOLUME'
+  | 'VELOCITY_SPIKE'
+  | 'STRUCTURING'
+  | 'RAPID_RAMP_REVERSAL'
+  | 'COUNTERPARTY_FANOUT'
+  | 'NEW_ACCOUNT_HIGH_VALUE'
+  | 'DORMANT_REACTIVATION'
+
+/**
+ * One reason a transaction scored the way it did.
+ *
+ * `score` is this signal's standalone contribution (0–100).  The aggregate is
+ * not a plain sum — see scoreSignals() in ./risk.ts.
+ */
+export interface RiskSignal {
+  code: SignalCode
+  severity: RiskLevel
+  /** Standalone contribution, 0–100. */
+  score: number
+  /** Analyst-facing one-liner.  Must not contain raw PII beyond the subject. */
+  description: string
+  /** Structured evidence for the case file (thresholds, observed values, ids). */
+  metadata?: Record<string, unknown>
+}
+
+// ---------------------------------------------------------------------------
+// Screening input / output
+// ---------------------------------------------------------------------------
+
+export type TransactionKind = 'onramp' | 'offramp' | 'billpay'
+
+/** ISO 3166-1 alpha-2, restricted to markets Aframp is licensed in. */
+export type Jurisdiction = 'NG' | 'KE' | 'GH' | 'ZA' | 'UG'
+
+/**
+ * A transaction presented for screening.
+ *
+ * Amounts are integer **USD cents** everywhere in this module, matching
+ * lib/kyc/withdrawalLimitService.ts.  Local-currency amounts are carried
+ * separately for the case file and are never used in threshold arithmetic.
+ */
+export interface ScreeningSubject {
+  /** Stable per-transaction id (order id, withdrawal id, …). */
+  transactionId: string
+  /** Wallet public key — the account identity used across this module. */
+  userId: string
+  kind: TransactionKind
+  amountCents: number
+  asset: string
+  chain: string
+  jurisdiction: Jurisdiction
+
+  /** Counterparty crypto address, when the transaction has one. */
+  walletAddress?: string
+  /** Bank or mobile-money account holder name, when the transaction has one. */
+  accountName?: string
+  /** Bank/mobile-money account number — hashed before it reaches the ledger. */
+  accountNumber?: string
+  /** Free-form counterparty key used for fan-out detection (bank acct, address). */
+  counterpartyId?: string
+
+  /** Account's KYC tier at screening time, for tier-relative thresholds. */
+  kycTier?: string
+  /** When the account first transacted.  Drives NEW_ACCOUNT_HIGH_VALUE. */
+  accountCreatedAt?: Date
+}
+
+export interface ScreeningResult {
+  transactionId: string
+  userId: string
+  decision: ScreeningDecision
+  /** Aggregate 0–100.  See scoreSignals(). */
+  riskScore: number
+  riskLevel: RiskLevel
+  signals: RiskSignal[]
+  /** Case id, when the decision opened one. */
+  caseId?: string
+  /** Which providers answered, and whether they degraded to the local list. */
+  providers: ProviderAttribution[]
+  screenedAt: string
+}
+
+export interface ProviderAttribution {
+  name: string
+  kind: 'wallet' | 'name'
+  /** false when the call failed and a fallback answered instead. */
+  ok: boolean
+  latencyMs: number
+  /** Provider's own reference id, for audit trails and re-pulls. */
+  reference?: string
+}
+
+// ---------------------------------------------------------------------------
+// Provider results
+// ---------------------------------------------------------------------------
+
+/** A sanctions/PEP/adverse-media hit against a screened name. */
+export interface NameMatch {
+  /** Provider or list entity id. */
+  entityId: string
+  name: string
+  /** 0–1.  1.0 is an exact normalised match. */
+  matchScore: number
+  /** e.g. "OFAC SDN", "UN Consolidated", "EU CFSP". */
+  listName: string
+  matchTypes: Array<'SANCTION' | 'PEP' | 'ADVERSE_MEDIA' | 'WATCHLIST'>
+  countries?: string[]
+  /** Aliases that matched, for the analyst to eyeball. */
+  aliases?: string[]
+}
+
+export interface NameScreeningResult {
+  matches: NameMatch[]
+  /** Provider's search/reference id for audit. */
+  reference?: string
+}
+
+export interface WalletRiskResult {
+  address: string
+  /** 0–100, normalised across providers. */
+  riskScore: number
+  riskLevel: RiskLevel
+  /** Categories the provider attributes to the address (e.g. "darknet_market"). */
+  categories: string[]
+  /** True when the address itself is on a sanctions list. */
+  sanctioned: boolean
+  reference?: string
+}
+
+// ---------------------------------------------------------------------------
+// Cases
+// ---------------------------------------------------------------------------
+
+export type CaseStatus =
+  | 'OPEN'
+  | 'IN_REVIEW'
+  | 'ESCALATED'
+  | 'CLEARED'
+  | 'CONFIRMED_SUSPICIOUS'
+
+export type CaseDisposition = 'FALSE_POSITIVE' | 'TRUE_POSITIVE' | 'INCONCLUSIVE'
+
+/** An entry in a case's append-only audit trail. */
+export interface CaseEvent {
+  at: string
+  /** Analyst id, or "system" for engine-generated entries. */
+  actor: string
+  action:
+    | 'CREATED'
+    | 'ASSIGNED'
+    | 'STATUS_CHANGED'
+    | 'NOTE_ADDED'
+    | 'SAR_FILED'
+    | 'REOPENED'
+  detail?: string
+}
+
+export interface ComplianceCase {
+  id: string
+  transactionId: string
+  userId: string
+  kind: TransactionKind
+  jurisdiction: Jurisdiction
+  amountCents: number
+  asset: string
+  status: CaseStatus
+  riskScore: number
+  riskLevel: RiskLevel
+  decision: ScreeningDecision
+  signals: RiskSignal[]
+  /** Analyst id, once picked up. */
+  assignedTo?: string
+  disposition?: CaseDisposition
+  /** Set when the case has been reported; see SarRecord.id. */
+  sarId?: string
+  events: CaseEvent[]
+  createdAt: string
+  updatedAt: string
+}
+
+// ---------------------------------------------------------------------------
+// SAR / STR
+// ---------------------------------------------------------------------------
+
+export type SarStatus = 'DRAFT' | 'SUBMITTED' | 'ACKNOWLEDGED' | 'REJECTED'
+
+export interface SarRecord {
+  id: string
+  caseId: string
+  userId: string
+  jurisdiction: Jurisdiction
+  /** The receiving FIU, e.g. "NFIU".  Derived from jurisdiction. */
+  regulator: string
+  status: SarStatus
+  /** Analyst's narrative — the substance of the filing. */
+  narrative: string
+  /** Signal codes that triggered the filing, copied at draft time. */
+  groundsForSuspicion: SignalCode[]
+  amountCents: number
+  /** Analyst who drafted it. */
+  filedBy: string
+  /**
+   * When the clock started — the moment suspicion was formed, i.e. the case's
+   * creation.  Deadlines run from here, not from draft time.
+   */
+  suspicionFormedAt: string
+  /** Computed from suspicionFormedAt + the jurisdiction's filing window. */
+  dueAt: string
+  submittedAt?: string
+  /** Regulator's acknowledgement reference, once returned. */
+  regulatorReference?: string
+  createdAt: string
+  updatedAt: string
+}

--- a/lib/compliance/types.ts
+++ b/lib/compliance/types.ts
@@ -88,6 +88,28 @@ export type TransactionKind = 'onramp' | 'offramp' | 'billpay'
 export type Jurisdiction = 'NG' | 'KE' | 'GH' | 'ZA' | 'UG'
 
 /**
+ * Markets Aframp accepts payments from but holds no AML registration in — the
+ * mobile-money footprint in lib/payments/regions.ts is wider than the licensed
+ * footprint.
+ *
+ * These are not jurisdictions in the regulatory sense: there is no FIU we file
+ * with and no statutory threshold to anchor structuring against.  They exist as
+ * a type so a transaction from one cannot be silently screened under some other
+ * market's policy, and so the console can show an analyst that a case has no
+ * filing route.  See UNLICENSED_MARKET_POLICY in ./config.ts.
+ */
+export type UnlicensedMarket = 'TZ' | 'CM' | 'CI' | 'RW' | 'ZM'
+
+/**
+ * Any market a screened transaction can originate in.
+ *
+ * Prefer `Jurisdiction` wherever the value genuinely must be a licensed market
+ * (SAR filing, regulator routing).  `Market` is for the screening path, which
+ * must accept everything the payment routes accept.
+ */
+export type Market = Jurisdiction | UnlicensedMarket
+
+/**
  * A transaction presented for screening.
  *
  * Amounts are integer **USD cents** everywhere in this module, matching
@@ -103,7 +125,12 @@ export interface ScreeningSubject {
   amountCents: number
   asset: string
   chain: string
-  jurisdiction: Jurisdiction
+  /**
+   * Where the transaction originates.  Drives the structuring threshold, the
+   * SAR filing deadline and the country hint sent to name screening.  May be an
+   * unlicensed market — see UNLICENSED_MARKET_POLICY.
+   */
+  jurisdiction: Market
 
   /** Counterparty crypto address, when the transaction has one. */
   walletAddress?: string
@@ -215,7 +242,7 @@ export interface ComplianceCase {
   transactionId: string
   userId: string
   kind: TransactionKind
-  jurisdiction: Jurisdiction
+  jurisdiction: Market
   amountCents: number
   asset: string
   status: CaseStatus

--- a/lib/compliance/velocity.ts
+++ b/lib/compliance/velocity.ts
@@ -19,7 +19,8 @@
  * or corroboration between rules to hold a payment.  See scoreSignals().
  */
 
-import { DAY_MS, JURISDICTIONS, VELOCITY_RULES } from './config'
+import { DAY_MS, VELOCITY_RULES } from './config'
+import { policyFor } from './markets'
 import {
   getDistinctCounterparties,
   getEntriesInWindow,
@@ -192,7 +193,8 @@ function checkStructuring(subject: ScreeningSubject, now: Date): RiskSignal | nu
   const rule = VELOCITY_RULES.structuring
   if (!rule.enabled) return null
 
-  const threshold = JURISDICTIONS[subject.jurisdiction].reportingThresholdCents
+  const policy = policyFor(subject.jurisdiction)
+  const threshold = policy.reportingThresholdCents
   const bandFloor = threshold * (1 - rule.bandPct)
 
   const inBand = (amount: number) => amount >= bandFloor && amount < threshold
@@ -219,7 +221,7 @@ function checkStructuring(subject: ScreeningSubject, now: Date): RiskSignal | nu
       bandFloorCents: Math.round(bandFloor),
       windowDays: Math.round(rule.windowMs / DAY_MS),
       jurisdiction: subject.jurisdiction,
-      localThresholdNote: JURISDICTIONS[subject.jurisdiction].localThresholdNote,
+      localThresholdNote: policy.localThresholdNote,
     },
   }
 }

--- a/lib/compliance/velocity.ts
+++ b/lib/compliance/velocity.ts
@@ -1,0 +1,401 @@
+/**
+ * Velocity rules — behavioural transaction monitoring.
+ *
+ * Each rule is a pure function of (subject, ledger history, config) → signal or
+ * null.  Pure because rules get argued about: an analyst clearing a case, or a
+ * regulator reviewing the model, must be able to reproduce exactly why a
+ * transaction fired, and every rule below returns the observed values and the
+ * threshold it breached in `metadata` for precisely that reason.
+ *
+ * The rules target the three classic laundering stages as they present on a
+ * crypto ramp:
+ *
+ *   Placement  — STRUCTURING, NEW_ACCOUNT_HIGH_VALUE, DORMANT_REACTIVATION
+ *   Layering   — RAPID_RAMP_REVERSAL, COUNTERPARTY_FANOUT
+ *   Volume     — VELOCITY_TX_COUNT, VELOCITY_VOLUME, VELOCITY_SPIKE
+ *
+ * None of them is decisive alone.  That is by design: a single velocity signal
+ * scores below DECISION_THRESHOLDS.review, so it takes either a severe signal
+ * or corroboration between rules to hold a payment.  See scoreSignals().
+ */
+
+import { DAY_MS, JURISDICTIONS, VELOCITY_RULES } from './config'
+import {
+  getDistinctCounterparties,
+  getEntriesInWindow,
+  getFirstEntry,
+  getLastEntryBefore,
+  getWindowTotals,
+  type LedgerEntry,
+} from './ledger'
+import type { RiskSignal, ScreeningSubject } from './types'
+
+export interface VelocityContext {
+  /** Evaluation time.  Injectable so rules are testable without a fake clock. */
+  now?: Date
+}
+
+/**
+ * Runs every enabled rule and returns the signals that fired.
+ *
+ * The subject transaction is *not* yet in the ledger when this runs — it is
+ * recorded after screening completes, so that a blocked transaction still
+ * lands in the history.  Rules that need to include the current transaction in
+ * a total therefore add `subject.amountCents` explicitly; this is easy to get
+ * wrong in one direction (a rule that silently excludes the transaction it is
+ * judging) so each such rule says so at its call site.
+ */
+export function evaluateVelocityRules(
+  subject: ScreeningSubject,
+  { now = new Date() }: VelocityContext = {}
+): RiskSignal[] {
+  const signals: RiskSignal[] = []
+
+  const rules = [
+    checkTransactionCount,
+    checkVolume,
+    checkVolumeSpike,
+    checkStructuring,
+    checkRapidReversal,
+    checkCounterpartyFanout,
+    checkNewAccountHighValue,
+    checkDormantReactivation,
+  ]
+
+  for (const rule of rules) {
+    const signal = rule(subject, now)
+    if (signal) signals.push(signal)
+  }
+
+  return signals
+}
+
+// ---------------------------------------------------------------------------
+// Volume and frequency
+// ---------------------------------------------------------------------------
+
+/** More transactions in the window than a retail user plausibly makes. */
+function checkTransactionCount(subject: ScreeningSubject, now: Date): RiskSignal | null {
+  const rule = VELOCITY_RULES.txCount
+  if (!rule.enabled) return null
+
+  const { count } = getWindowTotals(subject.userId, { windowMs: rule.windowMs, now })
+  // +1 for the transaction being screened, which is not in the ledger yet.
+  const withCurrent = count + 1
+  if (withCurrent <= rule.maxCount) return null
+
+  return {
+    code: 'VELOCITY_TX_COUNT',
+    severity: 'MEDIUM',
+    score: rule.score,
+    description: `${withCurrent} transactions in ${hours(rule.windowMs)}h (threshold ${rule.maxCount})`,
+    metadata: {
+      observedCount: withCurrent,
+      threshold: rule.maxCount,
+      windowHours: hours(rule.windowMs),
+    },
+  }
+}
+
+/** Throughput in the window above the configured ceiling. */
+function checkVolume(subject: ScreeningSubject, now: Date): RiskSignal | null {
+  const rule = VELOCITY_RULES.volume
+  if (!rule.enabled) return null
+
+  const { volumeCents } = getWindowTotals(subject.userId, { windowMs: rule.windowMs, now })
+  // Includes the transaction being screened — the point is whether letting it
+  // through would breach the ceiling, not whether history already has.
+  const withCurrent = volumeCents + subject.amountCents
+  if (withCurrent <= rule.maxVolumeCents) return null
+
+  return {
+    code: 'VELOCITY_VOLUME',
+    severity: 'HIGH',
+    score: rule.score,
+    description: `${usd(withCurrent)} moved in ${hours(rule.windowMs)}h (threshold ${usd(rule.maxVolumeCents)})`,
+    metadata: {
+      observedVolumeCents: withCurrent,
+      thresholdCents: rule.maxVolumeCents,
+      windowHours: hours(rule.windowMs),
+    },
+  }
+}
+
+/**
+ * Today's volume far above the account's own trailing average.
+ *
+ * Relative rather than absolute, so it catches an account whose normal is $50
+ * suddenly moving $900 — under the absolute ceiling, but a tenfold change in
+ * behaviour.  Absolute limits alone are exactly what a competent launderer
+ * sizes their transactions against.
+ */
+function checkVolumeSpike(subject: ScreeningSubject, now: Date): RiskSignal | null {
+  const rule = VELOCITY_RULES.spike
+  if (!rule.enabled) return null
+
+  const first = getFirstEntry(subject.userId)
+  if (!first) return null
+
+  // Not enough history for "normal" to mean anything yet.  Firing here would
+  // flag every legitimate second transaction a new user makes.
+  const historyDays = (now.getTime() - first.occurredAt.getTime()) / DAY_MS
+  if (historyDays < rule.minHistoryDays) return null
+
+  const baseline = getWindowTotals(subject.userId, { windowMs: rule.baselineMs, now })
+  if (baseline.volumeCents < rule.minBaselineCents) return null
+
+  const recent = getWindowTotals(subject.userId, { windowMs: rule.windowMs, now })
+  const todayCents = recent.volumeCents + subject.amountCents
+
+  // Baseline excludes the current window so a spike is not compared against
+  // itself, which would flatten the ratio and hide exactly what we're after.
+  const baselineExcludingToday = Math.max(0, baseline.volumeCents - recent.volumeCents)
+  const baselineDays = Math.max(1, (rule.baselineMs - rule.windowMs) / DAY_MS)
+  const dailyMean = baselineExcludingToday / baselineDays
+
+  if (dailyMean <= 0) return null
+  const ratio = todayCents / dailyMean
+  if (ratio < rule.multiplier) return null
+
+  return {
+    code: 'VELOCITY_SPIKE',
+    severity: 'HIGH',
+    score: rule.score,
+    description: `${usd(todayCents)} today is ${ratio.toFixed(1)}× this account's ${usd(Math.round(dailyMean))} daily average`,
+    metadata: {
+      todayCents,
+      dailyMeanCents: Math.round(dailyMean),
+      ratio: Number(ratio.toFixed(2)),
+      multiplierThreshold: rule.multiplier,
+      baselineDays: Math.round(baselineDays),
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Structuring
+// ---------------------------------------------------------------------------
+
+/**
+ * Repeated transactions sized just under the reporting threshold.
+ *
+ * Deliberately splitting a reportable amount into sub-threshold pieces is an
+ * offence in its own right in all five markets, independent of whether the
+ * underlying funds are criminal — so this rule is scored highly.
+ *
+ * Both legs are required: transactions must cluster in the band *and* sum to
+ * at least the threshold.  A trader who habitually moves similar amounts trips
+ * the first leg constantly; only someone reassembling a reportable total trips
+ * both.
+ */
+function checkStructuring(subject: ScreeningSubject, now: Date): RiskSignal | null {
+  const rule = VELOCITY_RULES.structuring
+  if (!rule.enabled) return null
+
+  const threshold = JURISDICTIONS[subject.jurisdiction].reportingThresholdCents
+  const bandFloor = threshold * (1 - rule.bandPct)
+
+  const inBand = (amount: number) => amount >= bandFloor && amount < threshold
+  if (!inBand(subject.amountCents)) return null
+
+  const history = getEntriesInWindow(subject.userId, { windowMs: rule.windowMs, now })
+  const banded = history.filter((e) => inBand(e.amountCents))
+
+  const count = banded.length + 1 // includes the transaction being screened
+  if (count < rule.minCount) return null
+
+  const total = banded.reduce((sum, e) => sum + e.amountCents, 0) + subject.amountCents
+  if (total < threshold) return null
+
+  return {
+    code: 'STRUCTURING',
+    severity: 'HIGH',
+    score: rule.score,
+    description: `${count} transactions of ${usd(Math.round(total / count))}–ish just below the ${subject.jurisdiction} reporting threshold of ${usd(threshold)}, totalling ${usd(total)}`,
+    metadata: {
+      bandedCount: count,
+      totalCents: total,
+      reportingThresholdCents: threshold,
+      bandFloorCents: Math.round(bandFloor),
+      windowDays: Math.round(rule.windowMs / DAY_MS),
+      jurisdiction: subject.jurisdiction,
+      localThresholdNote: JURISDICTIONS[subject.jurisdiction].localThresholdNote,
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Layering
+// ---------------------------------------------------------------------------
+
+/**
+ * An onramp reversed by an offramp of similar size, or vice versa, within
+ * hours.
+ *
+ * Round-tripping fiat → crypto → fiat pays the spread twice and gains the user
+ * nothing, so there is rarely an economic reason to do it. There is a
+ * laundering reason: it puts a blockchain hop between the source account and
+ * the destination one.
+ */
+function checkRapidReversal(subject: ScreeningSubject, now: Date): RiskSignal | null {
+  const rule = VELOCITY_RULES.rapidReversal
+  if (!rule.enabled) return null
+  if (subject.amountCents < rule.minAmountCents) return null
+  if (subject.kind === 'billpay') return null
+
+  const opposite = subject.kind === 'onramp' ? 'offramp' : 'onramp'
+  const history = getEntriesInWindow(subject.userId, { windowMs: rule.windowMs, now })
+
+  const counterpart = history.find(
+    (e) => e.kind === opposite && withinTolerance(e.amountCents, subject.amountCents, rule.valueTolerance)
+  )
+  if (!counterpart) return null
+
+  const gapMinutes = Math.round((now.getTime() - counterpart.occurredAt.getTime()) / 60_000)
+
+  return {
+    code: 'RAPID_RAMP_REVERSAL',
+    severity: 'HIGH',
+    score: rule.score,
+    description: `${subject.kind} of ${usd(subject.amountCents)} reverses a ${opposite} of ${usd(counterpart.amountCents)} made ${gapMinutes} minutes earlier`,
+    metadata: {
+      counterpartTransactionId: counterpart.transactionId,
+      counterpartAmountCents: counterpart.amountCents,
+      counterpartKind: opposite,
+      gapMinutes,
+      windowHours: hours(rule.windowMs),
+    },
+  }
+}
+
+/**
+ * Value fanned out across an implausible number of distinct recipients.
+ *
+ * The mirror image of structuring: rather than splitting the input, the output
+ * is split across mule accounts.
+ */
+function checkCounterpartyFanout(subject: ScreeningSubject, now: Date): RiskSignal | null {
+  const rule = VELOCITY_RULES.counterpartyFanout
+  if (!rule.enabled) return null
+
+  const keys = getDistinctCounterparties(subject.userId, { windowMs: rule.windowMs, now })
+  // The current counterparty may be new; count it without double-counting a
+  // repeat, which is what makes this a *distinct* recipient measure.
+  if (subject.counterpartyId) keys.add(subject.counterpartyId)
+
+  if (keys.size <= rule.maxCounterparties) return null
+
+  return {
+    code: 'COUNTERPARTY_FANOUT',
+    severity: 'MEDIUM',
+    score: rule.score,
+    description: `${keys.size} distinct counterparties in ${hours(rule.windowMs)}h (threshold ${rule.maxCounterparties})`,
+    metadata: {
+      distinctCounterparties: keys.size,
+      threshold: rule.maxCounterparties,
+      windowHours: hours(rule.windowMs),
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Account lifecycle
+// ---------------------------------------------------------------------------
+
+/** A large transaction before the account has any track record. */
+function checkNewAccountHighValue(subject: ScreeningSubject, now: Date): RiskSignal | null {
+  const rule = VELOCITY_RULES.newAccountHighValue
+  if (!rule.enabled) return null
+  if (subject.amountCents < rule.minAmountCents) return null
+
+  // Prefer the real account creation date; fall back to first observed
+  // activity, which is all the ledger knows about accounts predating it.
+  const createdAt = subject.accountCreatedAt ?? getFirstEntry(subject.userId)?.occurredAt
+  if (!createdAt) {
+    // No history at all — this is the account's first transaction, and it is
+    // over the threshold.
+    return newAccountSignal(subject, 0, rule)
+  }
+
+  const ageMs = now.getTime() - createdAt.getTime()
+  if (ageMs > rule.windowMs) return null
+
+  return newAccountSignal(subject, ageMs, rule)
+}
+
+function newAccountSignal(
+  subject: ScreeningSubject,
+  ageMs: number,
+  rule: typeof VELOCITY_RULES.newAccountHighValue
+): RiskSignal {
+  const ageDays = Math.floor(ageMs / DAY_MS)
+  return {
+    code: 'NEW_ACCOUNT_HIGH_VALUE',
+    severity: 'MEDIUM',
+    score: rule.score,
+    description: `${usd(subject.amountCents)} on an account ${ageDays === 0 ? 'created today' : `${ageDays} days old`}`,
+    metadata: {
+      amountCents: subject.amountCents,
+      accountAgeDays: ageDays,
+      thresholdCents: rule.minAmountCents,
+      maxAgeDays: Math.round(rule.windowMs / DAY_MS),
+    },
+  }
+}
+
+/**
+ * A significant transaction after a long silence.
+ *
+ * Dormant accounts get bought, phished or coerced; a sudden reactivation at
+ * value is a recognised mule pattern rather than a quirk.
+ */
+function checkDormantReactivation(subject: ScreeningSubject, now: Date): RiskSignal | null {
+  const rule = VELOCITY_RULES.dormantReactivation
+  if (!rule.enabled) return null
+  if (subject.amountCents < rule.minAmountCents) return null
+
+  const last = getLastEntryBefore(subject.userId, now)
+  if (!last) return null // no prior activity is newness, not dormancy
+
+  const gapMs = now.getTime() - last.occurredAt.getTime()
+  if (gapMs < rule.dormancyMs) return null
+
+  const gapDays = Math.floor(gapMs / DAY_MS)
+
+  return {
+    code: 'DORMANT_REACTIVATION',
+    severity: 'MEDIUM',
+    score: rule.score,
+    description: `${usd(subject.amountCents)} after ${gapDays} days of inactivity`,
+    metadata: {
+      amountCents: subject.amountCents,
+      dormantDays: gapDays,
+      dormancyThresholdDays: Math.round(rule.dormancyMs / DAY_MS),
+      lastTransactionId: last.transactionId,
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function withinTolerance(a: number, b: number, tolerance: number): boolean {
+  if (b === 0) return a === 0
+  return Math.abs(a - b) / b <= tolerance
+}
+
+function hours(ms: number): number {
+  return Math.round(ms / 3_600_000)
+}
+
+/** Formats cents for analyst-facing signal text. */
+function usd(cents: number): string {
+  return `$${(cents / 100).toLocaleString('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })}`
+}
+
+/** Exported for the ledger-shaped fixtures velocity tests build. */
+export type { LedgerEntry }

--- a/scripts/refresh-sanctions-lists.mjs
+++ b/scripts/refresh-sanctions-lists.mjs
@@ -1,0 +1,259 @@
+#!/usr/bin/env node
+/* eslint-disable no-console -- CLI job: stdout and a non-zero exit are its interface. */
+/**
+ * Refreshes the local sanctions screening corpus.
+ *
+ *   node scripts/refresh-sanctions-lists.mjs [--out data/sanctions/snapshot.json]
+ *
+ * Fetches the OFAC SDN and UN Consolidated lists, normalises both into the
+ * SanctionsEntity shape used by lib/compliance/sanctions/list.ts, and writes a
+ * single snapshot JSON.
+ *
+ * Why this exists as a job rather than a live API call:
+ *
+ *   Sanctions designations take effect on publication, not on our next refresh,
+ *   so the corpus must be pulled on a schedule — daily at minimum.  Fetching it
+ *   per transaction would be both slow and rude to two public services.  The
+ *   snapshot is deliberately NOT committed to the repository: it is large, it
+ *   changes several times a week, and a stale committed copy is worse than no
+ *   copy because it looks current.
+ *
+ * Run it:
+ *   - on deploy, so a fresh instance never boots on fixture data
+ *   - daily thereafter (cron / scheduled GitHub Action)
+ *
+ * The application reports snapshot age on /api/admin/compliance/health and the
+ * console banners it past SNAPSHOT_STALE_DAYS.  A refresh failure is therefore
+ * visible rather than silent — but this script also exits non-zero so the
+ * scheduler notices first.
+ *
+ * ⚠️  Source URLs and file formats are those published at time of writing.
+ *     OFAC and the UN do change them.  Verify before relying on this in
+ *     production, and treat a parse yielding implausibly few entities as a
+ *     failure — see MIN_PLAUSIBLE_ENTITIES below.
+ */
+
+import { writeFile, mkdir } from 'node:fs/promises'
+import { dirname, resolve } from 'node:path'
+
+const SOURCES = {
+  // OFAC Specially Designated Nationals, XML.  Includes digital currency
+  // addresses in the `<feature>` elements, which is the part no other list
+  // gives us.
+  ofacSdn: 'https://sanctionslistservice.ofac.treas.gov/api/PublicationPreview/exports/SDN_ENHANCED.XML',
+  // UN Security Council Consolidated List, XML.
+  unConsolidated: 'https://scsanctions.un.org/resources/xml/en/consolidated.xml',
+}
+
+/**
+ * A successful fetch that parses to near-nothing is the dangerous failure: the
+ * job "succeeds", the snapshot loads, health reports green, and we screen
+ * against an empty corpus.  Both lists carry thousands of entries, so anything
+ * below this means the format changed under us.
+ */
+const MIN_PLAUSIBLE_ENTITIES = 500
+
+const FETCH_TIMEOUT_MS = 120_000
+
+async function main() {
+  const outIndex = process.argv.indexOf('--out')
+  const outPath = resolve(
+    outIndex >= 0 && process.argv[outIndex + 1]
+      ? process.argv[outIndex + 1]
+      : 'data/sanctions/snapshot.json'
+  )
+
+  console.log('Refreshing sanctions lists…')
+
+  const entities = []
+  const sources = []
+
+  for (const [key, url] of Object.entries(SOURCES)) {
+    try {
+      console.log(`  fetching ${key} …`)
+      const xml = await fetchText(url)
+      const parsed = key === 'ofacSdn' ? parseOfac(xml) : parseUn(xml)
+      console.log(`    ${parsed.length} entities`)
+      entities.push(...parsed)
+      sources.push(parsed[0]?.source ?? key)
+    } catch (error) {
+      // Fail the whole job rather than writing a partial snapshot.  A snapshot
+      // missing one list still loads and still reports healthy, which is
+      // exactly the silent degradation this script is supposed to prevent.
+      console.error(`    FAILED: ${error.message}`)
+      process.exitCode = 1
+      return
+    }
+  }
+
+  if (entities.length < MIN_PLAUSIBLE_ENTITIES) {
+    console.error(
+      `Refusing to write snapshot: parsed only ${entities.length} entities ` +
+        `(expected at least ${MIN_PLAUSIBLE_ENTITIES}). The upstream format has probably changed.`
+    )
+    process.exitCode = 1
+    return
+  }
+
+  const snapshot = {
+    generatedAt: new Date().toISOString(),
+    sources,
+    entities,
+  }
+
+  await mkdir(dirname(outPath), { recursive: true })
+  await writeFile(outPath, JSON.stringify(snapshot), 'utf8')
+
+  const addresses = entities.reduce((n, e) => n + e.cryptoAddresses.length, 0)
+  console.log(
+    `Wrote ${entities.length} entities (${addresses} crypto addresses) to ${outPath}`
+  )
+}
+
+async function fetchText(url) {
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+  try {
+    const response = await fetch(url, { signal: controller.signal })
+    if (!response.ok) throw new Error(`HTTP ${response.status} from ${url}`)
+    return await response.text()
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Parsing
+// ---------------------------------------------------------------------------
+//
+// Both parsers are regex-based rather than using a real XML parser.  That is a
+// deliberate trade for a build-time script with no runtime dependencies: the
+// documents are machine-generated with stable element names, and the failure
+// mode of a bad parse is caught by MIN_PLAUSIBLE_ENTITIES above rather than
+// being silently absorbed.  If either list moves to a materially different
+// structure, replace these with a streaming XML parser — do not patch the
+// regexes further.
+
+function parseOfac(xml) {
+  const entities = []
+
+  for (const block of matchBlocks(xml, /<entity[\s\S]*?<\/entity>/gi)) {
+    const id = firstMatch(block, /\bid="(\d+)"/i)
+    const name = firstMatch(block, /<formattedFullName>([^<]+)<\/formattedFullName>/i)
+    if (!id || !name) continue
+
+    const primary = decodeXml(name)
+    const aliases = matchValues(block, /<formattedFullName>([^<]+)<\/formattedFullName>/gi)
+      .map(decodeXml)
+      .filter((alias) => alias !== primary)
+
+    // Digital currency addresses are published as feature values whose type
+    // name starts "Digital Currency Address".
+    const cryptoAddresses = matchValues(
+      block,
+      /<feature[^>]*>[\s\S]*?Digital Currency Address[\s\S]*?<value>([^<]+)<\/value>[\s\S]*?<\/feature>/gi
+    ).map((value) => decodeXml(value).trim().toLowerCase())
+
+    entities.push({
+      id: `OFAC-${id}`,
+      source: 'OFAC SDN',
+      name: primary,
+      aliases: unique(aliases),
+      entityType: /<entityType>Individual<\/entityType>/i.test(block) ? 'INDIVIDUAL' : 'ENTITY',
+      matchTypes: ['SANCTION'],
+      countries: unique(matchValues(block, /<country>([^<]+)<\/country>/gi).map(decodeXml)),
+      cryptoAddresses: unique(cryptoAddresses),
+    })
+  }
+
+  return entities
+}
+
+function parseUn(xml) {
+  const entities = []
+
+  const individuals = matchBlocks(xml, /<INDIVIDUAL>[\s\S]*?<\/INDIVIDUAL>/gi)
+  const groups = matchBlocks(xml, /<ENTITY>[\s\S]*?<\/ENTITY>/gi)
+
+  for (const [blocks, type] of [
+    [individuals, 'INDIVIDUAL'],
+    [groups, 'ENTITY'],
+  ]) {
+    for (const block of blocks) {
+      const id = firstMatch(block, /<DATAID>([^<]+)<\/DATAID>/i)
+      if (!id) continue
+
+      // UN splits personal names across numbered elements; entities use a
+      // single FIRST_NAME holding the whole name.
+      const nameParts = [
+        firstMatch(block, /<FIRST_NAME>([^<]+)<\/FIRST_NAME>/i),
+        firstMatch(block, /<SECOND_NAME>([^<]+)<\/SECOND_NAME>/i),
+        firstMatch(block, /<THIRD_NAME>([^<]+)<\/THIRD_NAME>/i),
+        firstMatch(block, /<FOURTH_NAME>([^<]+)<\/FOURTH_NAME>/i),
+      ].filter(Boolean)
+
+      const name = decodeXml(nameParts.join(' ').trim())
+      if (!name) continue
+
+      const aliases = matchValues(block, /<ALIAS_NAME>([^<]+)<\/ALIAS_NAME>/gi)
+        .map((alias) => decodeXml(alias).trim())
+        .filter(Boolean)
+
+      entities.push({
+        id: `UN-${id}`,
+        source: 'UN Consolidated',
+        name,
+        aliases: unique(aliases),
+        entityType: type,
+        matchTypes: ['SANCTION'],
+        countries: unique(
+          matchValues(block, /<COUNTRY>([^<]*)<\/COUNTRY>/gi)
+            .map((country) => decodeXml(country).trim())
+            .filter(Boolean)
+        ),
+        cryptoAddresses: [],
+        listedAt: firstMatch(block, /<LISTED_ON>([^<]+)<\/LISTED_ON>/i) ?? undefined,
+      })
+    }
+  }
+
+  return entities
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Whole matches, for splitting a document into per-record blocks. */
+function matchBlocks(text, pattern) {
+  return [...text.matchAll(pattern)].map((m) => m[0])
+}
+
+/** First capture group of every match. */
+function matchValues(text, pattern) {
+  return [...text.matchAll(pattern)].map((m) => m[1])
+}
+
+function firstMatch(text, pattern) {
+  const match = text.match(pattern)
+  return match ? match[1] : null
+}
+
+function decodeXml(value) {
+  return value
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&#(\d+);/g, (_, code) => String.fromCharCode(Number(code)))
+}
+
+function unique(values) {
+  return [...new Set(values)]
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})


### PR DESCRIPTION
…kflow

Adds the AML/CFT controls required to operate a crypto ramp in NG, KE, GH, ZA and UG: transaction monitoring, velocity rules, sanctions screening and a SAR workflow.

lib/compliance/monitor.ts is the single entry point. Payment routes call screenTransaction() and act on ALLOW/REVIEW/BLOCK; they never form their own view of risk. Wired into the offramp path first, since that is where a designated person actually receives value.

- Providers: Chainalysis and Elliptic adapters for wallet risk, ComplyAdvantage for entity screening, plus a local list-based provider used as failover and in CI. Kept as two interfaces because analytics and entity screening are not interchangeable.
- Sanctions: normalisation, token-set comparison and Jaro-Winkler matching, so transliteration and name-order variants are caught. Addresses match exactly. scripts/refresh-sanctions-lists.mjs pulls OFAC SDN and UN Consolidated.
- Velocity: eight rules covering structuring, rapid ramp reversal, counterparty fan-out, self-relative volume spikes, dormancy and new-account value.
- Cases and SARs: append-only audit trail, mandatory decision rationale, and filing deadlines that run from when suspicion was formed rather than from draft time.
- Admin console at /admin/compliance, gated by per-analyst bearer tokens.


Screening fails closed: a provider outage holds the transaction rather than approving it. BLOCK and REVIEW return an identical customer-facing message to avoid tipping off. Blocked attempts are still recorded, so probing behaviour stays visible.

Stores are in-memory, mirroring db/migrations/003_create_compliance.sql, following the existing convention in lib/orders/order-store.ts. Persistence, production-grade admin auth and legal sign-off on the jurisdictional figures are tracked as known gaps in docs/AML_COMPLIANCE.md.

---

## Update: screening wired into the remaining payment paths (`d9cd271`)

The note above about the offramp being wired "first" is now closed out. Mobile money and bill payments were still moving money unscreened — gap 8 in `docs/AML_COMPLIANCE.md`. Both now call `screenTransaction()`:

| Route | Leg |
| --- | --- |
| `/api/withdrawals` | offramp |
| `/api/payments/mobile-money/initiate` | onramp / bill pay |
| `/api/bills/initiate` | bill pay |
| `/api/compliance/screen` | generic |

Screening runs **before** the provider call. An STK push that has already prompted the customer's handset has moved money as far as they are concerned; holding it afterwards means reversing a settled collection rather than declining an attempt.

**FX is configuration, not a feed** (`lib/compliance/markets.ts`). Thresholds are USD cents; these routes arrive in local currency. A rate API in the payment path would turn every rate outage into a payments outage under `FAIL_CLOSED`, and a structuring band that drifts with spot makes "was this transaction in the band?" unanswerable after the fact. An unmapped currency is refused, never screened against a guessed market.

**Anonymous payers are keyed by instrument** (`lib/compliance/identity.ts`). Bill and mobile-money payers without a connected wallet get a salted hash of their handset or email. A per-request id would key every payment to a fresh account and every time-based rule would silently never fire — worse than not screening, because the queue still looks healthy while it happens.

**Markets with no local registration are screened but not filable.** Mobile money reaches TZ, CM, CI, RW and ZM, beyond the licensed five. Those transactions are screened in full under `UNLICENSED_MARKET_POLICY`; `draftSar()` refuses them with `NO_FILING_ROUTE`, and the SQL `CHECK` on `compliance_sars.jurisdiction` refuses the row independently — a SAR addressed to no regulator would set `sar_id` and make a live review obligation read as discharged. **Whether to keep serving those markets is a licensing decision, not an engineering one.** This keeps those payments screened rather than unscreened; it is not a substitute for registering or withdrawing.

39 new tests (179 total in the module). 13 drive the exported route handlers rather than the module, because a wiring regression is invisible from the inside: every unit test still passes and money simply stops being screened.

### ⚠️ CI failures are pre-existing, not from this branch

Four suites are already broken on `main` and fail here too: `lib/kyc/withdrawalLimitService` (`TypeError: release is not a function`), `lib/payments/mpesa`, `lib/payments/mtn-momo`, and `helpcenter` (imports `vitest`, which is not installed). 27 failures, verified identical against a clean worktree at `HEAD` before any of this work. This branch adds 13 passing tests and breaks nothing.

`lib/kyc` deserves attention independently: it fails every test in that suite including the concurrency tests that exist to prove withdrawals cannot double-spend, and that service runs immediately before AML screening on the offramp path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



closes #323 