### PR TITLE
Chore/solve issues

### DIFF
--- a/.github/workflows/uptime-monitor.yml
+++ b/.github/workflows/uptime-monitor.yml
@@ -35,9 +35,91 @@ jobs:
             echo "✅ Onramp page up"
           fi
 
+      - name: Check offramp page
+        id: offramp
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 https://aframp.vercel.app/offramp || echo "000")
+          if [ "$STATUS" != "200" ]; then
+            echo "status=down" >> $GITHUB_OUTPUT
+            echo "⚠️ Offramp page returned HTTP $STATUS"
+          else
+            echo "status=up" >> $GITHUB_OUTPUT
+            echo "✅ Offramp page up"
+          fi
+
+      - name: Check bills page
+        id: bills
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 https://aframp.vercel.app/bills || echo "000")
+          if [ "$STATUS" != "200" ]; then
+            echo "status=down" >> $GITHUB_OUTPUT
+            echo "⚠️ Bills page returned HTTP $STATUS"
+          else
+            echo "status=up" >> $GITHUB_OUTPUT
+            echo "✅ Bills page up"
+          fi
+
+      - name: Check swap page
+        id: swap
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 https://aframp.vercel.app/swap || echo "000")
+          if [ "$STATUS" != "200" ]; then
+            echo "status=down" >> $GITHUB_OUTPUT
+            echo "⚠️ Swap page returned HTTP $STATUS"
+          else
+            echo "status=up" >> $GITHUB_OUTPUT
+            echo "✅ Swap page up"
+          fi
+
+      - name: Check exchange-rate API
+        id: exchange_rate_api
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 https://aframp.vercel.app/api/exchange-rate || echo "000")
+          if [ "$STATUS" != "200" ]; then
+            echo "status=down" >> $GITHUB_OUTPUT
+            echo "⚠️ Exchange-rate API returned HTTP $STATUS"
+          else
+            echo "status=up" >> $GITHUB_OUTPUT
+            echo "✅ Exchange-rate API up"
+          fi
+
+      - name: Check rates API
+        id: rates_api
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 https://aframp.vercel.app/api/rates || echo "000")
+          if [ "$STATUS" != "200" ]; then
+            echo "status=down" >> $GITHUB_OUTPUT
+            echo "⚠️ Rates API returned HTTP $STATUS"
+          else
+            echo "status=up" >> $GITHUB_OUTPUT
+            echo "✅ Rates API up"
+          fi
+
       - name: Alert on downtime
-        if: steps.homepage.outputs.status == 'down' || steps.onramp.outputs.status == 'down'
+        if: |
+          steps.homepage.outputs.status == 'down' ||
+          steps.onramp.outputs.status == 'down' ||
+          steps.offramp.outputs.status == 'down' ||
+          steps.bills.outputs.status == 'down' ||
+          steps.swap.outputs.status == 'down' ||
+          steps.exchange_rate_api.outputs.status == 'down' ||
+          steps.rates_api.outputs.status == 'down'
         uses: actions/github-script@v7
         with:
           script: |
-            console.log(`🚨 ALERT: AFRAMP may be DOWN\n\nTime: ${new Date().toISOString()}\nHomepage: ${{ steps.homepage.outputs.status }}\nOnramp: ${{ steps.onramp.outputs.status }}\n\nCheck: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}`);
+            const statuses = {
+              Homepage:       '${{ steps.homepage.outputs.status }}',
+              Onramp:         '${{ steps.onramp.outputs.status }}',
+              Offramp:        '${{ steps.offramp.outputs.status }}',
+              Bills:          '${{ steps.bills.outputs.status }}',
+              Swap:           '${{ steps.swap.outputs.status }}',
+              'Exchange-rate API': '${{ steps.exchange_rate_api.outputs.status }}',
+              'Rates API':    '${{ steps.rates_api.outputs.status }}',
+            };
+            const down = Object.entries(statuses)
+              .filter(([, v]) => v === 'down')
+              .map(([k]) => `  • ${k}`)
+              .join('\n');
+            console.log(
+              `🚨 ALERT: AFRAMP endpoints are DOWN\n\nTime: ${new Date().toISOString()}\n\nAffected:\n${down}\n\nCheck: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}`
+            );

