### PR TITLE
test: add coverage for Stellar SDK modules and API route handlers (#3…

### DIFF
--- a/app/api/__tests__/routes.test.ts
+++ b/app/api/__tests__/routes.test.ts
@@ -1,0 +1,725 @@
+/**
+ * Tests for API route handlers
+ *
+ * Covers:
+ *  - GET /api/exchange-rate   — CoinGecko fetch, caching, error handling
+ *  - POST /api/onramp/create-order — order creation, field population
+ *  - POST /api/withdrawals    — KYC tier limit enforcement, validation
+ *  - GET/POST /api/referral   — code generation, discount application
+ *  - POST /api/bills/initiate — Paystack integration, validation
+ */
+
+// ---------------------------------------------------------------------------
+// exchange-rate
+// ---------------------------------------------------------------------------
+
+describe('GET /api/exchange-rate', () => {
+  const COINGECKO_URL = 'https://api.coingecko.com/api/v3/simple/price'
+
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('returns 200 with rate data from CoinGecko', async () => {
+    const mockData = {
+      'usd-coin': { ngn: 1600, kes: 130 },
+      stellar: { ngn: 160, kes: 13 },
+    }
+
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve(mockData),
+    })
+
+    const { GET } = await import('@/app/api/exchange-rate/route')
+    const response = await GET()
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data).toEqual(mockData)
+  })
+
+  it('returns error status when CoinGecko responds with non-ok', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      json: () => Promise.resolve({}),
+    })
+
+    const { GET } = await import('@/app/api/exchange-rate/route')
+    const response = await GET()
+    const data = await response.json()
+
+    expect(response.status).toBe(429)
+    expect(data.error).toBe('Failed to fetch rates')
+  })
+
+  it('returns 500 when fetch throws an exception', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('Network error'))
+
+    const { GET } = await import('@/app/api/exchange-rate/route')
+    const response = await GET()
+    const data = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(data.error).toBe('Unable to fetch exchange rates')
+  })
+
+  it('calls CoinGecko with the correct URL including ngn,kes,ghs,zar,ugx currencies', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    })
+
+    const { GET } = await import('@/app/api/exchange-rate/route')
+    await GET()
+
+    const calledUrl = (global.fetch as jest.Mock).mock.calls[0][0] as string
+    expect(calledUrl).toContain('coingecko.com')
+    expect(calledUrl).toContain('ngn')
+    expect(calledUrl).toContain('kes')
+    expect(calledUrl).toContain('ghs')
+    expect(calledUrl).toContain('zar')
+    expect(calledUrl).toContain('ugx')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// create-order
+// ---------------------------------------------------------------------------
+
+describe('POST /api/onramp/create-order', () => {
+  beforeEach(() => {
+    jest.resetModules()
+    jest.useFakeTimers()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it('returns 200 with created order on valid request', async () => {
+    jest.setSystemTime(new Date('2025-01-01T00:00:00Z'))
+
+    const { POST } = await import('@/app/api/onramp/create-order/route')
+
+    const orderData = {
+      orderId: 'ORD-001',
+      userId: 'GABC123',
+      amount: 10000,
+      currency: 'NGN',
+      asset: 'cNGN',
+    }
+
+    const request = new Request('http://localhost/api/onramp/create-order', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(orderData),
+    })
+
+    // Advance timers so the 800ms simulated delay resolves
+    const responsePromise = POST(request)
+    jest.advanceTimersByTime(1000)
+    const response = await responsePromise
+
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.success).toBe(true)
+    expect(data.order.status).toBe('created')
+    expect(data.order.orderId).toBe('ORD-001')
+  })
+
+  it('sets createdAt and expiresAt on the created order', async () => {
+    jest.setSystemTime(new Date('2025-01-01T00:00:00Z'))
+    const now = Date.now()
+
+    const { POST } = await import('@/app/api/onramp/create-order/route')
+
+    const request = new Request('http://localhost/api/onramp/create-order', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orderId: 'ORD-002', amount: 5000, currency: 'KES' }),
+    })
+
+    const responsePromise = POST(request)
+    jest.advanceTimersByTime(1000)
+    const response = await responsePromise
+
+    const data = await response.json()
+
+    expect(data.order.createdAt).toBe(now)
+    // expiresAt = createdAt + 15 minutes
+    expect(data.order.expiresAt).toBe(now + 15 * 60 * 1000)
+  })
+
+  it('returns 500 when request body is invalid JSON', async () => {
+    const { POST } = await import('@/app/api/onramp/create-order/route')
+
+    const request = new Request('http://localhost/api/onramp/create-order', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not valid json{{{',
+    })
+
+    const responsePromise = POST(request)
+    jest.advanceTimersByTime(1000)
+    const response = await responsePromise
+
+    expect(response.status).toBe(500)
+    const data = await response.json()
+    expect(data.success).toBe(false)
+  })
+
+  it('includes the message "Order created successfully"', async () => {
+    const { POST } = await import('@/app/api/onramp/create-order/route')
+
+    const request = new Request('http://localhost/api/onramp/create-order', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ orderId: 'ORD-003' }),
+    })
+
+    const responsePromise = POST(request)
+    jest.advanceTimersByTime(1000)
+    const response = await responsePromise
+
+    const data = await response.json()
+    expect(data.message).toBe('Order created successfully')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// withdrawals
+// ---------------------------------------------------------------------------
+
+describe('POST /api/withdrawals', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('returns 200 with orderId when TIER_1 user is within daily limit', async () => {
+    const { POST } = await import('@/app/api/withdrawals/route')
+
+    const request = new Request('http://localhost/api/withdrawals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        userId: `user_${Date.now()}_${Math.random()}`,
+        amountCents: 100_00, // $100
+        asset: 'cNGN',
+        chain: 'Stellar',
+        kycTier: 'TIER_1',
+      }),
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.orderId).toMatch(/^OFF-/)
+    expect(data.status).toBe('pending')
+    expect(data.asset).toBe('cNGN')
+  })
+
+  it('returns 403 when TIER_0 user attempts a withdrawal', async () => {
+    const { POST } = await import('@/app/api/withdrawals/route')
+
+    const request = new Request('http://localhost/api/withdrawals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        userId: `tier0_${Date.now()}`,
+        amountCents: 1,
+        asset: 'cNGN',
+        chain: 'Stellar',
+        kycTier: 'TIER_0',
+      }),
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(403)
+    expect(data.error).toBe('WITHDRAWAL_LIMIT_EXCEEDED')
+  })
+
+  it('returns 403 when TIER_1 user exceeds the $1,000 daily limit', async () => {
+    const { POST } = await import('@/app/api/withdrawals/route')
+
+    // Use a unique userId so it is not affected by other tests
+    const userId = `tier1_exceed_${Date.now()}_${Math.random()}`
+
+    // Seed state via first request that fills the limit
+    await POST(
+      new Request('http://localhost/api/withdrawals', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId, amountCents: 1_000_00, asset: 'cNGN', chain: 'Stellar', kycTier: 'TIER_1' }),
+      })
+    )
+
+    // Second request should be rejected
+    const response = await POST(
+      new Request('http://localhost/api/withdrawals', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId, amountCents: 1_00, asset: 'cNGN', chain: 'Stellar', kycTier: 'TIER_1' }),
+      })
+    )
+
+    expect(response.status).toBe(403)
+    const data = await response.json()
+    expect(data.error).toBe('WITHDRAWAL_LIMIT_EXCEEDED')
+  })
+
+  it('returns 400 for invalid JSON body', async () => {
+    const { POST } = await import('@/app/api/withdrawals/route')
+
+    const request = new Request('http://localhost/api/withdrawals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'invalid json{',
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(400)
+    const data = await response.json()
+    expect(data.error).toBe('Invalid JSON body')
+  })
+
+  it('returns 400 when required fields are missing', async () => {
+    const { POST } = await import('@/app/api/withdrawals/route')
+
+    const request = new Request('http://localhost/api/withdrawals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId: 'user123' }), // missing amountCents, asset, chain, kycTier
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(400)
+    const data = await response.json()
+    expect(data.error).toBe('Invalid request')
+  })
+
+  it('returns 400 for invalid kycTier value', async () => {
+    const { POST } = await import('@/app/api/withdrawals/route')
+
+    const request = new Request('http://localhost/api/withdrawals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        userId: 'user123',
+        amountCents: 100,
+        asset: 'cNGN',
+        chain: 'Stellar',
+        kycTier: 'INVALID_TIER',
+      }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(400)
+  })
+
+  it('TIER_3 user is always allowed regardless of amount', async () => {
+    const { POST } = await import('@/app/api/withdrawals/route')
+
+    const request = new Request('http://localhost/api/withdrawals', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        userId: `tier3_${Date.now()}`,
+        amountCents: 99_999_99,
+        asset: 'USDC',
+        chain: 'Stellar',
+        kycTier: 'TIER_3',
+      }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(200)
+  })
+
+  it('response includes remaining and resetAt fields', async () => {
+    const { POST } = await import('@/app/api/withdrawals/route')
+
+    const response = await POST(
+      new Request('http://localhost/api/withdrawals', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          userId: `fields_${Date.now()}`,
+          amountCents: 5_000,
+          asset: 'cNGN',
+          chain: 'Stellar',
+          kycTier: 'TIER_1',
+        }),
+      })
+    )
+
+    const data = await response.json()
+    expect(response.status).toBe(200)
+    expect('remaining' in data).toBe(true)
+    expect('resetAt' in data).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// referral
+// ---------------------------------------------------------------------------
+
+describe('GET /api/referral', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('returns 400 when wallet param is missing', async () => {
+    const { GET } = await import('@/app/api/referral/route')
+    const request = new Request('http://localhost/api/referral')
+    const response = await GET(request)
+
+    expect(response.status).toBe(400)
+    const data = await response.json()
+    expect(data.error).toBe('wallet required')
+  })
+
+  it('returns a referral record with code, ownerAddress, and referees', async () => {
+    const { GET } = await import('@/app/api/referral/route')
+    const wallet = 'GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3TNFWQQE6'
+    const request = new Request(`http://localhost/api/referral?wallet=${wallet}`)
+    const response = await GET(request)
+
+    expect(response.status).toBe(200)
+    const data = await response.json()
+    expect(data.code).toBeTruthy()
+    expect(data.ownerAddress).toBe(wallet)
+    expect(Array.isArray(data.referees)).toBe(true)
+    expect(typeof data.totalRebatesEarned).toBe('number')
+    expect(typeof data.createdAt).toBe('number')
+  })
+
+  it('returns the same code on repeated calls for the same wallet', async () => {
+    const { GET } = await import('@/app/api/referral/route')
+    const wallet = 'GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3TNFWQQE6'
+    const req1 = new Request(`http://localhost/api/referral?wallet=${wallet}`)
+    const req2 = new Request(`http://localhost/api/referral?wallet=${wallet}`)
+
+    const r1 = await (await GET(req1)).json()
+    const r2 = await (await GET(req2)).json()
+
+    expect(r1.code).toBe(r2.code)
+  })
+
+  it('referral code starts with AFR-', async () => {
+    const { GET } = await import('@/app/api/referral/route')
+    const wallet = 'GBPXEZPKDQMTQPXHDKVMPJF5GGMEXNWRDANL7HZNFMLFK2AEY5MLJK2'
+    const request = new Request(`http://localhost/api/referral?wallet=${wallet}`)
+    const response = await GET(request)
+    const data = await response.json()
+
+    expect(data.code).toMatch(/^AFR-/)
+  })
+})
+
+describe('POST /api/referral', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('returns 400 when code or refereeWallet is missing', async () => {
+    const { POST } = await import('@/app/api/referral/route')
+
+    const request = new Request('http://localhost/api/referral', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: 'AFR-TEST-1234' }), // missing refereeWallet
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(400)
+    const data = await response.json()
+    expect(data.error).toBe('code and refereeWallet required')
+  })
+
+  it('returns 404 for an unknown referral code', async () => {
+    const { POST } = await import('@/app/api/referral/route')
+
+    const response = await POST(
+      new Request('http://localhost/api/referral', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code: 'AFR-XXXX-9999', refereeWallet: 'GNEWWALLET' }),
+      })
+    )
+
+    expect(response.status).toBe(404)
+    const data = await response.json()
+    expect(data.error).toBe('Invalid referral code')
+  })
+
+  it('returns 400 when the owner tries to use their own code', async () => {
+    // First create the code via GET
+    const ownerWallet = 'GSELFUSE_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+
+    const { GET, POST } = await import('@/app/api/referral/route')
+    const getResponse = await GET(new Request(`http://localhost/api/referral?wallet=${ownerWallet}`))
+    const { code } = await getResponse.json()
+
+    const postResponse = await POST(
+      new Request('http://localhost/api/referral', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code, refereeWallet: ownerWallet }),
+      })
+    )
+
+    expect(postResponse.status).toBe(400)
+    const data = await postResponse.json()
+    expect(data.error).toBe('Cannot use your own referral code')
+  })
+
+  it('returns 200 with discountPct when a valid code is applied', async () => {
+    const ownerWallet = 'GOWNER_BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+    const refereeWallet = 'GREFEREE_CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC'
+
+    const { GET, POST } = await import('@/app/api/referral/route')
+    const getResponse = await GET(new Request(`http://localhost/api/referral?wallet=${ownerWallet}`))
+    const { code } = await getResponse.json()
+
+    const postResponse = await POST(
+      new Request('http://localhost/api/referral', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code, refereeWallet }),
+      })
+    )
+
+    expect(postResponse.status).toBe(200)
+    const data = await postResponse.json()
+    expect(data.success).toBe(true)
+    expect(data.discountPct).toBe(10)
+  })
+
+  it('returns 409 when the same wallet tries to use the code twice', async () => {
+    const ownerWallet = 'GOWNER_DDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD'
+    const refereeWallet = 'GREFEREE_EEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE'
+
+    const { GET, POST } = await import('@/app/api/referral/route')
+    const getResponse = await GET(new Request(`http://localhost/api/referral?wallet=${ownerWallet}`))
+    const { code } = await getResponse.json()
+
+    // First use — should succeed
+    await POST(
+      new Request('http://localhost/api/referral', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code, refereeWallet }),
+      })
+    )
+
+    // Second use — should be rejected
+    const secondResponse = await POST(
+      new Request('http://localhost/api/referral', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ code, refereeWallet }),
+      })
+    )
+
+    expect(secondResponse.status).toBe(409)
+    const data = await secondResponse.json()
+    expect(data.error).toBe('Code already used by this wallet')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// bills/initiate
+// ---------------------------------------------------------------------------
+
+describe('POST /api/bills/initiate', () => {
+  beforeEach(() => {
+    jest.resetModules()
+  })
+
+  it('returns 400 when required fields are missing', async () => {
+    const { POST } = await import('@/app/api/bills/initiate/route')
+
+    const request = new Request('http://localhost/api/bills/initiate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        billerId: 'DSTV',
+        // missing accountNumber, amount, customerEmail
+      }),
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(400)
+    const data = await response.json()
+    expect(data.error).toBe('Missing required fields')
+  })
+
+  it('returns 200 with authorization_url and reference on success', async () => {
+    // Mock the Paystack API call
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          data: {
+            authorization_url: 'https://paystack.com/pay/test-ref',
+            reference: 'TEST-REF-001',
+          },
+        }),
+    })
+
+    const { POST } = await import('@/app/api/bills/initiate/route')
+
+    const request = new Request('http://localhost/api/bills/initiate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        billerId: 'DSTV',
+        billerName: 'DSTV Subscription',
+        accountNumber: '1234567890',
+        amount: 5000,
+        customerEmail: 'user@example.com',
+        customerPhone: '+2348012345678',
+        paymentMethod: 'card',
+        gateway: 'paystack',
+      }),
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.success).toBe(true)
+    expect(data.authorization_url).toBeTruthy()
+    expect(data.reference).toBeTruthy()
+  })
+
+  it('generates a unique BILL- reference for each request', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          data: { authorization_url: 'https://paystack.com/pay/ref', reference: 'paystack-ref' },
+        }),
+    })
+
+    const { POST } = await import('@/app/api/bills/initiate/route')
+
+    const makeRequest = () =>
+      POST(
+        new Request('http://localhost/api/bills/initiate', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            billerId: 'ELECTRICITY',
+            billerName: 'NEPA',
+            accountNumber: '9876543210',
+            amount: 2000,
+            customerEmail: 'power@example.com',
+          }),
+        })
+      )
+
+    const [r1, r2] = await Promise.all([makeRequest(), makeRequest()])
+    const [d1, d2] = await Promise.all([r1.json(), r2.json()])
+
+    // References should be unique
+    expect(d1.reference).not.toBe(d2.reference)
+  })
+
+  it('reference starts with BILL-', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          data: { authorization_url: 'https://paystack.com/pay/ref', reference: 'paystack-ref' },
+        }),
+    })
+
+    const { POST } = await import('@/app/api/bills/initiate/route')
+
+    const response = await POST(
+      new Request('http://localhost/api/bills/initiate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          billerId: 'CABLE',
+          billerName: 'StarTimes',
+          accountNumber: '111222333',
+          amount: 3000,
+          customerEmail: 'tv@example.com',
+        }),
+      })
+    )
+
+    const data = await response.json()
+    expect(data.reference).toMatch(/^BILL-/)
+  })
+
+  it('returns 500 when Paystack API throws an error', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('Paystack unavailable'))
+
+    const { POST } = await import('@/app/api/bills/initiate/route')
+
+    const response = await POST(
+      new Request('http://localhost/api/bills/initiate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          billerId: 'DSTV',
+          billerName: 'DSTV',
+          accountNumber: '1234567890',
+          amount: 5000,
+          customerEmail: 'user@example.com',
+        }),
+      })
+    )
+
+    expect(response.status).toBe(500)
+    const data = await response.json()
+    expect(data.error).toBe('Failed to initiate payment')
+  })
+
+  it('passes metadata including billerId, billerName, and accountNumber to the gateway', async () => {
+    const mockFetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          data: { authorization_url: 'https://paystack.com/pay/ref', reference: 'ref-001' },
+        }),
+    })
+    global.fetch = mockFetch
+
+    const { POST } = await import('@/app/api/bills/initiate/route')
+
+    await POST(
+      new Request('http://localhost/api/bills/initiate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          billerId: 'GOTV',
+          billerName: 'GOtv Subscription',
+          accountNumber: '5551234567',
+          amount: 1500,
+          customerEmail: 'gotv@example.com',
+        }),
+      })
+    )
+
+    const body = JSON.parse((mockFetch.mock.calls[0] as [string, { body: string }])[1].body)
+    expect(body.metadata.billerId).toBe('GOTV')
+    expect(body.metadata.billerName).toBe('GOtv Subscription')
+    expect(body.metadata.accountNumber).toBe('5551234567')
+  })
+})

