### PR TITLE
fix: resolve broken routes, dead rate fallback, and Lightning UX (#271 #272 #273 #274)

### DIFF
--- a/components/dashboard/quick-actions.tsx
+++ b/components/dashboard/quick-actions.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import { motion } from 'framer-motion'
 import { ArrowLeftRight, ArrowUp, ArrowDown, Zap, Coins, CreditCard } from 'lucide-react'
 import { useRouter } from 'next/navigation'
@@ -15,13 +16,16 @@ const actions = [
   { icon: ArrowLeftRight, label: 'Swap', action: 'swap', color: 'text-blue-500' },
   { icon: ArrowUp, label: 'Send', action: 'send', color: 'text-green-500' },
   { icon: ArrowDown, label: 'Receive', action: 'receive', color: 'text-purple-500' },
-  { icon: Zap, label: 'Lightning', action: 'lightning', color: 'text-yellow-500' },
+  // Lightning Network / instant payment feature is not yet implemented.
+  // Marked as comingSoon so users see a tooltip instead of a dead click (#274).
+  { icon: Zap, label: 'Lightning', action: 'lightning', color: 'text-yellow-500', comingSoon: true },
   { icon: Coins, label: 'Onramp', action: 'onramp', color: 'text-orange-500' },
   { icon: CreditCard, label: 'Pay Bills', action: 'bills', color: 'text-pink-500' },
 ] as const
 
 export function QuickActions({ onSwap, onSend, onReceive }: QuickActionsProps) {
   const router = useRouter()
+  const [tooltip, setTooltip] = useState<string | null>(null)
 
   return (
     <motion.div
@@ -31,27 +35,55 @@ export function QuickActions({ onSwap, onSend, onReceive }: QuickActionsProps) {
     >
       <h3 className="text-lg font-semibold text-foreground mb-4">Quick Actions</h3>
       <div className="grid grid-cols-3 sm:grid-cols-6 gap-4">
-        {actions.map((action, index) => (
-          <motion.button
-            key={action.label}
-            initial={{ opacity: 0, scale: 0.9 }}
-            animate={{ opacity: 1, scale: 1 }}
-            transition={{ delay: index * 0.05 }}
-            whileHover={{ scale: 1.05 }}
-            whileTap={{ scale: 0.95 }}
-            onClick={() => {
-              if (action.action === 'swap') onSwap()
-              else if (action.action === 'send') onSend()
-              else if (action.action === 'receive') onReceive()
-              else if (action.action === 'onramp') router.push('/onramp')
-              else if (action.action === 'bills') router.push('/bills')
-            }}
-            className="flex flex-col items-center gap-2 p-4 rounded-xl bg-muted hover:bg-muted/80 transition-colors"
-          >
-            <action.icon className={cn('w-6 h-6', action.color)} />
-            <span className="text-xs font-medium text-foreground">{action.label}</span>
-          </motion.button>
-        ))}
+        {actions.map((action, index) => {
+          const isComingSoon = 'comingSoon' in action && action.comingSoon
+
+          return (
+            <div key={action.label} className="relative flex flex-col items-center">
+              <motion.button
+                initial={{ opacity: 0, scale: 0.9 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ delay: index * 0.05 }}
+                whileHover={!isComingSoon ? { scale: 1.05 } : undefined}
+                whileTap={!isComingSoon ? { scale: 0.95 } : undefined}
+                disabled={isComingSoon}
+                aria-label={isComingSoon ? `${action.label} — coming soon` : action.label}
+                onClick={() => {
+                  if (isComingSoon) return
+                  if (action.action === 'swap') onSwap()
+                  else if (action.action === 'send') onSend()
+                  else if (action.action === 'receive') onReceive()
+                  else if (action.action === 'onramp') router.push('/onramp')
+                  else if (action.action === 'bills') router.push('/bills')
+                }}
+                onMouseEnter={() => isComingSoon && setTooltip(action.label)}
+                onMouseLeave={() => setTooltip(null)}
+                onFocus={() => isComingSoon && setTooltip(action.label)}
+                onBlur={() => setTooltip(null)}
+                className={cn(
+                  'flex flex-col items-center gap-2 p-4 rounded-xl bg-muted transition-colors w-full',
+                  isComingSoon
+                    ? 'opacity-50 cursor-not-allowed'
+                    : 'hover:bg-muted/80'
+                )}
+              >
+                <action.icon className={cn('w-6 h-6', action.color)} />
+                <span className="text-xs font-medium text-foreground">{action.label}</span>
+              </motion.button>
+
+              {/* Coming soon tooltip — shown on hover/focus for disabled actions */}
+              {isComingSoon && tooltip === action.label && (
+                <div
+                  role="tooltip"
+                  className="absolute -top-9 left-1/2 -translate-x-1/2 whitespace-nowrap rounded-md bg-popover text-popover-foreground border border-border px-2.5 py-1 text-xs shadow-md z-10 pointer-events-none"
+                >
+                  Coming soon
+                  <div className="absolute left-1/2 -translate-x-1/2 top-full w-2 h-2 bg-popover border-b border-r border-border rotate-45 -mt-1" />
+                </div>
+              )}
+            </div>
+          )
+        })}
       </div>
     </motion.div>
   )

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -13,16 +13,20 @@ import { cn } from '@/lib/utils'
 
 const navItems = [
   { label: 'Dashboard', href: '/dashboard' },
-  { label: 'Transactions', href: '/dashboard/transactions' },
-  { label: 'Wallets', href: '/dashboard/wallets' },
-  { label: 'Settings', href: '/dashboard/settings' },
+  // /dashboard/transactions and /dashboard/wallets do not exist; route to the
+  // dashboard with a tab query param so navigation resolves correctly (#273).
+  { label: 'Transactions', href: '/dashboard?tab=transactions' },
+  { label: 'Wallets', href: '/dashboard?tab=wallets' },
+  // /dashboard/settings does not exist; the real settings page is at /settings.
+  { label: 'Settings', href: '/settings' },
 ]
 
 const bottomNavItems = [
   { label: 'Dashboard', href: '/dashboard', icon: LayoutDashboard },
   { label: 'Onramp', href: '/onramp', icon: ArrowDownUp },
   { label: 'Bills', href: '/bills', icon: Receipt },
-  { label: 'Wallet', href: '/dashboard/wallets', icon: Wallet },
+  // Bottom nav Wallet tab also pointed to non-existent /dashboard/wallets (#273).
+  { label: 'Wallet', href: '/dashboard?tab=wallets', icon: Wallet },
 ]
 
 export function Navbar() {

--- a/components/onramp/onramp-page-client.tsx
+++ b/components/onramp/onramp-page-client.tsx
@@ -148,6 +148,16 @@ export function OnrampPageClient() {
       return
     }
 
+    // Guard: refuse to create an order if the live exchange rate is unavailable.
+    // Using a stale or hardcoded fallback rate would expose users or the platform
+    // to incorrect pricing (see issue #271).
+    if (!data?.rate) {
+      alert(
+        'Exchange rate is currently unavailable. Please wait for the rate to load or refresh the page before proceeding.'
+      )
+      return
+    }
+
     setIsSubmitting(true)
 
     try {
@@ -169,7 +179,7 @@ export function OnrampPageClient() {
         cryptoAsset: form.state.cryptoAsset,
         paymentMethod: form.state.paymentMethod,
         amount: form.amountValue,
-        exchangeRate: data?.rate || 1600, // Fallback rate for demo
+        exchangeRate: data.rate,
         cryptoAmount: form.cryptoAmount,
         fees: discountedFees,
         walletAddress: walletAddress,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -24,6 +24,18 @@ const nextConfig = {
     minimumCacheTTL: 60,
   },
   output: 'standalone',
+  async redirects() {
+    return [
+      // /login and signup are the same flow (phone + OTP). Redirect /login to
+      // /signup so that 401-page CTAs and any external links don't dead-end on
+      // a 404 (issue #272).
+      {
+        source: '/login',
+        destination: '/signup',
+        permanent: false,
+      },
+    ]
+  },
   async headers() {
     return [
       {


### PR DESCRIPTION
## Summary

This PR fixes four reported bugs/features in a single atomic change.

---

### #271 — Remove hardcoded 1600 NGN/cNGN fallback exchange rate (Bug / High)

**File:** `components/onramp/onramp-page-client.tsx`

- Added a guard in `handleSubmit` that returns early with a user-facing error message if `data?.rate` is falsy — no order is created when the live rate is unavailable.
- Replaced `exchangeRate: data?.rate || 1600` with `exchangeRate: data.rate`. The hardcoded fallback is removed entirely.

---

### #272 — Add /login route — 401-page CTA dead-ends on 404 (Feature / Medium)

**File:** `next.config.mjs`

- Added a `redirects()` entry that routes `/login` → `/signup` (307 temporary redirect).
- Login and signup are the same phone+OTP flow, so a redirect is the minimal correct fix. The 401-page CTA now resolves to the existing signup page.

---

### #273 — Navbar links to non-existent routes (Bug / High)

**File:** `components/navbar.tsx`

- `Transactions` → `/dashboard?tab=transactions`
- `Wallets` → `/dashboard?tab=wallets`
- `Settings` → `/settings` (the real settings page)
- Bottom nav `Wallet` link also updated from `/dashboard/wallets` → `/dashboard?tab=wallets`

All four previously 404-ing links now resolve to real pages.

---

### #274 — Lightning quick-action button has no handler (Bug / Medium)

**File:** `components/dashboard/quick-actions.tsx`

- Added `comingSoon: true` flag to the Lightning action.
- Buttons marked `comingSoon` receive `disabled`, `opacity-50`, and `cursor-not-allowed` — clicks are ignored.
- On hover/focus a `Coming soon` tooltip renders above the button via local state.
- All other quick actions are unchanged.

---

## Files Changed

| File | Issue |
|------|-------|
| `components/onramp/onramp-page-client.tsx` | #271 |
| `next.config.mjs` | #272 |
| `components/navbar.tsx` | #273 |
| `components/dashboard/quick-actions.tsx` | #274 |

Closes #271
Closes #272
Closes #273
Closes #274