--- a/components/onramp/onramp-payment-client.tsx
+++ b/components/onramp/onramp-payment-client.tsx
@@ -1,14 +1,36 @@
 'use client'
 
-import { useEffect, useState } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import Link from 'next/link'
-import { Clock, Copy, CheckCircle, AlertCircle, Loader2 } from 'lucide-react'
+import { Clock, Copy, CheckCircle, AlertCircle, Loader2, ExternalLink } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { LoadingSpinner } from '@/components/ui/loading-spinner'
 import { OrderStatus } from '@/types/onramp'
 import { useOrderTracking } from '@/hooks/use-order-tracking'
 import { formatCurrency, truncateAddress } from '@/lib/calculations'
+import { buildEscrowPaymentXdr, AFRAMP_ESCROW_ADDRESS } from '@/lib/stellar-p2p'
+import { signTransactionWithFreighter } from '@/lib/wallet/freighter'
+import * as StellarSdk from '@stellar/stellar-sdk'
+import type { FreighterNetwork } from '@/lib/wallet'
+
+/** Resolve the Freighter network from localStorage (same pattern as rest of app). */
+function getWalletNetwork(): FreighterNetwork {
+  if (typeof window === 'undefined') return 'PUBLIC'
+  return (localStorage.getItem('walletNetwork') as FreighterNetwork) ?? 'PUBLIC'
+}
+
+/** Asset issuer for non-XLM assets (mirrors the env-var pattern in stellar-p2p). */
+const ASSET_ISSUERS: Record<string, string> = {
+  cNGN:
+    (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_CNGN_ISSUER) ||
+    'GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3TNFWQQE',
+  USDC:
+    (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_USDC_ISSUER) ||
+    'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+  cKES: (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_CKES_ISSUER) || '',
+  cGHS: (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_CGHS_ISSUER) || '',
+}
 
 export function OnrampPaymentClient() {
   const router = useRouter()
@@ -17,10 +39,16 @@ export function OnrampPaymentClient() {
   const { order, updateOrderStatus } = useOrderTracking(orderId)
   const [timeLeft, setTimeLeft] = useState(0)
 
+  // Stellar payment state
+  const [stellarStep, setStellarStep] = useState<
+    'idle' | 'building' | 'signing' | 'submitting' | 'done' | 'error'
+  >('idle')
+  const [txHash, setTxHash] = useState<string | null>(null)
+  const [stellarError, setStellarError] = useState<string | null>(null)
+
   useEffect(() => {
     if (!orderId || !order) return
 
-    // Redirect if order is not in correct state
     if (order.status === 'completed') {
       router.push(`/onramp/success?order=${orderId}`)
       return
@@ -41,7 +69,6 @@ export function OnrampPaymentClient() {
       setTimeLeft(remaining)
 
       if (remaining === 0) {
-        // Order expired
         updateOrderStatus('failed')
       }
     }
@@ -62,13 +89,130 @@ export function OnrampPaymentClient() {
     return () => clearTimeout(timer)
   }, [order, updateOrderStatus])
 
-  const handleCopy = async (text: string, _type: string) => {
+  const handleCopy = async (text: string) => {
     try {
       await navigator.clipboard.writeText(text)
     } catch (err) {
       console.error('Copy failed', err)
     }
   }
+
+  /**
+   * Full Stellar payment flow:
+   * 1. Build XDR (payment from user wallet → Aframp escrow)
+   * 2. Sign with Freighter
+   * 3. Submit to Horizon
+   * 4. Store txHash on the order
+   * 5. Trigger fiat disbursement webhook (PATCH /api/onramp/order/:id/status)
+   */
+  const handleStellarPayment = useCallback(async () => {
+    if (!order) return
+
+    const walletAddress = localStorage.getItem('walletAddress') ?? ''
+    if (!walletAddress) {
+      setStellarError('No wallet connected. Please connect your Freighter wallet.')
+      return
+    }
+
+    const network = getWalletNetwork()
+    const horizonUrl =
+      network === 'TESTNET'
+        ? 'https://horizon-testnet.stellar.org'
+        : 'https://horizon.stellar.org'
+
+    setStellarError(null)
+    setStellarStep('building')
+
+    try {
+      // ── Step 1: Build unsigned XDR ──────────────────────────────────────
+      const xdr = await buildEscrowPaymentXdr({
+        sourcePublicKey: walletAddress,
+        amount: order.cryptoAmount.toFixed(7),
+        assetCode: order.cryptoAsset,
+        assetIssuer: ASSET_ISSUERS[order.cryptoAsset] || undefined,
+        orderId: order.id,
+        network,
+      })
+
+      // ── Step 2: Sign with Freighter ─────────────────────────────────────
+      setStellarStep('signing')
+      const networkPassphrase =
+        network === 'TESTNET'
+          ? StellarSdk.Networks.TESTNET
+          : StellarSdk.Networks.PUBLIC
+
+      const signed = await signTransactionWithFreighter(xdr, network, networkPassphrase)
+      if (signed.error || !signed.signedTxXdr) {
+        throw new Error(signed.error ?? 'Transaction signing was cancelled or failed')
+      }
+
+      // ── Step 3: Submit to Horizon ───────────────────────────────────────
+      setStellarStep('submitting')
+      const submitRes = await fetch(`${horizonUrl}/transactions`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: `tx=${encodeURIComponent(signed.signedTxXdr)}`,
+      })
+      const submitData = await submitRes.json()
+      if (!submitRes.ok) {
+        const resultCode =
+          submitData?.extras?.result_codes?.transaction ??
+          submitData?.title ??
+          'Transaction submission failed'
+        throw new Error(resultCode)
+      }
+
+      const hash: string = submitData.hash
+      setTxHash(hash)
+
+      // ── Step 4: Store txHash and update order status ────────────────────
+      // Persist hash in localStorage for the processing page
+      const storedOrder = JSON.parse(
+        localStorage.getItem(`onramp:order:${order.id}`) ?? '{}'
+      )
+      const updatedOrder = { ...storedOrder, txHash: hash, status: 'payment_received' }
+      localStorage.setItem(`onramp:order:${order.id}`, JSON.stringify(updatedOrder))
+      localStorage.setItem('onramp:latest-order', JSON.stringify(updatedOrder))
+
+      // ── Step 5: Trigger fiat disbursement webhook ───────────────────────
+      // Notifies the backend that the on-chain payment is confirmed so it
+      // can initiate the fiat payout to the recipient.
+      await fetch(`/api/onramp/order/${order.id}/status`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          status: 'payment_received',
+          additionalData: {
+            txHash: hash,
+            escrowAddress: AFRAMP_ESCROW_ADDRESS,
+            walletAddress,
+            referralCode: order.referralCode,
+          },
+        }),
+      })
+
+      setStellarStep('done')
+      updateOrderStatus('payment_received')
+
+      // Navigate to processing page after a brief pause
+      setTimeout(() => {
+        router.push(`/onramp/processing/${order.id}`)
+      }, 1500)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Stellar payment failed'
+      setStellarError(msg)
+      setStellarStep('error')
+    }
+  }, [order, router, updateOrderStatus])
+
+  // ── Legacy bank-transfer confirmation (non-Stellar payment methods) ────
+  const handleBankTransferConfirm = useCallback(() => {
+    if (!order) return
+    updateOrderStatus('payment_received')
+    setTimeout(() => {
+      router.push(`/onramp/processing/${order.id}`)
+    }, 0)
+  }, [order, router, updateOrderStatus])
 
   if (!order) {
     return (
@@ -146,6 +290,45 @@ export function OnrampPaymentClient() {
       } as const
     )[order.status as OrderStatus] ?? 0
 
+  const isStellarPayment =
+    order.paymentMethod === 'bank_transfer' ? false : true
+
+  /** Button label / disabled state for the Stellar signing button */
+  const stellarButtonLabel = () => {
+    switch (stellarStep) {
+      case 'building':
+        return (
+          <>
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            Building transaction…
+          </>
+        )
+      case 'signing':
+        return (
+          <>
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            Waiting for Freighter…
+          </>
+        )
+      case 'submitting':
+        return (
+          <>
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            Submitting to Stellar…
+          </>
+        )
+      case 'done':
+        return (
+          <>
+            <CheckCircle className="h-4 w-4 mr-2" />
+            Payment confirmed!
+          </>
+        )
+      default:
+        return 'Pay with Freighter'
+    }
+  }
+
   return (
     <div className="min-h-screen bg-background">
       <header className="sticky top-0 z-40 border-b border-border bg-card/80 backdrop-blur-md">
@@ -192,7 +375,99 @@ export function OnrampPaymentClient() {
             <div className="text-xs text-muted-foreground">{progress}% complete</div>
           </div>
 
-          {/* Payment Details */}
+          {/* ── Stellar Payment Section ─────────────────────────────────────── */}
+          {order.status === 'awaiting_payment' && isStellarPayment && (
+            <div className="rounded-3xl border border-border bg-card p-6 mb-6">
+              <h3 className="text-lg font-semibold text-foreground mb-2">
+                Pay with Stellar Wallet
+              </h3>
+              <p className="text-sm text-muted-foreground mb-4">
+                Send{' '}
+                <span className="font-semibold">
+                  {order.cryptoAmount.toFixed(7)} {order.cryptoAsset}
+                </span>{' '}
+                from your Freighter wallet to the Aframp escrow. Your Freighter extension will open
+                for you to sign.
+              </p>
+
+              <div className="space-y-2 text-sm mb-4">
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Escrow address:</span>
+                  <div className="flex items-center gap-2">
+                    <span className="font-mono text-foreground text-xs">
+                      {truncateAddress(AFRAMP_ESCROW_ADDRESS, 8)}
+                    </span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => handleCopy(AFRAMP_ESCROW_ADDRESS)}
+                      className="h-6 w-6 p-0"
+                    >
+                      <Copy className="h-3 w-3" />
+                    </Button>
+                  </div>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Amount:</span>
+                  <span className="font-semibold text-foreground">
+                    {order.cryptoAmount.toFixed(7)} {order.cryptoAsset}
+                  </span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-muted-foreground">Memo (order ID):</span>
+                  <span className="font-mono text-foreground text-xs">
+                    {order.id.slice(0, 28)}
+                  </span>
+                </div>
+              </div>
+
+              {/* Stellar error */}
+              {stellarStep === 'error' && stellarError && (
+                <div className="mb-4 flex items-start gap-2 p-3 rounded-lg bg-destructive/10 text-destructive text-sm">
+                  <AlertCircle className="h-4 w-4 mt-0.5 shrink-0" />
+                  <span>{stellarError}</span>
+                </div>
+              )}
+
+              {/* txHash on success */}
+              {stellarStep === 'done' && txHash && (
+                <div className="mb-4 flex items-center gap-2 p-3 rounded-lg bg-green-50 dark:bg-green-900/20 text-sm">
+                  <CheckCircle className="h-4 w-4 text-green-600 shrink-0" />
+                  <span className="text-green-700 dark:text-green-300">Payment confirmed on-chain!</span>
+                  <a
+                    href={`https://stellar.expert/explorer/public/tx/${txHash}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="ml-auto text-primary hover:underline flex items-center gap-1 text-xs"
+                  >
+                    View tx <ExternalLink className="h-3 w-3" />
+                  </a>
+                </div>
+              )}
+
+              <Button
+                onClick={handleStellarPayment}
+                disabled={stellarStep !== 'idle' && stellarStep !== 'error'}
+                className="w-full"
+                size="lg"
+              >
+                {stellarButtonLabel()}
+              </Button>
+
+              {stellarStep === 'error' && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="w-full mt-2"
+                  onClick={() => setStellarStep('idle')}
+                >
+                  Try again
+                </Button>
+              )}
+            </div>
+          )}
+
+          {/* ── Bank Transfer Section ───────────────────────────────────────── */}
           {order.status === 'awaiting_payment' && order.paymentMethod === 'bank_transfer' && (
             <div className="rounded-3xl border border-border bg-card p-6 mb-6">
               <h3 className="text-lg font-semibold text-foreground mb-4">Bank Transfer Details</h3>
@@ -205,7 +480,7 @@ export function OnrampPaymentClient() {
                     <Button
                       variant="ghost"
                       size="sm"
-                      onClick={() => handleCopy('1234567890', 'account')}
+                      onClick={() => handleCopy('1234567890')}
                       className="h-6 w-6 p-0"
                     >
                       <Copy className="h-3 w-3" />
@@ -232,7 +507,7 @@ export function OnrampPaymentClient() {
                     <Button
                       variant="ghost"
                       size="sm"
-                      onClick={() => handleCopy(order.fees.totalCost.toString(), 'amount')}
+                      onClick={() => handleCopy(order.fees.totalCost.toString())}
                       className="h-6 w-6 p-0"
                     >
                       <Copy className="h-3 w-3" />
@@ -284,17 +559,11 @@ export function OnrampPaymentClient() {
             </div>
           </div>
 
-          {/* Confirm Button */}
-          {order.status === 'awaiting_payment' && (
+          {/* Bank-transfer confirm button (after user has manually sent funds) */}
+          {order.status === 'awaiting_payment' && order.paymentMethod === 'bank_transfer' && (
             <div className="mt-6">
               <Button
-                onClick={() => {
-                  updateOrderStatus('payment_received')
-
-                  setTimeout(() => {
-                    router.push(`/onramp/processing/${order.id}`)
-                  }, 0)
-                }}
+                onClick={handleBankTransferConfirm}
                 className="w-full"
                 size="lg"
               >

--- a/lib/stellar-p2p.ts
+++ b/lib/stellar-p2p.ts
@@ -1,11 +1,23 @@
-import Server, { Asset, Memo, Networks, Operation, TransactionBuilder } from '@stellar/stellar-sdk'
+import * as StellarSdk from '@stellar/stellar-sdk'
 import { signTransactionWithFreighter } from '@/lib/wallet/freighter'
 import type { FreighterNetwork } from '@/lib/wallet'
+
+const { Asset, Memo, Networks, Operation, TransactionBuilder, Server } = StellarSdk
 
 const HORIZON_URLS: Record<string, string> = {
   PUBLIC: 'https://horizon.stellar.org',
   TESTNET: 'https://horizon-testnet.stellar.org',
 }
+
+/**
+ * Aframp escrow address. Payments flow:
+ *   user wallet → AFRAMP_ESCROW_ADDRESS
+ * then the backend disburses fiat after confirming the on-chain receipt.
+ * Override via NEXT_PUBLIC_ESCROW_ADDRESS for non-prod environments.
+ */
+export const AFRAMP_ESCROW_ADDRESS =
+  (typeof process !== 'undefined' && process.env.NEXT_PUBLIC_ESCROW_ADDRESS) ||
+  'GAHJJJKMOKYE4RVPZEWZTKH5FVI4PA3VL7GK2LFNUBSGBV3TNFWQQE'
 
 /** Validate a Stellar public key (G + 55 base32 chars). */
 export function isValidStellarAddress(address: string): boolean {
@@ -19,6 +31,57 @@ export async function estimateStellarFee(network: FreighterNetwork | null): Prom
   const fee = await server.fetchBaseFee()
   // base fee is in stroops (1 XLM = 10_000_000 stroops)
   return (fee / 10_000_000).toFixed(7)
+}
+
+export interface BuildEscrowPaymentParams {
+  sourcePublicKey: string
+  /** Amount of the crypto asset being sent (e.g. "31.25"). */
+  amount: string
+  assetCode: string
+  assetIssuer?: string
+  /** Order ID used as the transaction memo so the backend can reconcile. */
+  orderId: string
+  network: FreighterNetwork | null
+}
+
+/**
+ * Build an unsigned XDR for a payment from the user's wallet to the Aframp
+ * escrow address.  The caller must sign this via Freighter and submit it.
+ */
+export async function buildEscrowPaymentXdr(
+  params: BuildEscrowPaymentParams
+): Promise<string> {
+  const { sourcePublicKey, amount, assetCode, assetIssuer, orderId, network } = params
+
+  const horizonUrl = HORIZON_URLS[network ?? 'PUBLIC'] ?? HORIZON_URLS.PUBLIC
+  const server = new Server(horizonUrl)
+  const networkPassphrase = network === 'TESTNET' ? Networks.TESTNET : Networks.PUBLIC
+
+  const sourceAccount = await server.loadAccount(sourcePublicKey)
+  const fee = await server.fetchBaseFee()
+
+  const asset =
+    assetCode === 'XLM'
+      ? Asset.native()
+      : new Asset(assetCode, assetIssuer ?? sourcePublicKey)
+
+  const tx = new TransactionBuilder(sourceAccount, {
+    fee: fee.toString(),
+    networkPassphrase,
+  })
+    .addOperation(
+      Operation.payment({
+        destination: AFRAMP_ESCROW_ADDRESS,
+        asset,
+        amount,
+      })
+    )
+    // Memo encodes the order ID so the backend can reconcile this tx
+    .addMemo(Memo.text(orderId.slice(0, 28)))
+    .setTimeout(300)
+    .build()
+
+  return tx.toXDR()
 }
 
 export interface SendP2PParams {

--- a/lib/swap/stellar-swap.ts
+++ b/lib/swap/stellar-swap.ts
@@ -1,5 +1,10 @@
-import Server, { Asset, Networks, Operation, TransactionBuilder } from '@stellar/stellar-sdk'
+import * as StellarSdk from '@stellar/stellar-sdk'
 import type { FreighterNetwork } from '@/lib/wallet'
+
+const { Asset, Networks, Operation, TransactionBuilder } = StellarSdk
+// Server is accessed as a named export under the default namespace in the Stellar SDK
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const Server: new (url: string) => any = (StellarSdk as any).Horizon?.Server ?? (StellarSdk as any).Server
 
 const HORIZON_PUBLIC = 'https://horizon.stellar.org'
 const HORIZON_TESTNET = 'https://horizon-testnet.stellar.org'
@@ -16,7 +21,7 @@ export const SWAP_ASSETS = ['cNGN', 'USDC', 'XLM', 'cKES', 'cGHS'] as const
 export type SwapAsset = (typeof SWAP_ASSETS)[number]
 
 export interface SwapPath {
-  path: Asset[]
+  path: StellarSdk.Asset[]
   sourceAmount: string
   destinationAmount: string
 }
@@ -27,7 +32,7 @@ export interface SwapSimulation {
   fromAmount: string
   toAmount: string
   /** Best path found by Stellar DEX path-finding */
-  path: Asset[]
+  path: StellarSdk.Asset[]
   /** Minimum received after slippage */
   minReceived: string
   /** Effective exchange rate */
@@ -37,7 +42,7 @@ export interface SwapSimulation {
   slippagePct: number
 }
 
-function getAsset(code: SwapAsset): Asset {
+function getAsset(code: SwapAsset): StellarSdk.Asset {
   if (code === 'XLM') return Asset.native()
   const issuer = ASSET_ISSUERS[code]
   if (!issuer) throw new Error(`Unknown issuer for ${code}`)
@@ -49,21 +54,24 @@ function getHorizon(network: FreighterNetwork | null) {
 }
 
 /**
- * Simulate a swap using Stellar DEX strict-receive path payment.
- * Returns the best route and expected output — equivalent to 1inch/Jupiter quote.
+ * Find the optimal DEX route for a strict-send path payment.
+ *
+ * Queries Stellar Horizon's `/paths/strict-send` endpoint and returns all
+ * candidate paths sorted by best (highest) destination amount first.
+ *
+ * This is the routing layer — call {@link simulateSwap} for a full quote
+ * including slippage math, or call this directly when you need the raw paths.
  */
-export async function simulateSwap(
+export async function findSwapPath(
   fromAsset: SwapAsset,
   toAsset: SwapAsset,
   fromAmount: string,
-  slippagePct: number,
   network: FreighterNetwork | null
-): Promise<SwapSimulation> {
+): Promise<SwapPath[]> {
   const horizonUrl = getHorizon(network)
   const src = getAsset(fromAsset)
   const dest = getAsset(toAsset)
 
-  // Use Stellar's path-payment strict-send finder
   const params = new URLSearchParams({
     source_asset_type: src.isNative() ? 'native' : 'credit_alphanum4',
     ...(src.isNative() ? {} : { source_asset_code: src.getCode(), source_asset_issuer: src.getIssuer() }),
@@ -78,30 +86,52 @@ export async function simulateSwap(
   const data = await res.json()
   const records: Array<{
     destination_amount: string
+    source_amount: string
     path: Array<{ asset_type: string; asset_code?: string; asset_issuer?: string }>
   }> = data._embedded?.records ?? []
 
   if (records.length === 0) throw new Error('No swap path found for this pair')
 
-  // Best path = highest destination amount
-  const best = records.reduce((a, b) =>
-    parseFloat(a.destination_amount) >= parseFloat(b.destination_amount) ? a : b
-  )
+  // Map to our SwapPath type and sort best (highest dest amount) first
+  const paths: SwapPath[] = records.map((r) => ({
+    sourceAmount: r.source_amount,
+    destinationAmount: r.destination_amount,
+    path: r.path.map((p) =>
+      p.asset_type === 'native' ? Asset.native() : new Asset(p.asset_code!, p.asset_issuer!)
+    ),
+  }))
 
-  const toAmount = best.destination_amount
+  paths.sort((a, b) => parseFloat(b.destinationAmount) - parseFloat(a.destinationAmount))
+
+  return paths
+}
+
+/**
+ * Simulate a swap using Stellar DEX strict-receive path payment.
+ * Returns the best route and expected output — equivalent to 1inch/Jupiter quote.
+ */
+export async function simulateSwap(
+  fromAsset: SwapAsset,
+  toAsset: SwapAsset,
+  fromAmount: string,
+  slippagePct: number,
+  network: FreighterNetwork | null
+): Promise<SwapSimulation> {
+  // Use findSwapPath to get the optimal DEX route
+  const paths = await findSwapPath(fromAsset, toAsset, fromAmount, network)
+
+  // Best path is first after sorting
+  const best = paths[0]
+  const toAmount = best.destinationAmount
   const minReceived = (parseFloat(toAmount) * (1 - slippagePct / 100)).toFixed(7)
   const rate = (parseFloat(toAmount) / parseFloat(fromAmount)).toFixed(7)
-
-  const path = best.path.map((p) =>
-    p.asset_type === 'native' ? Asset.native() : new Asset(p.asset_code!, p.asset_issuer!)
-  )
 
   return {
     fromAsset,
     toAsset,
     fromAmount,
     toAmount,
-    path,
+    path: best.path,
     minReceived,
     rate,
     fee: '100', // base fee in stroops
@@ -110,7 +140,8 @@ export async function simulateSwap(
 }
 
 /**
- * Build a path-payment strict-send XDR for signing via Freighter.
+ * Build a PathPaymentStrictSend XDR for signing via Freighter.
+ * Uses the optimal path from simulateSwap / findSwapPath.
  */
 export async function buildSwapXdr(
   sourcePublicKey: string,


### PR DESCRIPTION
8a68e20 feat(onramp): add Stellar payment transaction flow
  
  - components/onramp/onramp-payment-client.tsx — replaced the mock "I've Made the Transfer" button with a
  full Stellar flow: build escrow payment XDR → sign with Freighter → submit to Horizon → store txHash in
  localStorage → PATCH /api/onramp/order/:id/status (fiat disbursement webhook). Shows a Stellar Expert link
  on success. Bank transfer method still uses the original confirm button.
  
  d2e33d0 feat(swap): add PathPaymentStrictSend flow with findSwapPath
  
  - lib/swap/stellar-swap.ts — fixed the broken named import Server → import * as StellarSdk. Added
  findSwapPath() which queries Horizon /paths/strict-send and returns all candidate routes sorted by best
  output. simulateSwap() now delegates to findSwapPath() internally. buildSwapXdr() builds
  PathPaymentStrictSend. The existing use-swap.ts / swap-modal.tsx already handle signing, submitting, and
  displaying the tx hash.
  
  51a3bcd ci(uptime): add missing critical endpoints to uptime monitor
  
  - .github/workflows/uptime-monitor.yml — added 5 new check steps (/offramp, /bills, /swap,
  /api/exchange-rate, /api/rates) and updated the alert condition and message to list all affected endpoints
  by name.

Closes #283 

Closes #284 

Closes #285 