--- a/lib/__tests__/stellar-offramp.test.ts
+++ b/lib/__tests__/stellar-offramp.test.ts
@@ -1,0 +1,350 @@
+/**
+ * Tests for lib/offramp/stellar-offramp.ts — buildOfframpPaymentXdr
+ *
+ * Covers:
+ *  - XDR builds correctly for XLM native asset
+ *  - XDR builds correctly for cNGN with a configured issuer
+ *  - Falls back to native asset for unknown asset codes
+ *  - Correct destination, amount, and fee are passed to the operation
+ *  - Memo is added when provided and truncated at 28 chars
+ *  - No memo is added when memo is not provided
+ *  - TESTNET vs PUBLIC Horizon URL selection
+ *  - TESTNET vs PUBLIC network passphrase selection
+ *  - setTimeout(300) is called
+ *  - Returns the XDR string from the built transaction
+ */
+
+import { buildOfframpPaymentXdr } from '../offramp/stellar-offramp'
+
+// ---------------------------------------------------------------------------
+// Mock @stellar/stellar-sdk
+// ---------------------------------------------------------------------------
+
+const mockBuild = jest.fn()
+const mockToXDR = jest.fn().mockReturnValue('OFFRAMP_XDR==')
+const mockSetTimeout = jest.fn().mockReturnThis()
+const mockAddMemo = jest.fn().mockReturnThis()
+const mockAddOperation = jest.fn().mockReturnThis()
+
+const mockBuilder = {
+  addOperation: mockAddOperation,
+  addMemo: mockAddMemo,
+  setTimeout: mockSetTimeout,
+  build: mockBuild,
+}
+
+mockBuild.mockReturnValue({ toXDR: mockToXDR })
+
+const mockLoadAccount = jest.fn()
+const mockFetchBaseFee = jest.fn().mockResolvedValue(100)
+
+const MockServer = jest.fn().mockImplementation(() => ({
+  loadAccount: mockLoadAccount,
+  fetchBaseFee: mockFetchBaseFee,
+}))
+
+const nativeAsset = { isNative: () => true }
+const MockAssetNative = jest.fn().mockReturnValue(nativeAsset)
+const MockAsset = jest.fn().mockImplementation((code: string, issuer: string) => ({
+  code,
+  issuer,
+  isNative: () => false,
+}))
+MockAsset.native = MockAssetNative
+
+const MockMemoText = jest.fn().mockImplementation((text: string) => ({ type: 'text', text }))
+const MockMemo = { text: MockMemoText }
+
+const MockNetworks = {
+  PUBLIC: 'Public Global Stellar Network ; September 2015',
+  TESTNET: 'Test SDF Network ; September 2015',
+}
+
+const mockPaymentOp = jest.fn().mockReturnValue({ type: 'payment' })
+const MockOperation = { payment: mockPaymentOp }
+
+const MockTransactionBuilder = jest.fn().mockImplementation(() => mockBuilder)
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  __esModule: true,
+  default: MockServer,
+  Asset: MockAsset,
+  Memo: MockMemo,
+  Networks: MockNetworks,
+  Operation: MockOperation,
+  TransactionBuilder: MockTransactionBuilder,
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SOURCE_KEY = 'GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3TNFWQQE6'
+const DEST_KEY   = 'GBPXEZPKDQMTQPXHDKVMPJF5GGMEXNWRDANL7HZNFMLFK2AEY5MLJK2'
+const CNGN_ISSUER = 'GCNGN_ISSUER_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockFetchBaseFee.mockResolvedValue(100)
+  mockLoadAccount.mockResolvedValue({ id: SOURCE_KEY, sequence: '1' })
+  mockBuild.mockReturnValue({ toXDR: mockToXDR })
+  MockTransactionBuilder.mockImplementation(() => mockBuilder)
+  process.env.NEXT_PUBLIC_CNGN_ISSUER = CNGN_ISSUER
+})
+
+// ---------------------------------------------------------------------------
+// XDR build
+// ---------------------------------------------------------------------------
+
+describe('buildOfframpPaymentXdr — XDR build', () => {
+  it('returns the XDR string from the built transaction', async () => {
+    const xdr = await buildOfframpPaymentXdr({
+      sourcePublicKey: SOURCE_KEY,
+      destination: DEST_KEY,
+      amount: 100,
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(xdr).toBe('OFFRAMP_XDR==')
+  })
+
+  it('calls setTimeout(300) on the builder', async () => {
+    await buildOfframpPaymentXdr({
+      sourcePublicKey: SOURCE_KEY,
+      destination: DEST_KEY,
+      amount: 50,
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(mockSetTimeout).toHaveBeenCalledWith(300)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Asset selection
+// ---------------------------------------------------------------------------
+
+describe('buildOfframpPaymentXdr — asset selection', () => {
+  it('uses Asset.native() for XLM', async () => {
+    await buildOfframpPaymentXdr({
+      sourcePublicKey: SOURCE_KEY,
+      destination: DEST_KEY,
+      amount: 10,
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(MockAssetNative).toHaveBeenCalled()
+    expect(MockAsset).not.toHaveBeenCalled()
+  })
+
+  it('creates cNGN Asset with correct issuer when NEXT_PUBLIC_CNGN_ISSUER is set', async () => {
+    await buildOfframpPaymentXdr({
+      sourcePublicKey: SOURCE_KEY,
+      destination: DEST_KEY,
+      amount: 1000,
+      assetCode: 'cNGN',
+      network: 'PUBLIC',
+    })
+
+    expect(MockAsset).toHaveBeenCalledWith('cNGN', CNGN_ISSUER)
+  })
+
+  it('falls back to native asset when assetCode is cNGN but CNGN_ISSUER is not set', async () => {
+    process.env.NEXT_PUBLIC_CNGN_ISSUER = ''
+
+    await buildOfframpPaymentXdr({
+      sourcePublicKey: SOURCE_KEY,
+      destination: DEST_KEY,
+      amount: 500,
+      assetCode: 'cNGN',
+      network: 'PUBLIC',
+    })
+
+    // When issuer is empty, it falls back to native
+    expect(MockAssetNative).toHaveBeenCalled()
+  })
+
+  it('falls back to native asset for unknown asset codes (e.g. USDC without configured issuer)', async () => {
+    await buildOfframpPaymentXdr({
+      sourcePublicKey: SOURCE_KEY,
+      destination: DEST_KEY,
+      amount: 200,
+      assetCode: 'USDC',
+      network: 'PUBLIC',
+    })
+
+    expect(MockAssetNative).toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Payment operation parameters
+// ---------------------------------------------------------------------------
+
+describe('buildOfframpPaymentXdr — payment operation params', () => {
+  it('passes the correct destination to the payment operation', async () => {
+    await buildOfframpPaymentXdr({
+      sourcePublicKey: SOURCE_KEY,
+      destination: DEST_KEY,
+      amount: 100,
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(mockPaymentOp).toHaveBeenCalledWith(
+      expect.objectContaining({ destination: DEST_KEY })
+    )
+  })
+
+  it('converts numeric amount to string for the payment operation', async () => {
+    await buildOfframpPaymentXdr({
+      sourcePublicKey: SOURCE_KEY,
+      destination: DEST_KEY,
+      amount: 750,
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(mockPaymentOp).toHaveBeenCalledWith(
+      expect.objectContaining({ amount: '750' })
+    )
+  })
+
+  it('sets fee from Horizon fetchBaseFee on the TransactionBuilder', async () => {
+    mockFetchBaseFee.mockResolvedValue(500)
+
+    await buildOfframpPaymentXdr({
+      sourcePublicKey: SOURCE_KEY,
+      destination: DEST_KEY,
+      amount: 10,
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(MockTransactionBuilder).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ fee: '500' })
+    )
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Memo handling
+// ---------------------------------------------------------------------------
+
+describe('buildOfframpPaymentXdr — memo', () => {
+  it('adds a text memo when memo is provided', async () => {
+    await buildOfframpPaymentXdr({
+      sourcePublicKey: SOURCE_KEY,
+      destination: DEST_KEY,
+      amount: 100,
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+      memo: 'Offramp order 123',
+    })
+
+    expect(MockMemoText).toHaveBeenCalledWith('Offramp order 123')
+    expect(mockAddMemo).toHaveBeenCalled()
+  })
+
+  it('truncates memo to 28 characters', async () => {
+    const longMemo = 'This is a memo that is longer than twenty-eight characters'
+    await buildOfframpPaymentXdr({
+      sourcePublicKey: SOURCE_KEY,
+      destination: DEST_KEY,
+      amount: 100,
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+      memo: longMemo,
+    })
+
+    expect(MockMemoText).toHaveBeenCalledWith(longMemo.slice(0, 28))
+  })
+
+  it('does not add memo when memo is undefined', async () => {
+    await buildOfframpPaymentXdr({
+      sourcePublicKey: SOURCE_KEY,
+      destination: DEST_KEY,
+      amount: 100,
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(mockAddMemo).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// Network / Horizon URL selection
+// ---------------------------------------------------------------------------
+
+describe('buildOfframpPaymentXdr — network selection', () => {
+  it('uses TESTNET Horizon URL when network is TESTNET', async () => {
+    await buildOfframpPaymentXdr({
+      sourcePublicKey: SOURCE_KEY,
+      destination: DEST_KEY,
+      amount: 10,
+      assetCode: 'XLM',
+      network: 'TESTNET',
+    })
+
+    expect(MockServer).toHaveBeenCalledWith('https://horizon-testnet.stellar.org')
+  })
+
+  it('uses PUBLIC Horizon URL when network is PUBLIC', async () => {
+    await buildOfframpPaymentXdr({
+      sourcePublicKey: SOURCE_KEY,
+      destination: DEST_KEY,
+      amount: 10,
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(MockServer).toHaveBeenCalledWith('https://horizon.stellar.org')
+  })
+
+  it('uses PUBLIC Horizon URL when network is null', async () => {
+    await buildOfframpPaymentXdr({
+      sourcePublicKey: SOURCE_KEY,
+      destination: DEST_KEY,
+      amount: 10,
+      assetCode: 'XLM',
+      network: null,
+    })
+
+    expect(MockServer).toHaveBeenCalledWith('https://horizon.stellar.org')
+  })
+
+  it('uses TESTNET network passphrase when network is TESTNET', async () => {
+    await buildOfframpPaymentXdr({
+      sourcePublicKey: SOURCE_KEY,
+      destination: DEST_KEY,
+      amount: 10,
+      assetCode: 'XLM',
+      network: 'TESTNET',
+    })
+
+    expect(MockTransactionBuilder).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ networkPassphrase: MockNetworks.TESTNET })
+    )
+  })
+
+  it('uses PUBLIC network passphrase when network is PUBLIC', async () => {
+    await buildOfframpPaymentXdr({
+      sourcePublicKey: SOURCE_KEY,
+      destination: DEST_KEY,
+      amount: 10,
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(MockTransactionBuilder).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ networkPassphrase: MockNetworks.PUBLIC })
+    )
+  })
+})

--- a/lib/__tests__/stellar-p2p.test.ts
+++ b/lib/__tests__/stellar-p2p.test.ts
@@ -1,0 +1,469 @@
+/**
+ * Tests for lib/stellar-p2p.ts
+ *
+ * Covers:
+ *  - isValidStellarAddress — valid and invalid inputs
+ *  - estimateStellarFee — returns XLM fee string, uses correct Horizon URL
+ *  - sendStellarP2P — XDR builds correctly for given params
+ *                   — correct asset codes and issuers are used
+ *                   — memo is applied correctly (and truncated at 28 chars)
+ *                   — fee from Horizon is forwarded to TransactionBuilder
+ *                   — error: invalid destination address
+ *                   — error: server.loadAccount throws
+ *                   — error: Freighter signing fails
+ *                   — error: submitTransaction throws
+ *                   — XLM native asset vs. custom asset branch
+ */
+
+import { isValidStellarAddress, estimateStellarFee, sendStellarP2P } from '../stellar-p2p'
+
+// ---------------------------------------------------------------------------
+// Mock @stellar/stellar-sdk
+// ---------------------------------------------------------------------------
+
+const mockBuild = jest.fn()
+const mockToXDR = jest.fn().mockReturnValue('AAAA==')
+const mockSetTimeout = jest.fn().mockReturnThis()
+const mockAddMemo = jest.fn().mockReturnThis()
+const mockAddOperation = jest.fn().mockReturnThis()
+
+const mockBuilder = {
+  addOperation: mockAddOperation,
+  addMemo: mockAddMemo,
+  setTimeout: mockSetTimeout,
+  build: mockBuild,
+}
+
+mockBuild.mockReturnValue({ toXDR: mockToXDR })
+
+const mockLoadAccount = jest.fn()
+const mockFetchBaseFee = jest.fn().mockResolvedValue(100)
+const mockSubmitTransaction = jest.fn()
+const mockFromXDR = jest.fn().mockReturnValue({})
+
+const MockServer = jest.fn().mockImplementation(() => ({
+  loadAccount: mockLoadAccount,
+  fetchBaseFee: mockFetchBaseFee,
+  submitTransaction: mockSubmitTransaction,
+}))
+
+const MockAssetNative = jest.fn().mockImplementation(() => ({ isNative: () => true }))
+const MockAsset = jest.fn().mockImplementation((code: string, issuer: string) => ({
+  code,
+  issuer,
+  isNative: () => false,
+}))
+MockAsset.native = MockAssetNative
+
+const MockMemoText = jest.fn().mockImplementation((text: string) => ({ type: 'text', text }))
+const MockMemo = { text: MockMemoText }
+
+const MockNetworks = { PUBLIC: 'Public Global Stellar Network ; September 2015', TESTNET: 'Test SDF Network ; September 2015' }
+
+const mockPaymentOperation = jest.fn().mockReturnValue({ type: 'payment' })
+const MockOperation = { payment: mockPaymentOperation }
+
+const MockTransactionBuilder = jest.fn().mockImplementation(() => mockBuilder)
+MockTransactionBuilder.fromXDR = mockFromXDR
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  __esModule: true,
+  default: MockServer,
+  Asset: MockAsset,
+  Memo: MockMemo,
+  Networks: MockNetworks,
+  Operation: MockOperation,
+  TransactionBuilder: MockTransactionBuilder,
+}))
+
+// ---------------------------------------------------------------------------
+// Mock Freighter signing
+// ---------------------------------------------------------------------------
+
+const mockSignTransaction = jest.fn()
+
+jest.mock('@/lib/wallet/freighter', () => ({
+  signTransactionWithFreighter: mockSignTransaction,
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const VALID_ADDRESS = 'GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3TNFWQQE6'
+const DEST_ADDRESS  = 'GBPXEZPKDQMTQPXHDKVMPJF5GGMEXNWRDANL7HZNFMLFK2AEY5MLJK2'
+
+function makeStellarAccount() {
+  return { id: VALID_ADDRESS, sequence: '1' }
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockFetchBaseFee.mockResolvedValue(100)
+  mockLoadAccount.mockResolvedValue(makeStellarAccount())
+  mockBuild.mockReturnValue({ toXDR: mockToXDR })
+  mockSignTransaction.mockResolvedValue({ signedTxXdr: 'BBBB==', error: undefined })
+  mockSubmitTransaction.mockResolvedValue({ hash: 'abc123txhash' })
+  MockTransactionBuilder.mockImplementation(() => mockBuilder)
+})
+
+// ---------------------------------------------------------------------------
+// isValidStellarAddress
+// ---------------------------------------------------------------------------
+
+describe('isValidStellarAddress', () => {
+  it('returns true for a valid 56-char G-prefix address', () => {
+    expect(isValidStellarAddress(VALID_ADDRESS)).toBe(true)
+  })
+
+  it('returns false for an address starting with B', () => {
+    expect(isValidStellarAddress('BBPXEZPKDQMTQPXHDKVMPJF5GGMEXNWRDANL7HZNFMLFK2AEY5MLJK2')).toBe(false)
+  })
+
+  it('returns false for an address that is too short', () => {
+    expect(isValidStellarAddress('GABC')).toBe(false)
+  })
+
+  it('returns false for an empty string', () => {
+    expect(isValidStellarAddress('')).toBe(false)
+  })
+
+  it('returns false for an address with lowercase chars', () => {
+    expect(isValidStellarAddress('gahjjjkmokye4rvpzewztkh5fvi4pa3vl7gk2lfnubsgbv3tnfwqqe6')).toBe(false)
+  })
+
+  it('returns false for an address with invalid characters', () => {
+    // Contains '0', '1', '8', '9' which are not in base32 charset
+    const invalid = 'G0HJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3TNFWQQE6'
+    expect(isValidStellarAddress(invalid)).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// estimateStellarFee
+// ---------------------------------------------------------------------------
+
+describe('estimateStellarFee', () => {
+  it('converts base fee in stroops to XLM string', async () => {
+    mockFetchBaseFee.mockResolvedValue(100)
+    const fee = await estimateStellarFee('PUBLIC')
+    // 100 stroops / 10_000_000 = 0.0000100 XLM
+    expect(fee).toBe('0.0000100')
+  })
+
+  it('uses the TESTNET Horizon URL when network is TESTNET', async () => {
+    await estimateStellarFee('TESTNET')
+    expect(MockServer).toHaveBeenCalledWith('https://horizon-testnet.stellar.org')
+  })
+
+  it('uses the PUBLIC Horizon URL when network is PUBLIC', async () => {
+    await estimateStellarFee('PUBLIC')
+    expect(MockServer).toHaveBeenCalledWith('https://horizon.stellar.org')
+  })
+
+  it('falls back to PUBLIC Horizon URL when network is null', async () => {
+    await estimateStellarFee(null)
+    expect(MockServer).toHaveBeenCalledWith('https://horizon.stellar.org')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sendStellarP2P — invalid destination
+// ---------------------------------------------------------------------------
+
+describe('sendStellarP2P — validation', () => {
+  it('returns error for invalid destination address', async () => {
+    const result = await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: 'not-a-stellar-address',
+      amount: '10',
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+    expect(result.txHash).toBe('')
+    expect(result.error).toBe('Invalid destination address')
+    // Should not even hit Horizon
+    expect(mockLoadAccount).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sendStellarP2P — XDR build correctness
+// ---------------------------------------------------------------------------
+
+describe('sendStellarP2P — XDR build', () => {
+  it('builds a payment operation with the correct destination, asset, and amount', async () => {
+    await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '25.5',
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(mockPaymentOperation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        destination: DEST_ADDRESS,
+        amount: '25.5',
+      })
+    )
+  })
+
+  it('uses Asset.native() for XLM asset code', async () => {
+    await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '1',
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(MockAssetNative).toHaveBeenCalled()
+  })
+
+  it('creates a custom Asset for non-XLM asset code with provided issuer', async () => {
+    const issuer = 'GAISSUERADDRESSAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+    await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '50',
+      assetCode: 'cNGN',
+      assetIssuer: issuer,
+      network: 'PUBLIC',
+    })
+
+    expect(MockAsset).toHaveBeenCalledWith('cNGN', issuer)
+  })
+
+  it('falls back to sourcePublicKey as issuer when assetIssuer is not provided', async () => {
+    await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '10',
+      assetCode: 'USDC',
+      network: 'PUBLIC',
+    })
+
+    expect(MockAsset).toHaveBeenCalledWith('USDC', VALID_ADDRESS)
+  })
+
+  it('sets the fee from Horizon fetchBaseFee on the TransactionBuilder', async () => {
+    mockFetchBaseFee.mockResolvedValue(200)
+
+    await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '5',
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(MockTransactionBuilder).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ fee: '200' })
+    )
+  })
+
+  it('uses PUBLIC network passphrase when network is PUBLIC', async () => {
+    await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '1',
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(MockTransactionBuilder).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ networkPassphrase: MockNetworks.PUBLIC })
+    )
+  })
+
+  it('uses TESTNET network passphrase when network is TESTNET', async () => {
+    await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '1',
+      assetCode: 'XLM',
+      network: 'TESTNET',
+    })
+
+    expect(MockTransactionBuilder).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ networkPassphrase: MockNetworks.TESTNET })
+    )
+  })
+
+  it('calls setTimeout(300) on the builder', async () => {
+    await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '1',
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(mockSetTimeout).toHaveBeenCalledWith(300)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sendStellarP2P — memo handling
+// ---------------------------------------------------------------------------
+
+describe('sendStellarP2P — memo', () => {
+  it('adds a text memo when memo is provided', async () => {
+    await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '1',
+      assetCode: 'XLM',
+      memo: 'Invoice #42',
+      network: 'PUBLIC',
+    })
+
+    expect(MockMemoText).toHaveBeenCalledWith('Invoice #42')
+    expect(mockAddMemo).toHaveBeenCalled()
+  })
+
+  it('truncates memo to 28 characters', async () => {
+    const longMemo = 'This memo is definitely longer than 28 characters long'
+    await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '1',
+      assetCode: 'XLM',
+      memo: longMemo,
+      network: 'PUBLIC',
+    })
+
+    expect(MockMemoText).toHaveBeenCalledWith(longMemo.trim().slice(0, 28))
+  })
+
+  it('does not add memo when memo is undefined', async () => {
+    await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '1',
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(mockAddMemo).not.toHaveBeenCalled()
+  })
+
+  it('does not add memo when memo is empty string', async () => {
+    await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '1',
+      assetCode: 'XLM',
+      memo: '   ',
+      network: 'PUBLIC',
+    })
+
+    expect(mockAddMemo).not.toHaveBeenCalled()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sendStellarP2P — success flow
+// ---------------------------------------------------------------------------
+
+describe('sendStellarP2P — success', () => {
+  it('returns txHash on success', async () => {
+    mockSubmitTransaction.mockResolvedValue({ hash: 'deadbeef' })
+
+    const result = await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '10',
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(result.txHash).toBe('deadbeef')
+    expect(result.error).toBeUndefined()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// sendStellarP2P — error cases
+// ---------------------------------------------------------------------------
+
+describe('sendStellarP2P — errors', () => {
+  it('returns error when loadAccount throws', async () => {
+    mockLoadAccount.mockRejectedValue(new Error('Account not found'))
+
+    const result = await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '10',
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(result.txHash).toBe('')
+    expect(result.error).toBe('Account not found')
+  })
+
+  it('returns error when Freighter signing returns an error', async () => {
+    mockSignTransaction.mockResolvedValue({ signedTxXdr: '', error: 'User rejected' })
+
+    const result = await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '10',
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(result.txHash).toBe('')
+    expect(result.error).toBe('User rejected')
+  })
+
+  it('returns "Signing failed" when signedTxXdr is empty with no error message', async () => {
+    mockSignTransaction.mockResolvedValue({ signedTxXdr: '', error: undefined })
+
+    const result = await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '10',
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(result.txHash).toBe('')
+    expect(result.error).toBe('Signing failed')
+  })
+
+  it('returns error when submitTransaction throws', async () => {
+    mockSubmitTransaction.mockRejectedValue(new Error('Insufficient balance'))
+
+    const result = await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '10',
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(result.txHash).toBe('')
+    expect(result.error).toBe('Insufficient balance')
+  })
+
+  it('returns "Transaction failed" for non-Error throws', async () => {
+    mockSubmitTransaction.mockRejectedValue('string error')
+
+    const result = await sendStellarP2P({
+      sourcePublicKey: VALID_ADDRESS,
+      destination: DEST_ADDRESS,
+      amount: '10',
+      assetCode: 'XLM',
+      network: 'PUBLIC',
+    })
+
+    expect(result.txHash).toBe('')
+    expect(result.error).toBe('Transaction failed')
+  })
+})

--- a/lib/__tests__/stellar-swap.test.ts
+++ b/lib/__tests__/stellar-swap.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Tests for lib/swap/stellar-swap.ts
+ *
+ * Covers:
+ *  - simulateSwap — successful path with best-path selection
+ *               — throws when fetch is not ok
+ *               — throws when no swap path found (empty records)
+ *               — selects the path with the highest destination_amount
+ *               — slippage is applied to minReceived correctly
+ *               — rate calculation
+ *               — asset resolution (XLM native vs custom with issuer)
+ *               — unknown asset issuer throws
+ *  - buildSwapXdr — calls pathPaymentStrictSend with correct params
+ *                 — uses correct network passphrase
+ *                 — self-swap destination is sourcePublicKey
+ *                 — returns an XDR string
+ */
+
+import { simulateSwap, buildSwapXdr, type SwapSimulation } from '../swap/stellar-swap'
+
+// ---------------------------------------------------------------------------
+// Mock @stellar/stellar-sdk
+// ---------------------------------------------------------------------------
+
+const mockBuild = jest.fn()
+const mockToXDR = jest.fn().mockReturnValue('CCCC==')
+const mockSetTimeout = jest.fn().mockReturnThis()
+const mockAddOperation = jest.fn().mockReturnThis()
+
+const mockBuilder = {
+  addOperation: mockAddOperation,
+  setTimeout: mockSetTimeout,
+  build: mockBuild,
+}
+
+mockBuild.mockReturnValue({ toXDR: mockToXDR })
+
+const mockLoadAccount = jest.fn()
+const mockFetchBaseFee = jest.fn().mockResolvedValue(100)
+
+const MockServer = jest.fn().mockImplementation(() => ({
+  loadAccount: mockLoadAccount,
+  fetchBaseFee: mockFetchBaseFee,
+}))
+
+const nativeAsset = { isNative: () => true, getCode: () => 'XLM', getIssuer: () => '' }
+const MockAssetNative = jest.fn().mockReturnValue(nativeAsset)
+const MockAsset = jest.fn().mockImplementation((code: string, issuer: string) => ({
+  code,
+  issuer,
+  isNative: () => false,
+  getCode: () => code,
+  getIssuer: () => issuer,
+}))
+MockAsset.native = MockAssetNative
+
+const MockNetworks = {
+  PUBLIC: 'Public Global Stellar Network ; September 2015',
+  TESTNET: 'Test SDF Network ; September 2015',
+}
+
+const mockPathPaymentOp = jest.fn().mockReturnValue({ type: 'pathPaymentStrictSend' })
+const MockOperation = { pathPaymentStrictSend: mockPathPaymentOp }
+
+const MockTransactionBuilder = jest.fn().mockImplementation(() => mockBuilder)
+
+jest.mock('@stellar/stellar-sdk', () => ({
+  __esModule: true,
+  default: MockServer,
+  Asset: MockAsset,
+  Networks: MockNetworks,
+  Operation: MockOperation,
+  TransactionBuilder: MockTransactionBuilder,
+}))
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SOURCE_KEY = 'GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3TNFWQQE6'
+
+function mockFetch(responses: Array<{ ok: boolean; status?: number; body?: unknown }>) {
+  let callIndex = 0
+  return jest.fn().mockImplementation(() => {
+    const res = responses[callIndex] ?? responses[responses.length - 1]
+    callIndex++
+    return Promise.resolve({
+      ok: res.ok,
+      status: res.status ?? (res.ok ? 200 : 400),
+      json: () => Promise.resolve(res.body ?? {}),
+    })
+  })
+}
+
+function makePathRecord(destinationAmount: string) {
+  return {
+    destination_amount: destinationAmount,
+    path: [
+      { asset_type: 'credit_alphanum4', asset_code: 'USDC', asset_issuer: 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' },
+    ],
+  }
+}
+
+const mockSim: SwapSimulation = {
+  fromAsset: 'cNGN',
+  toAsset: 'USDC',
+  fromAmount: '100',
+  toAmount: '0.0630000',
+  path: [],
+  minReceived: '0.0623700',
+  rate: '0.0006300',
+  fee: '100',
+  slippagePct: 1,
+}
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  mockFetchBaseFee.mockResolvedValue(100)
+  mockLoadAccount.mockResolvedValue({ id: SOURCE_KEY, sequence: '1' })
+  mockBuild.mockReturnValue({ toXDR: mockToXDR })
+  MockTransactionBuilder.mockImplementation(() => mockBuilder)
+  // Ensure NEXT_PUBLIC_CNGN_ISSUER is set so getAsset works for cNGN
+  process.env.NEXT_PUBLIC_CNGN_ISSUER = 'GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3TNFWQQE'
+  process.env.NEXT_PUBLIC_USDC_ISSUER = 'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN'
+})
+
+// ---------------------------------------------------------------------------
+// simulateSwap
+// ---------------------------------------------------------------------------
+
+describe('simulateSwap — success', () => {
+  it('returns a simulation object with correct fields', async () => {
+    global.fetch = mockFetch([
+      {
+        ok: true,
+        body: { _embedded: { records: [makePathRecord('0.0630000')] } },
+      },
+    ])
+
+    const result = await simulateSwap('cNGN', 'USDC', '100', 1, 'PUBLIC')
+
+    expect(result.fromAsset).toBe('cNGN')
+    expect(result.toAsset).toBe('USDC')
+    expect(result.fromAmount).toBe('100')
+    expect(result.toAmount).toBe('0.0630000')
+    expect(result.slippagePct).toBe(1)
+    expect(result.fee).toBe('100')
+  })
+
+  it('applies slippage to minReceived correctly', async () => {
+    global.fetch = mockFetch([
+      {
+        ok: true,
+        body: { _embedded: { records: [makePathRecord('100.0000000')] } },
+      },
+    ])
+
+    // 2% slippage: minReceived = 100 * (1 - 0.02) = 98.0
+    const result = await simulateSwap('XLM', 'cNGN', '1000', 2, 'PUBLIC')
+    expect(parseFloat(result.minReceived)).toBeCloseTo(98, 5)
+  })
+
+  it('calculates rate correctly (toAmount / fromAmount)', async () => {
+    global.fetch = mockFetch([
+      {
+        ok: true,
+        body: { _embedded: { records: [makePathRecord('200.0000000')] } },
+      },
+    ])
+
+    const result = await simulateSwap('XLM', 'cNGN', '100', 0.5, 'PUBLIC')
+    // rate = 200 / 100 = 2.0
+    expect(parseFloat(result.rate)).toBeCloseTo(2.0, 5)
+  })
+
+  it('selects the path with the highest destination_amount', async () => {
+    global.fetch = mockFetch([
+      {
+        ok: true,
+        body: {
+          _embedded: {
+            records: [
+              makePathRecord('50.0000000'),
+              makePathRecord('100.0000000'), // best
+              makePathRecord('75.0000000'),
+            ],
+          },
+        },
+      },
+    ])
+
+    const result = await simulateSwap('cNGN', 'USDC', '1000', 1, 'PUBLIC')
+    expect(result.toAmount).toBe('100.0000000')
+  })
+
+  it('uses the TESTNET Horizon URL when network is TESTNET', async () => {
+    global.fetch = mockFetch([
+      { ok: true, body: { _embedded: { records: [makePathRecord('1.0')] } } },
+    ])
+
+    await simulateSwap('XLM', 'cNGN', '10', 0.5, 'TESTNET')
+
+    const fetchCall = (global.fetch as jest.Mock).mock.calls[0][0] as string
+    expect(fetchCall).toContain('horizon-testnet.stellar.org')
+  })
+
+  it('uses the PUBLIC Horizon URL when network is PUBLIC', async () => {
+    global.fetch = mockFetch([
+      { ok: true, body: { _embedded: { records: [makePathRecord('1.0')] } } },
+    ])
+
+    await simulateSwap('XLM', 'cNGN', '10', 0.5, 'PUBLIC')
+
+    const fetchCall = (global.fetch as jest.Mock).mock.calls[0][0] as string
+    expect(fetchCall).toContain('horizon.stellar.org')
+  })
+
+  it('uses native source_asset_type for XLM', async () => {
+    global.fetch = mockFetch([
+      { ok: true, body: { _embedded: { records: [makePathRecord('50.0')] } } },
+    ])
+
+    await simulateSwap('XLM', 'cNGN', '10', 0.5, 'PUBLIC')
+
+    const fetchCall = (global.fetch as jest.Mock).mock.calls[0][0] as string
+    expect(fetchCall).toContain('source_asset_type=native')
+  })
+
+  it('includes issuer in query for credit asset', async () => {
+    global.fetch = mockFetch([
+      { ok: true, body: { _embedded: { records: [makePathRecord('10.0')] } } },
+    ])
+
+    await simulateSwap('cNGN', 'USDC', '100', 0.5, 'PUBLIC')
+
+    const fetchCall = (global.fetch as jest.Mock).mock.calls[0][0] as string
+    expect(fetchCall).toContain('source_asset_code=cNGN')
+    expect(fetchCall).toContain('source_asset_issuer=')
+  })
+
+  it('maps path records to Asset objects', async () => {
+    global.fetch = mockFetch([
+      {
+        ok: true,
+        body: {
+          _embedded: {
+            records: [
+              {
+                destination_amount: '10.0',
+                path: [{ asset_type: 'native' }],
+              },
+            ],
+          },
+        },
+      },
+    ])
+
+    const result = await simulateSwap('cNGN', 'USDC', '100', 0.5, 'PUBLIC')
+    expect(result.path).toHaveLength(1)
+  })
+})
+
+describe('simulateSwap — errors', () => {
+  it('throws when fetch response is not ok', async () => {
+    global.fetch = mockFetch([{ ok: false, status: 400 }])
+
+    await expect(simulateSwap('cNGN', 'USDC', '100', 1, 'PUBLIC')).rejects.toThrow(
+      'Path-finding failed: 400'
+    )
+  })
+
+  it('throws when no records are returned', async () => {
+    global.fetch = mockFetch([
+      { ok: true, body: { _embedded: { records: [] } } },
+    ])
+
+    await expect(simulateSwap('cNGN', 'USDC', '100', 1, 'PUBLIC')).rejects.toThrow(
+      'No swap path found for this pair'
+    )
+  })
+
+  it('throws for unknown asset with no issuer', async () => {
+    // cKES has no issuer configured by default
+    delete process.env.NEXT_PUBLIC_CKES_ISSUER
+    // The module-level ASSET_ISSUERS will have cKES as empty string
+    // Because the mock re-requires the module... we test via observable throw
+    global.fetch = mockFetch([
+      { ok: true, body: { _embedded: { records: [makePathRecord('1.0')] } } },
+    ])
+
+    // This will throw from getAsset because issuer is empty string
+    await expect(simulateSwap('cKES', 'USDC', '100', 1, 'PUBLIC')).rejects.toThrow()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// buildSwapXdr
+// ---------------------------------------------------------------------------
+
+describe('buildSwapXdr', () => {
+  it('returns an XDR string', async () => {
+    const xdr = await buildSwapXdr(SOURCE_KEY, mockSim, 'PUBLIC')
+    expect(typeof xdr).toBe('string')
+    expect(xdr.length).toBeGreaterThan(0)
+  })
+
+  it('calls pathPaymentStrictSend with correct sendAsset, sendAmount, destMin, and path', async () => {
+    await buildSwapXdr(SOURCE_KEY, mockSim, 'PUBLIC')
+
+    expect(mockPathPaymentOp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sendAmount: mockSim.fromAmount,
+        destMin: mockSim.minReceived,
+      })
+    )
+  })
+
+  it('uses sourcePublicKey as the destination (self-swap)', async () => {
+    await buildSwapXdr(SOURCE_KEY, mockSim, 'PUBLIC')
+
+    expect(mockPathPaymentOp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        destination: SOURCE_KEY,
+      })
+    )
+  })
+
+  it('uses PUBLIC network passphrase when network is PUBLIC', async () => {
+    await buildSwapXdr(SOURCE_KEY, mockSim, 'PUBLIC')
+
+    expect(MockTransactionBuilder).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ networkPassphrase: MockNetworks.PUBLIC })
+    )
+  })
+
+  it('uses TESTNET network passphrase when network is TESTNET', async () => {
+    await buildSwapXdr(SOURCE_KEY, { ...mockSim, fromAsset: 'XLM', toAsset: 'cNGN' }, 'TESTNET')
+
+    expect(MockTransactionBuilder).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ networkPassphrase: MockNetworks.TESTNET })
+    )
+  })
+
+  it('uses TESTNET Horizon URL when network is TESTNET', async () => {
+    await buildSwapXdr(SOURCE_KEY, { ...mockSim, fromAsset: 'XLM', toAsset: 'cNGN' }, 'TESTNET')
+    expect(MockServer).toHaveBeenCalledWith('https://horizon-testnet.stellar.org')
+  })
+
+  it('sets fee from Horizon on the TransactionBuilder', async () => {
+    mockFetchBaseFee.mockResolvedValue(300)
+    await buildSwapXdr(SOURCE_KEY, mockSim, 'PUBLIC')
+
+    expect(MockTransactionBuilder).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ fee: '300' })
+    )
+  })
+
+  it('calls setTimeout(300)', async () => {
+    await buildSwapXdr(SOURCE_KEY, mockSim, 'PUBLIC')
+    expect(mockSetTimeout).toHaveBeenCalledWith(300)
+  })
+})


### PR DESCRIPTION
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  create me a nice pr msg that i can copy and paste closing all issue
   
  Here's a PR message you can copy and paste:
  
  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  test: add unit test coverage for Stellar SDK modules and API route handlers
  
  Closes #305
  Closes #306
  Closes #307
  Closes #308
  
  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  What's Changed
  
  Added unit test coverage for the highest-risk modules in the codebase — Stellar transaction builders, mobile money payment rails, KYC withdrawal
  limits, and all critical API route handlers.
  
  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Files Added
  
  ┌───────────────────────────────────────┬────────────────────────────────┐
  │ File                                  │ Covers                         │
  ├───────────────────────────────────────┼────────────────────────────────┤
  │ lib/__tests__/stellar-p2p.test.ts     │ lib/stellar-p2p.ts             │
  ├───────────────────────────────────────┼────────────────────────────────┤
  │ lib/__tests__/stellar-swap.test.ts    │ lib/swap/stellar-swap.ts       │
  ├───────────────────────────────────────┼────────────────────────────────┤
  │ lib/__tests__/stellar-offramp.test.ts │ lib/offramp/stellar-offramp.ts │
  ├───────────────────────────────────────┼────────────────────────────────┤
  │ app/api/__tests__/routes.test.ts      │ All 5 API route handlers       │
  └───────────────────────────────────────┴────────────────────────────────┘
  
  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Test Coverage Summary
  
  #306 — Stellar P2P, Swap & Offramp SDK
  
  - isValidStellarAddress — valid/invalid address formats
  - sendStellarP2P — XDR builds correctly, correct asset codes and issuers, memo truncated at 28 chars, fee from Horizon applied, error cases:
  invalid address, account not found, Freighter signing failure, submitTransaction failure
  - simulateSwap — best-path selection, slippage applied to minReceived, rate calculation, TESTNET vs PUBLIC URL, empty records throws, non-ok
  response throws
  - buildSwapXdr — pathPaymentStrictSend params, self-swap destination, network passphrase, fee forwarding
  - buildOfframpPaymentXdr — XLM native vs cNGN with issuer vs fallback, memo truncation, TESTNET/PUBLIC Horizon URL and network passphrase
  
  #305 — API Route Handlers
  
  - GET /api/exchange-rate — CoinGecko fetch, non-ok upstream response, fetch exception, correct currency params
  - POST /api/onramp/create-order — order creation, createdAt/expiresAt population, invalid JSON → 500
  - POST /api/withdrawals — TIER_0 blocked (403), TIER_1 daily limit enforced (403), TIER_3 unlimited (200), missing fields → 400, invalid tier → 400
  - GET/POST /api/referral — code generation (deterministic, AFR- prefix), self-use blocked (400), invalid code → 404, duplicate use → 409, discount
  applied (200, 10%)
  - POST /api/bills/initiate — missing fields → 400, Paystack integration, unique BILL- reference generated, metadata forwarded, gateway error → 500
  
  #307 — M-Pesa & MTN MoMo (tests already existed — verified complete)
  
  - STK Push request formatting, PENDING return, non-zero ResponseCode throws
  - Status polling: ResultCode 0 → SUCCESSFUL, 1 → INSUFFICIENT_FUNDS, 1032 → CANCELLED
  - MTN requestToPay → PENDING, 202 accepted, non-202 throws, FAILED status throws
  
  #308 — Withdrawal Limit Service (tests already existed — verified complete)
  
  - TIER_0 always rejected, no record written
  - TIER_1 / TIER_2 rolling 24h window enforced
  - TIER_3 unlimited
  - Concurrent requests serialised via mutex — no double-spend past limit
  - Rolling window correctly expires records older than 24h
  
  ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
  
  Approach
  
  All Stellar SDK calls are mocked via jest.mock('@stellar/stellar-sdk') — no real network calls are made. API routes use jest.resetModules() +
  dynamic import() per test to isolate in-memory state between test cases. External HTTP calls (CoinGecko, Paystack, M-Pesa, MTN MoMo) are mocked
  with global.fetch.