### PR TITLE
feat: real-time exchange rate SSE feed, price sparklines, and theme fixes (#332 #333)

### DIFF
--- a/app/api/exchange-rate/stream/route.ts
+++ b/app/api/exchange-rate/stream/route.ts
@@ -1,0 +1,122 @@
+import { NextRequest } from 'next/server'
+
+export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
+
+const COINGECKO_URL =
+  'https://api.coingecko.com/api/v3/simple/price?ids=usd-coin,stellar,tether&vs_currencies=ngn,kes,ghs,zar,ugx'
+
+// Binance WebSocket symbols we care about for sparkline / tick data
+// We poll CoinGecko every 10 s (free tier) and push via SSE.
+const POLL_INTERVAL_MS = 10_000
+const PING_INTERVAL_MS = 20_000
+
+type RatePayload = {
+  'usd-coin': Record<string, number>
+  stellar: Record<string, number>
+  tether: Record<string, number>
+  timestamp: number
+}
+
+async function fetchRates(): Promise<RatePayload | null> {
+  try {
+    const res = await fetch(COINGECKO_URL, {
+      headers: { 'User-Agent': 'Aframp/1.0', Accept: 'application/json' },
+      // no Next.js cache — we want fresh data every time
+      cache: 'no-store',
+    })
+    if (!res.ok) return null
+    const data = await res.json()
+    return { ...data, timestamp: Date.now() }
+  } catch {
+    return null
+  }
+}
+
+/**
+ * GET /api/exchange-rate/stream
+ *
+ * Server-Sent Events endpoint that pushes exchange-rate updates to the client.
+ *
+ * Events:
+ *   - "snapshot"  initial rates on connect
+ *   - "update"    fresh rates every ~10 s when data changes
+ *   - "error"     when the upstream fetch fails (client should use cached data)
+ *   - ": ping"    keepalive comment every 20 s
+ */
+export async function GET(request: NextRequest) {
+  const encoder = new TextEncoder()
+
+  const stream = new ReadableStream({
+    async start(controller) {
+      let closed = false
+
+      function send(event: string, data: unknown) {
+        if (closed) return
+        try {
+          controller.enqueue(
+            encoder.encode(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`)
+          )
+        } catch {
+          // controller already closed
+        }
+      }
+
+      // Send initial snapshot immediately
+      const initial = await fetchRates()
+      if (initial) {
+        send('snapshot', initial)
+      } else {
+        send('error', { message: 'Initial rate fetch failed' })
+      }
+
+      let lastPayload = initial ? JSON.stringify(initial) : ''
+
+      // Ping to keep connection alive through proxies
+      const pingInterval = setInterval(() => {
+        if (closed) return
+        try {
+          controller.enqueue(encoder.encode(': ping\n\n'))
+        } catch {
+          clearInterval(pingInterval)
+          clearInterval(pollInterval)
+        }
+      }, PING_INTERVAL_MS)
+
+      // Poll upstream and push only when data changes
+      const pollInterval = setInterval(async () => {
+        if (closed) return
+        const payload = await fetchRates()
+        if (!payload) {
+          send('error', { message: 'Rate refresh failed' })
+          return
+        }
+        const serialised = JSON.stringify(payload)
+        if (serialised !== lastPayload) {
+          lastPayload = serialised
+          send('update', payload)
+        }
+      }, POLL_INTERVAL_MS)
+
+      request.signal.addEventListener('abort', () => {
+        closed = true
+        clearInterval(pingInterval)
+        clearInterval(pollInterval)
+        try {
+          controller.close()
+        } catch {
+          // already closed
+        }
+      })
+    },
+  })
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  })
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -50,7 +50,7 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <body className="font-sans antialiased" suppressHydrationWarning>
-        <ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
+        <ThemeProvider attribute="class" defaultTheme="system" enableSystem disableTransitionOnChange>
           <KycProvider>
             <NotificationProvider>
               {children}

--- a/components/offramp/offramp-calculator.tsx
+++ b/components/offramp/offramp-calculator.tsx
@@ -1,10 +1,11 @@
 'use client'
 
-import { AlertTriangle, Clock, Info, Loader2 } from 'lucide-react'
+import { AlertTriangle, Clock, Info, Loader2, TrendingDown, TrendingUp } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { AmountInput } from '@/components/onramp/amount-input'
 import { CurrencySelector } from '@/components/onramp/currency-selector'
 import { AssetSelector } from '@/components/offramp/asset-selector'
+import { Sparkline } from '@/components/ui/sparkline'
 import { formatCurrency, formatNumber } from '@/lib/calculations'
 import { formatRateCountdown, formatUsd } from '@/lib/offramp/formatters'
 import type { FiatCurrency } from '@/types/onramp'
@@ -19,6 +20,7 @@ interface OfframpCalculatorProps {
   rateCountdown: number
   rateUpdatedAt: number
   isRateLoading: boolean
+  rateSparkline?: number[]
   fiatAmount: number
   usdEquivalent: number
   fees: {
@@ -55,6 +57,7 @@ export function OfframpCalculator({
   rateCountdown,
   rateUpdatedAt,
   isRateLoading,
+  rateSparkline = [],
   fiatAmount,
   usdEquivalent,
   fees,
@@ -163,9 +166,14 @@ export function OfframpCalculator({
         <div className="rounded-2xl border border-border bg-muted/30 px-4 py-3 text-xs text-muted-foreground">
           <div className="flex items-center justify-between">
             <span>Rate</span>
-            <span className="font-medium text-foreground">
-              1 {selected.asset} = {formatNumber(rate, 2)} {fiatCurrency}
-            </span>
+            <div className="flex items-center gap-2">
+              {rateSparkline.length >= 2 && (
+                <Sparkline data={rateSparkline} width={60} height={22} />
+              )}
+              <span className="font-medium text-foreground">
+                1 {selected.asset} = {formatNumber(rate, 2)} {fiatCurrency}
+              </span>
+            </div>
           </div>
           <div className="mt-2 flex items-center justify-between">
             <span>Refresh in</span>
@@ -180,6 +188,7 @@ export function OfframpCalculator({
             type="button"
             onClick={onRefreshRate}
             className="mt-2 inline-flex items-center gap-2 text-xs text-primary"
+            aria-label="Refresh exchange rate"
           >
             {isRateLoading ? <Loader2 className="h-3 w-3 animate-spin" /> : null}
             Refresh rate

--- a/components/offramp/offramp-page-client.tsx
+++ b/components/offramp/offramp-page-client.tsx
@@ -44,7 +44,7 @@ export function OfframpPageClient() {
   const { options: assetOptions } = useOfframpBalances(address)
   const form = useOfframpForm(assetOptions, rateOverride)
   const selectedAsset = form.selectedAsset
-  const { rate, countdown, lastUpdated, isLoading, refresh } = useOfframpRate(
+  const { rate, countdown, lastUpdated, isLoading, refresh, sparkline } = useOfframpRate(
     selectedAsset.asset,
     selectedAsset.chain,
     form.state.fiatCurrency
@@ -220,6 +220,7 @@ export function OfframpPageClient() {
             rateCountdown={countdown}
             rateUpdatedAt={lastUpdated || 0}
             isRateLoading={isLoading}
+            rateSparkline={sparkline}
             fiatAmount={form.fiatAmount}
             usdEquivalent={usdEquivalent}
             fees={form.fees}

--- a/components/onramp/exchange-rate-display.tsx
+++ b/components/onramp/exchange-rate-display.tsx
@@ -1,7 +1,8 @@
 'use client'
 
-import { RefreshCcw, TrendingDown } from 'lucide-react'
+import { RefreshCcw, TrendingDown, TrendingUp } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import { Sparkline } from '@/components/ui/sparkline'
 
 interface ExchangeRateDisplayProps {
   displayRate: string
@@ -10,6 +11,8 @@ interface ExchangeRateDisplayProps {
   error?: string | null
   isLoading?: boolean
   onRefresh: () => void
+  /** Recent rate values for the sparkline (oldest → newest) */
+  sparkline?: number[]
 }
 
 export function ExchangeRateDisplay({
@@ -19,32 +22,47 @@ export function ExchangeRateDisplay({
   error,
   isLoading,
   onRefresh,
+  sparkline = [],
 }: ExchangeRateDisplayProps) {
   const countdownColor =
     countdown <= 9 ? 'text-destructive' : countdown <= 19 ? 'text-warning' : 'text-success'
 
+  const trend =
+    sparkline.length >= 2 ? sparkline[sparkline.length - 1] - sparkline[0] : 0
+
+  const TrendIcon = trend >= 0 ? TrendingUp : TrendingDown
+  const trendColor = trend >= 0 ? 'text-success' : 'text-destructive'
+
   return (
-    <div className="rounded-2xl border border-border bg-muted/30 px-4 py-3 text-center">
-      <div className="inline-flex items-center gap-2 text-sm font-medium text-muted-foreground">
-        <TrendingDown className="h-4 w-4 text-primary" />
-        <span>{displayRate || 'Fetching live rates...'}</span>
+    <div className="rounded-2xl border border-border bg-muted/30 px-4 py-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
+          <TrendIcon className={cn('h-4 w-4', trendColor)} />
+          <span>{displayRate || 'Fetching live rates...'}</span>
+        </div>
+        {sparkline.length >= 2 && (
+          <Sparkline data={sparkline} width={80} height={28} />
+        )}
       </div>
-      <div className={cn('mt-1 text-xs font-semibold', countdownColor)} aria-live="polite">
-        Rate updates in: {countdown}s
+      <div className="mt-1 flex items-center justify-between">
+        <div className={cn('text-xs font-semibold', countdownColor)} aria-live="polite">
+          {countdown > 0 ? `Updates in ${countdown}s` : 'Refreshing...'}
+        </div>
+        <button
+          type="button"
+          onClick={onRefresh}
+          className="inline-flex items-center gap-1 text-xs text-primary hover:text-primary/80"
+          aria-label="Refresh exchange rate"
+        >
+          <RefreshCcw className={cn('h-3 w-3', isLoading ? 'animate-spin' : '')} />
+          Refresh
+        </button>
       </div>
       {(warning || error) && (
         <div className="mt-2 rounded-lg border border-warning/40 bg-warning/10 px-3 py-2 text-xs text-warning-foreground">
           {warning || error}
         </div>
       )}
-      <button
-        type="button"
-        onClick={onRefresh}
-        className="mt-2 inline-flex items-center gap-1 text-xs text-primary hover:text-primary/80"
-      >
-        <RefreshCcw className={cn('h-3 w-3', isLoading ? 'animate-spin' : '')} />
-        Refresh rate
-      </button>
     </div>
   )
 }

--- a/components/onramp/onramp-calculator.tsx
+++ b/components/onramp/onramp-calculator.tsx
@@ -21,6 +21,7 @@ interface OnrampCalculatorProps {
   exchangeWarning?: string | null
   exchangeError?: string | null
   exchangeLoading?: boolean
+  exchangeSparkline?: number[]
   onRefreshRate: () => void
   onAmountChange: (value: string) => void
   onFiatChange: (value: FiatCurrency) => void
@@ -65,6 +66,7 @@ export function OnrampCalculator({
   exchangeWarning,
   exchangeError,
   exchangeLoading,
+  exchangeSparkline,
   onRefreshRate,
   onAmountChange,
   onFiatChange,
@@ -129,6 +131,7 @@ export function OnrampCalculator({
           error={exchangeError}
           isLoading={exchangeLoading}
           onRefresh={onRefreshRate}
+          sparkline={exchangeSparkline}
         />
 
         <div className="grid gap-4 md:grid-cols-[1fr_180px] md:items-end">

--- a/components/onramp/onramp-page-client.tsx
+++ b/components/onramp/onramp-page-client.tsx
@@ -54,7 +54,7 @@ export function OnrampPageClient() {
   const [rateOverride, setRateOverride] = useState(0)
 
   const form = useOnrampForm(rateOverride, walletConnected)
-  const { data, countdown, warning, error, isLoading, displayRate, refresh } = useExchangeRate(
+  const { data, countdown, warning, error, isLoading, displayRate, refresh, sparkline } = useExchangeRate(
     form.state.fiatCurrency,
     form.state.cryptoAsset
   )
@@ -283,6 +283,7 @@ export function OnrampPageClient() {
             exchangeWarning={warning}
             exchangeError={error}
             exchangeLoading={isLoading}
+            exchangeSparkline={sparkline}
             onRefreshRate={refresh}
             onAmountChange={form.setAmountInput}
             onFiatChange={(value) => form.setFiatCurrency(value as FiatCurrency)}

--- a/components/theme-toggle.tsx
+++ b/components/theme-toggle.tsx
@@ -1,37 +1,60 @@
 'use client'
 
 import { useTheme } from 'next-themes'
-import { Moon, Sun } from 'lucide-react'
+import { Monitor, Moon, Sun } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useEffect, useState } from 'react'
 
+/**
+ * Cycles through: system → light → dark → system …
+ * - Reads `resolvedTheme` for the icon so it always reflects the actual rendered theme.
+ * - `aria-label` is dynamic so screen readers announce the *next* action.
+ * - Renders a placeholder on the server to avoid hydration mismatch.
+ */
 export function ThemeToggle() {
-  const { theme, setTheme } = useTheme()
+  const { theme, setTheme, resolvedTheme } = useTheme()
   const [mounted, setMounted] = useState(false)
 
   useEffect(() => {
-    // Use a timeout to avoid hydration mismatch
-    const timer = setTimeout(() => setMounted(true), 0)
-    return () => clearTimeout(timer)
+    setMounted(true)
   }, [])
 
   if (!mounted) {
     return (
-      <Button variant="ghost" size="icon" className="h-9 w-9 rounded-full">
+      <Button variant="ghost" size="icon" className="h-9 w-9 rounded-full" aria-label="Toggle theme">
         <span className="sr-only">Toggle theme</span>
       </Button>
     )
   }
+
+  function nextTheme() {
+    if (theme === 'system') return 'light'
+    if (theme === 'light') return 'dark'
+    return 'system'
+  }
+
+  function ariaLabel() {
+    if (theme === 'system') return 'Switch to light theme'
+    if (theme === 'light') return 'Switch to dark theme'
+    return 'Switch to system theme'
+  }
+
+  const Icon =
+    theme === 'system'
+      ? Monitor
+      : resolvedTheme === 'dark'
+        ? Sun
+        : Moon
 
   return (
     <Button
       variant="ghost"
       size="icon"
       className="h-9 w-9 rounded-full text-muted-foreground hover:text-foreground hover:bg-muted"
-      onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
-      aria-label="Toggle theme"
+      onClick={() => setTheme(nextTheme())}
+      aria-label={ariaLabel()}
     >
-      {theme === 'dark' ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+      <Icon className="h-5 w-5" />
     </Button>
   )
 }

--- a/components/ui/sparkline.tsx
+++ b/components/ui/sparkline.tsx
@@ -1,0 +1,61 @@
+'use client'
+
+import { useMemo } from 'react'
+import { cn } from '@/lib/utils'
+
+interface SparklineProps {
+  /** Array of rate values, oldest → newest */
+  data: number[]
+  width?: number
+  height?: number
+  className?: string
+  /** Override line colour. Defaults to green when trend is up, red when down. */
+  color?: string
+}
+
+/**
+ * Lightweight SVG sparkline — no external chart library required.
+ * Renders a polyline from an array of numeric values.
+ */
+export function Sparkline({ data, width = 80, height = 28, className, color }: SparklineProps) {
+  const points = useMemo(() => {
+    if (data.length < 2) return ''
+    const min = Math.min(...data)
+    const max = Math.max(...data)
+    const range = max - min || 1
+    const step = width / (data.length - 1)
+    const pad = 2 // vertical padding in px
+
+    return data
+      .map((v, i) => {
+        const x = i * step
+        const y = height - pad - ((v - min) / range) * (height - pad * 2)
+        return `${x.toFixed(1)},${y.toFixed(1)}`
+      })
+      .join(' ')
+  }, [data, width, height])
+
+  const trend = data.length >= 2 ? data[data.length - 1] - data[0] : 0
+  const lineColor = color ?? (trend >= 0 ? '#10b981' : '#ef4444')
+
+  if (data.length < 2) return null
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className={cn('overflow-visible', className)}
+      aria-hidden="true"
+    >
+      <polyline
+        points={points}
+        fill="none"
+        stroke={lineColor}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  )
+}

--- a/hooks/use-exchange-rate.ts
+++ b/hooks/use-exchange-rate.ts
@@ -9,10 +9,10 @@ import type {
 } from '@/types/onramp'
 import { formatRate } from '@/lib/calculations'
 
-const API_URL = '/api/exchange-rate'
-
 const STORAGE_KEY = 'onramp:rates'
-const COUNTDOWN_START = 30
+const SPARKLINE_STORAGE_KEY = 'onramp:sparkline'
+const SSE_URL = '/api/exchange-rate/stream'
+const MAX_SPARKLINE_POINTS = 30 // keep last 30 data points (5 mins at 10 s intervals)
 
 function buildRateResult(
   fiat: FiatCurrency,
@@ -35,126 +35,181 @@ function buildRateResult(
   }
 }
 
-async function fetchWithRetry(retries: number) {
-  let attempt = 0
-  let lastError: Error | null = null
-
-  while (attempt < retries) {
-    try {
-      const response = await fetch(API_URL)
-      if (!response.ok) {
-        throw new Error(`Exchange rate request failed: ${response.status}`)
-      }
-      return (await response.json()) as {
-        'usd-coin': Record<string, number>
-        stellar: Record<string, number>
-      }
-    } catch (error) {
-      lastError = error as Error
-      const delay = 300 * 2 ** attempt
-      await new Promise((resolve) => setTimeout(resolve, delay))
-      attempt += 1
-    }
-  }
-
-  throw lastError || new Error('Unable to fetch exchange rates.')
+export interface ExchangeRateHook extends ExchangeRateState {
+  refresh: () => void
+  displayRate: string
+  sparkline: number[]
 }
 
-export function useExchangeRate(fiat: FiatCurrency, asset: CryptoAsset) {
+export function useExchangeRate(fiat: FiatCurrency, asset: CryptoAsset): ExchangeRateHook {
   const [state, setState] = useState<ExchangeRateState>({
     data: null,
     isLoading: true,
     error: null,
     warning: null,
-    countdown: COUNTDOWN_START,
+    countdown: 30,
   })
-  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const [sparkline, setSparkline] = useState<number[]>([])
+  const eventSourceRef = useRef<EventSource | null>(null)
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const updateFromCache = useCallback(
+  const updateFromPayload = useCallback(
     (
-      cached: { timestamp: number; data: Record<string, Record<string, number>> },
-      reason: string
+      payload: {
+        'usd-coin': Record<string, number>
+        stellar: Record<string, number>
+        timestamp: number
+      },
+      source: 'coingecko' | 'cache'
     ) => {
-      if (!cached?.data) return
       const lower = fiat.toLowerCase()
-      const usdcPrice = cached.data['usd-coin']?.[lower]
-      const xlmPrice = cached.data.stellar?.[lower]
+      const usdcPrice = payload['usd-coin']?.[lower]
+      const xlmPrice = payload.stellar?.[lower]
       if (!usdcPrice || !xlmPrice) return
 
-      const result = buildRateResult(fiat, asset, usdcPrice, xlmPrice, 'cache', cached.timestamp)
+      const result = buildRateResult(fiat, asset, usdcPrice, xlmPrice, source, payload.timestamp)
 
       setState((prev) => ({
         ...prev,
         data: result,
         isLoading: false,
-        warning: reason,
+        error: null,
+        warning: source === 'cache' ? 'Using cached exchange rate.' : null,
+        countdown: 30,
       }))
+
+      // Update sparkline
+      setSparkline((prev) => {
+        const next = [...prev, result.rate].slice(-MAX_SPARKLINE_POINTS)
+        try {
+          localStorage.setItem(SPARKLINE_STORAGE_KEY, JSON.stringify(next))
+        } catch {
+          // ignore quota errors
+        }
+        return next
+      })
+
+      // Persist to localStorage
+      try {
+        localStorage.setItem(
+          STORAGE_KEY,
+          JSON.stringify({ timestamp: result.lastUpdated, data: payload })
+        )
+      } catch {
+        // ignore quota errors
+      }
     },
     [asset, fiat]
   )
 
-  const refresh = useCallback(async () => {
-    setState((prev) => ({ ...prev, isLoading: true, error: null }))
-    try {
-      const data = await fetchWithRetry(3)
-      const lower = fiat.toLowerCase()
-      const usdcPrice = data['usd-coin']?.[lower]
-      const xlmPrice = data.stellar?.[lower]
-      if (!usdcPrice || !xlmPrice) {
-        throw new Error('Exchange rate unavailable for selected currency.')
-      }
+  const connectSSE = useCallback(() => {
+    // Clean up existing connection
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close()
+      eventSourceRef.current = null
+    }
 
-      const result = buildRateResult(fiat, asset, usdcPrice, xlmPrice, 'coingecko', Date.now())
-      localStorage.setItem(STORAGE_KEY, JSON.stringify({ timestamp: result.lastUpdated, data }))
+    const es = new EventSource(SSE_URL)
+    eventSourceRef.current = es
 
-      setState({
-        data: result,
-        isLoading: false,
-        error: null,
-        warning: null,
-        countdown: COUNTDOWN_START,
-      })
-    } catch (error) {
-      const message = (error as Error).message
-      console.error('Exchange rate error:', error)
+    es.addEventListener('snapshot', (event) => {
+      const payload = JSON.parse(event.data)
+      updateFromPayload(payload, 'coingecko')
+    })
+
+    es.addEventListener('update', (event) => {
+      const payload = JSON.parse(event.data)
+      updateFromPayload(payload, 'coingecko')
+    })
+
+    es.addEventListener('error', (event) => {
+      const data = (event as MessageEvent).data
+      const parsed = data ? JSON.parse(data) : { message: 'Stream connection lost' }
+      console.warn('SSE error:', parsed.message)
+
+      // Use cached data on stream error
       const cachedRaw = localStorage.getItem(STORAGE_KEY)
       if (cachedRaw) {
-        updateFromCache(JSON.parse(cachedRaw), 'Using cached exchange rate.')
+        try {
+          const cached = JSON.parse(cachedRaw)
+          updateFromPayload(cached.data, 'cache')
+        } catch {
+          // ignore parse errors
+        }
       }
+
       setState((prev) => ({
         ...prev,
-        isLoading: false,
-        error: message,
+        warning: 'Using cached rates. Real-time updates paused.',
       }))
-    }
-  }, [asset, fiat, updateFromCache])
+    })
 
+    es.onerror = () => {
+      es.close()
+      setState((prev) => ({
+        ...prev,
+        warning: 'Reconnecting to live rates...',
+      }))
+
+      // Reconnect after 5 seconds
+      reconnectTimerRef.current = setTimeout(() => {
+        connectSSE()
+      }, 5000)
+    }
+  }, [updateFromPayload])
+
+  // Initial mount: load cache + connect SSE
   useEffect(() => {
+    // Load cached rates
     const cachedRaw = localStorage.getItem(STORAGE_KEY)
     if (cachedRaw) {
-      updateFromCache(JSON.parse(cachedRaw), 'Using cached exchange rate while refreshing.')
+      try {
+        const cached = JSON.parse(cachedRaw)
+        updateFromPayload(cached.data, 'cache')
+      } catch {
+        // ignore
+      }
     }
-    refresh()
-  }, [refresh, updateFromCache])
 
-  useEffect(() => {
-    if (timerRef.current) clearInterval(timerRef.current)
+    // Load cached sparkline
+    const sparklineRaw = localStorage.getItem(SPARKLINE_STORAGE_KEY)
+    if (sparklineRaw) {
+      try {
+        setSparkline(JSON.parse(sparklineRaw))
+      } catch {
+        // ignore
+      }
+    }
 
-    timerRef.current = setInterval(() => {
-      setState((prev) => {
-        const next = prev.countdown - 1
-        if (next <= 0) {
-          refresh()
-          return { ...prev, countdown: COUNTDOWN_START }
-        }
-        return { ...prev, countdown: next }
-      })
-    }, 1000)
+    connectSSE()
 
     return () => {
-      if (timerRef.current) clearInterval(timerRef.current)
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close()
+        eventSourceRef.current = null
+      }
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current)
+        reconnectTimerRef.current = null
+      }
     }
-  }, [refresh])
+  }, [connectSSE, updateFromPayload])
+
+  // Countdown timer (UI only)
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setState((prev) => ({
+        ...prev,
+        countdown: prev.countdown > 0 ? prev.countdown - 1 : 30,
+      }))
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const refresh = useCallback(() => {
+    // Reconnect SSE to force a fresh fetch
+    connectSSE()
+  }, [connectSSE])
 
   const displayRate = useMemo(() => {
     if (!state.data) return ''
@@ -165,5 +220,6 @@ export function useExchangeRate(fiat: FiatCurrency, asset: CryptoAsset) {
     ...state,
     refresh,
     displayRate,
+    sparkline,
   }
 }

--- a/hooks/use-offramp-rate.ts
+++ b/hooks/use-offramp-rate.ts
@@ -4,8 +4,8 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import type { FiatCurrency } from '@/types/onramp'
 import type { OfframpAsset, OfframpChain } from '@/types/offramp'
 
-const RATE_REFRESH_SECONDS = 30
-const API_URL = '/api/exchange-rate'
+const SSE_URL = '/api/exchange-rate/stream'
+const MAX_SPARKLINE_POINTS = 30
 
 const coinGeckoIds: Record<OfframpAsset, string> = {
   cNGN: 'usd-coin',
@@ -27,61 +27,100 @@ export function useOfframpRate(
   chain: OfframpChain,
   fiatCurrency: FiatCurrency
 ) {
-  const [countdown, setCountdown] = useState(RATE_REFRESH_SECONDS)
+  const [countdown, setCountdown] = useState(30)
   const [lastUpdated, setLastUpdated] = useState<number | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [rate, setRate] = useState(0)
-  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const [sparkline, setSparkline] = useState<number[]>([])
+  const eventSourceRef = useRef<EventSource | null>(null)
+  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  const refresh = useCallback(async () => {
-    setIsLoading(true)
-    try {
-      const response = await fetch(API_URL)
-      if (!response.ok) throw new Error('Failed to fetch rates')
-      const data = await response.json()
+  const updateFromPayload = useCallback(
+    (payload: {
+      'usd-coin': Record<string, number>
+      stellar: Record<string, number>
+      tether: Record<string, number>
+      timestamp: number
+    }) => {
       const coinId = coinGeckoIds[asset]
       const fiatKey = fiatCurrencyKeys[fiatCurrency]
-      const baseRate = data[coinId]?.[fiatKey] ?? 0
+      const baseRate = payload[coinId]?.[fiatKey] ?? 0
+
+      if (!baseRate) return
 
       const chainMultiplier =
         chain === 'Ethereum' ? 1.01 : chain === 'Polygon' ? 0.995 : chain === 'Base' ? 1.002 : 1
 
-      setRate(baseRate * chainMultiplier)
-      setLastUpdated(Date.now())
-      setCountdown(RATE_REFRESH_SECONDS)
-    } catch (error) {
-      console.error('Offramp rate error:', error)
-      // Fallback to mock rate if API fails
-      const mockRate = asset === 'XLM' ? 180 : 1600
-      setRate(mockRate)
-      setLastUpdated(Date.now())
-      setCountdown(RATE_REFRESH_SECONDS)
-    } finally {
+      const finalRate = baseRate * chainMultiplier
+
+      setRate(finalRate)
+      setLastUpdated(payload.timestamp)
+      setCountdown(30)
       setIsLoading(false)
+
+      setSparkline((prev) => [...prev, finalRate].slice(-MAX_SPARKLINE_POINTS))
+    },
+    [asset, chain, fiatCurrency]
+  )
+
+  const connectSSE = useCallback(() => {
+    if (eventSourceRef.current) {
+      eventSourceRef.current.close()
+      eventSourceRef.current = null
     }
-  }, [asset, chain, fiatCurrency])
+
+    const es = new EventSource(SSE_URL)
+    eventSourceRef.current = es
+
+    es.addEventListener('snapshot', (event) => {
+      const payload = JSON.parse(event.data)
+      updateFromPayload(payload)
+    })
+
+    es.addEventListener('update', (event) => {
+      const payload = JSON.parse(event.data)
+      updateFromPayload(payload)
+    })
+
+    es.addEventListener('error', (event) => {
+      const data = (event as MessageEvent).data
+      const parsed = data ? JSON.parse(data) : { message: 'Stream error' }
+      console.warn('Offramp SSE error:', parsed.message)
+    })
+
+    es.onerror = () => {
+      es.close()
+      reconnectTimerRef.current = setTimeout(() => {
+        connectSSE()
+      }, 5000)
+    }
+  }, [updateFromPayload])
 
   useEffect(() => {
-    refresh()
-  }, [refresh])
-
-  useEffect(() => {
-    if (timerRef.current) clearInterval(timerRef.current)
-
-    timerRef.current = setInterval(() => {
-      setCountdown((prev) => {
-        if (prev <= 1) {
-          refresh()
-          return RATE_REFRESH_SECONDS
-        }
-        return prev - 1
-      })
-    }, 1000)
+    connectSSE()
 
     return () => {
-      if (timerRef.current) clearInterval(timerRef.current)
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close()
+        eventSourceRef.current = null
+      }
+      if (reconnectTimerRef.current) {
+        clearTimeout(reconnectTimerRef.current)
+        reconnectTimerRef.current = null
+      }
     }
-  }, [refresh])
+  }, [connectSSE])
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCountdown((prev) => (prev > 0 ? prev - 1 : 30))
+    }, 1000)
+    return () => clearInterval(interval)
+  }, [])
+
+  const refresh = useCallback(() => {
+    connectSSE()
+  }, [connectSSE])
 
   return {
     rate,
@@ -89,5 +128,6 @@ export function useOfframpRate(
     lastUpdated,
     isLoading,
     refresh,
+    sparkline,
   }
 }


### PR DESCRIPTION
## Summary

closes #332 
closes #333 

---

## Issue #332 — Real-time exchange rate feed replacing 20-second polling

### Problem

Exchange rates were fetched via two layers of polling: a 20-second Next.js `revalidate` on the API route, plus a 30-second `setInterval` in both `useExchangeRate` and `useOfframpRate`. This meant clients could be working with rates up to 50 seconds stale, and every connected client was independently hammering the API route.

### Changes

**`app/api/exchange-rate/stream/route.ts`** _(new)_
- SSE endpoint at `/api/exchange-rate/stream` that polls CoinGecko every **10 seconds** server-side and pushes events to all connected clients.
- Emits a `snapshot` event immediately on connect so the client has fresh rates with zero extra round-trip.
- Emits an `update` event only when the payload actually changes (diff check), reducing noise.
- Sends a `: ping` keepalive comment every 20 seconds to keep connections alive through proxies and load balancers.
- Sets `X-Accel-Buffering: no` to disable Nginx response buffering.
- Cleans up all intervals on client disconnect via `request.signal` abort listener.

**`hooks/use-exchange-rate.ts`**
- Replaced `setInterval` polling + `fetch` with an `EventSource` subscription to `/api/exchange-rate/stream`.
- Falls back to `localStorage` cached rates on stream error so the UI is never left blank.
- Auto-reconnects after 5 seconds on connection drop.
- Accumulates up to 30 rate data points in state and persists them to `localStorage` for the sparkline.
- Exports a `sparkline: number[]` field alongside existing state.

**`hooks/use-offramp-rate.ts`**
- Same migration from polling to SSE as `use-exchange-rate`.
- Also exposes `sparkline: number[]`.

**`components/ui/sparkline.tsx`** _(new)_
- Zero-dependency SVG polyline sparkline component — no extra packages required.
- Normalises data to the available pixel space with 2px vertical padding.
- Auto-colours green (`#10b981`) when trend is up, red (`#ef4444`) when down; accepts an override `color` prop.
- Marked `aria-hidden` — purely decorative, no screen reader impact.

**`components/onramp/exchange-rate-display.tsx`**
- Renders the `Sparkline` next to the rate label when 2 or more data points are available.
- Swaps the static `TrendingDown` icon for a dynamic `TrendingUp`/`TrendingDown` icon based on actual price direction.
- `aria-label` added to the refresh button.

**`components/offramp/offramp-calculator.tsx`**
- Rate summary row now renders the sparkline inline with the rate value.
- Added `aria-label` to the refresh rate button.

**`components/onramp/onramp-calculator.tsx`**
- Threads the new `exchangeSparkline` prop through to `ExchangeRateDisplay`.

**`components/onramp/onramp-page-client.tsx`** / **`components/offramp/offramp-page-client.tsx`**
- Destructures `sparkline` from the respective hooks and passes it down to the calculator components.

---

## Issue #333 — Dark/light mode persistence, OS sync, and accessibility

### Problem

- `app/layout.tsx` passed `defaultTheme="dark"` to `ThemeProvider`, hard-coding dark mode for every first-time visitor regardless of their OS preference.
- The theme toggle only cycled between `dark` and `light`, making it impossible to return to OS-synced behaviour once overridden.
- The toggle `aria-label` was static and did not communicate the _next_ action to assistive technologies.
- The `setTimeout(0)` hydration guard in the toggle was an unnecessary workaround pattern.

### Changes

**`app/layout.tsx`**
- Changed `defaultTheme="dark"` to `defaultTheme="system"` so first-time visitors get the theme that matches their OS `prefers-color-scheme`.
- `suppressHydrationWarning` confirmed present on `<html>` — already correct, no change needed.

**`components/theme-provider.tsx`**
- Already had `defaultTheme="system"`, `enableSystem`, and `storageKey="theme"` hardcoded as post-spread overrides — confirmed correct, no change needed.
- Theme persists across navigations and session restores via `localStorage` under the `theme` key (next-themes built-in behaviour).

**`components/theme-toggle.tsx`**
- Toggle now cycles **system → light → dark → system**, allowing users to restore OS sync at any time.
- Icon is driven by `resolvedTheme` (the actual rendered theme), not `theme`, so it is accurate even when `theme === 'system'`:
  - `system` → `Monitor` icon
  - resolved dark → `Sun` (click to switch to light)
  - resolved light → `Moon` (click to switch to dark)
- `aria-label` is now dynamic and announces the next action: _"Switch to light theme"_, _"Switch to dark theme"_, or _"Switch to system theme"_.
- Replaced `setTimeout(0)` guard with a clean `useEffect(() => setMounted(true), [])`.
- Server-side placeholder button now carries `aria-label` so it is not an unlabelled button during SSR.

---

## Files changed

| File | Status |
|---|---|
| `app/api/exchange-rate/stream/route.ts` | Added |
| `components/ui/sparkline.tsx` | Added |
| `hooks/use-exchange-rate.ts` | Modified |
| `hooks/use-offramp-rate.ts` | Modified |
| `components/onramp/exchange-rate-display.tsx` | Modified |
| `components/onramp/onramp-calculator.tsx` | Modified |
| `components/onramp/onramp-page-client.tsx` | Modified |
| `components/offramp/offramp-calculator.tsx` | Modified |
| `components/offramp/offramp-page-client.tsx` | Modified |
| `components/theme-toggle.tsx` | Modified |
| `app/layout.tsx` | Modified |
